### PR TITLE
Log to Nightscout

### DIFF
--- a/RileyLink/Log.h
+++ b/RileyLink/Log.h
@@ -12,7 +12,11 @@
 
 #define NSLog(args...) _Log(@"DEBUG ", __FILE__,__LINE__,__PRETTY_FUNCTION__,args);
 @interface Log : NSObject
+
++ (NSArray*) popLogEntries;
+
 void _Log(NSString *prefix, const char *file, int lineNumber, const char *funcName, NSString *format,...);
 @end
+
 
 #endif

--- a/RileyLink/Log.h
+++ b/RileyLink/Log.h
@@ -9,6 +9,7 @@
 #ifndef RILEYLINK_Log_h
 #define RILEYLINK_Log_h
 
+//#define LOG_TO_NS 1
 
 #define NSLog(args...) _Log(@"DEBUG ", __FILE__,__LINE__,__PRETTY_FUNCTION__,args);
 @interface Log : NSObject

--- a/RileyLink/Log.m
+++ b/RileyLink/Log.m
@@ -24,7 +24,9 @@ void append(NSString *msg){
   if (logEntries == nil) {
     logEntries = [NSMutableArray array];
   }
+#ifdef LOG_TO_NS
   [logEntries addObject:msg];
+#endif
   // get path to Documents/somefile.txt
   NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
   NSString *documentsDirectory = paths[0];

--- a/RileyLink/Log.m
+++ b/RileyLink/Log.m
@@ -10,10 +10,21 @@
 
 #import "Log.h"
 
+NSMutableArray *logEntries = nil;
+
 @implementation Log
 
++ (NSArray*) popLogEntries {
+  NSArray *rval = logEntries;
+  logEntries = [NSMutableArray array];
+  return rval;
+}
 
 void append(NSString *msg){
+  if (logEntries == nil) {
+    logEntries = [NSMutableArray array];
+  }
+  [logEntries addObject:msg];
   // get path to Documents/somefile.txt
   NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
   NSString *documentsDirectory = paths[0];

--- a/RileyLink/NightScoutUploader.m
+++ b/RileyLink/NightScoutUploader.m
@@ -256,7 +256,7 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
 
     [self addTreatment:treatment fromModel:m];
   }
-  [self flushTreatments];
+  [self flushAll];
 }
 
 
@@ -469,6 +469,22 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
 #pragma mark - Uploading
 
 - (void) flushAll {
+  
+  NSArray *logEntries = [Log popLogEntries];
+  if (logEntries.count > 0) {
+    NSDate *date = [NSDate date];
+    NSTimeInterval seconds = [date timeIntervalSince1970];
+    NSNumber *epochTime = @(seconds * 1000);
+
+    NSDictionary *entry =
+    @{@"date": epochTime,
+      @"dateString": [self.dateFormatter stringFromDate:date],
+      @"entries": logEntries,
+      @"type": @"logs"
+      };
+    [self.entries addObject:entry];
+  }
+  
   [self flushDeviceStatuses];
   [self flushEntries];
   [self flushTreatments];
@@ -489,7 +505,7 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
       [self.deviceStatuses addObjectsFromArray:inFlightDeviceStatuses];
     } else {
       NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-      NSLog(@"Submitted %d device statuses to nightscout: %@", inFlightDeviceStatuses.count, resp);
+      //NSLog(@"Submitted %d device statuses to nightscout: %@", inFlightDeviceStatuses.count, resp);
     }
   }];
 }
@@ -509,7 +525,7 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
       [self.entries addObjectsFromArray:inFlightEntries];
     } else {
       NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-      NSLog(@"Submitted %d entries to nightscout: %@", inFlightEntries.count, resp);
+      //NSLog(@"Submitted %d entries to nightscout: %@", inFlightEntries.count, resp);
     }
   }];
 }
@@ -530,7 +546,7 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
     } else {
       NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
       [self.sentTreatments addObjectsFromArray:inFlightTreatments];
-      NSLog(@"Submitted %d treatments to nightscout: %@", inFlightTreatments.count, resp);
+      //NSLog(@"Submitted %d treatments to nightscout: %@", inFlightTreatments.count, resp);
     }
   }];
 }
@@ -544,8 +560,8 @@ completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *erro
   NSMutableURLRequest *request = [[NSURLRequest requestWithURL:uploadURL] mutableCopy];
   NSError *error;
   NSData *sendData = [NSJSONSerialization dataWithJSONObject:outgoingJSON options:NSJSONWritingPrettyPrinted error:&error];
