### PR TITLE
Simplify code to generate NightScout upload URL

### DIFF
--- a/RileyLink/NightScoutUploader.m
+++ b/RileyLink/NightScoutUploader.m
@@ -198,17 +198,13 @@ static NSString *defaultNightscoutBatteryPath = @"/api/v1/devicestatus.json";
 - (void) reportToNightScout:(NSArray*)entries
 completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler
 {
-  NSURLComponents *components = [[NSURLComponents alloc] init];
-  NSURL *baseURL = [NSURL URLWithString:self.endpoint];
-  components.scheme = @"https";
-  components.host = baseURL.host;
-  components.path = [baseURL.path stringByAppendingString:defaultNightscoutUploadPath];
-  
-  NSMutableURLRequest *request = [[NSURLRequest requestWithURL:components.URL] mutableCopy];
+  NSURL *uploadURL = [NSURL URLWithString:defaultNightscoutUploadPath
+                            relativeToURL:[NSURL URLWithString:self.endpoint]];
+  NSMutableURLRequest *request = [[NSURLRequest requestWithURL:uploadURL] mutableCopy];
   NSError *error;
   NSData *sendData = [NSJSONSerialization dataWithJSONObject:entries options:NSJSONWritingPrettyPrinted error:&error];
   NSString *jsonPost = [[NSString alloc] initWithData:sendData encoding:NSUTF8StringEncoding];
-  NSLog(@"Posting to %@, %@", components.URL, jsonPost);
+  NSLog(@"Posting to %@, %@", [uploadURL absoluteString], jsonPost);
   [request setHTTPMethod:@"POST"];
   
   [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];


### PR DESCRIPTION
My NightScout instance is running at an address like http://my.site.com:1234/, but the code currently breaks on a URL containing a port number.

I suspect the original code was written that way to insist on https. SSL works out of the box for the standard Azure-hosted NightScout setup, but not necessarily on other setups (like mine). On the NS end, even the forced https redirect is Azure-specific: https://github.com/nightscout/cgm-remote-monitor/blob/master/web.config#L14

So I'm wondering: should it be a policy that rileylink_ios uploads only via https (and rewrites user-supplied urls to use https), or that _Azure-hosted_ NightScout hosts should be accessed only via https? The latter feels more correct to me, in which case we could make `reportToNightScout` alter the scheme only for URLs matching `*.azurewebsites.net`.

A third, simpler option is to not care about SSL for now on the rileylink_ios end, and wait until NS starts insisting on it. In that case, this change can be merged as-is.

(Disclaimer: these are the first lines of Objective-C I've ever written, but I manually tested this with both my Linode-hosted URL with a port, and my Azure-hosted NS site.)