-  NSString *jsonPost = [[NSString alloc] initWithData:sendData encoding:NSUTF8StringEncoding];
-  NSLog(@"Posting to %@, %@", [uploadURL absoluteString], jsonPost);
+  //NSString *jsonPost = [[NSString alloc] initWithData:sendData encoding:NSUTF8StringEncoding];
+  //NSLog(@"Posting to %@, %@", [uploadURL absoluteString], jsonPost);
   [request setHTTPMethod:@"POST"];
   
   [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];

--- a/RileyLink/NightScoutUploader.m
+++ b/RileyLink/NightScoutUploader.m
@@ -500,7 +500,7 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
       NSLog(@"Requeuing %d device statuses: %@", inFlightDeviceStatuses.count, error);
       [self.deviceStatuses addObjectsFromArray:inFlightDeviceStatuses];
     } else {
-      NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+      //NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
       //NSLog(@"Submitted %d device statuses to nightscout: %@", inFlightDeviceStatuses.count, resp);
     }
   }];
@@ -520,7 +520,7 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
       NSLog(@"Requeuing %d sgv entries: %@", inFlightEntries.count, error);
       [self.entries addObjectsFromArray:inFlightEntries];
     } else {
-      NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+      //NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
       //NSLog(@"Submitted %d entries to nightscout: %@", inFlightEntries.count, resp);
     }
   }];
@@ -540,7 +540,7 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
       NSLog(@"Requeuing %d treatments: %@", inFlightTreatments.count, error);
       [self.treatmentsQueue addObjectsFromArray:inFlightTreatments];
     } else {
-      NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+      //NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
       [self.sentTreatments addObjectsFromArray:inFlightTreatments];
       //NSLog(@"Submitted %d treatments to nightscout: %@", inFlightTreatments.count, resp);
     }

--- a/RileyLink/NightScoutUploader.m
+++ b/RileyLink/NightScoutUploader.m
@@ -315,13 +315,15 @@ static NSString *defaultNightscoutDeviceStatusPath = @"/api/v1/devicestatus.json
     [self storeRawPacket:packet fromDevice:device];
   }
   
-  if ([packet packetType] == PacketTypeSentry && [packet messageType] == MESSAGE_TYPE_PUMP_STATUS) {
+  if ([packet packetType] == PacketTypeSentry &&
+      [packet messageType] == MESSAGE_TYPE_PUMP_STATUS &&
+      [packet.address isEqualToString:[[Config sharedInstance] pumpID]]) {
     // Make this RL the active one, for history dumping.
     self.activeRileyLink = device;
     [self handlePumpStatus:packet fromDevice:device withRSSI:packet.rssi];
-    // Just got a MySentry packet; in 20s would be a good time to poll.
+    // Just got a MySentry packet; in 25s would be a good time to poll.
     if (!dumpHistoryScheduled) {
-      [self performSelector:@selector(fetchHistory:) withObject:nil afterDelay:20];
+      [self performSelector:@selector(fetchHistory:) withObject:nil afterDelay:25];
       dumpHistoryScheduled = YES;
     }
 

--- a/RileyLink/RileyLinkBLEDevice.m
+++ b/RileyLink/RileyLinkBLEDevice.m
@@ -321,7 +321,7 @@
   if (idleListeningEnabled) {
     GetPacketCmd *cmd = [[GetPacketCmd alloc] init];
     cmd.listenChannel = idleListenChannel;
-    cmd.timeoutMS = 30000;
+    cmd.timeoutMS = 60 * 1000;
     [self issueCommand:cmd];
   }
 }

--- a/log_processing/readlog.rb
+++ b/log_processing/readlog.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'open-uri'
+require 'json'
+
+if ARGV.count < 2
+  puts "Usage: readlog.rb <NSURL> <count>"
+  exit -1
+end 
+
+entries = JSON.parse(open("#{ARGV[0]}/api/v1/entries.json?find[type]=logs&count=#{ARGV[1]}").read)
+
+entries = entries.sort_by {|e| e["dateString"]}
+
+#puts entries.map {|e| e["dateString"]}.inspect
+
+entries.each do |e|
+  e["entries"].each do |line|
+    puts line
+  end
+end


### PR DESCRIPTION
This is a debug tool that will normally be left inactive.  To activate it, uncomment the `#define LOG_TO_NS 1` line in Log.h

Records will be written to your entries endpoint, with a type of 'logs'.  You can use the log_processing/readlog.rb tool to view the most recent logs stored in NS.

This is useful for figuring out what's going on in the app when it is running in the background.
