### PR TITLE
RileyLinkKit: High-level device interface

### DIFF
--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		434AB0971CBA0DF600422F4A /* PumpOpsSynchronous.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB0931CBA0DF600422F4A /* PumpOpsSynchronous.swift */; };
 		434AB0981CBA0DF600422F4A /* PumpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB0941CBA0DF600422F4A /* PumpState.swift */; };
 		434AB09E1CBA28F100422F4A /* NSTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */; };
+		434AB0BE1CBB4E3200422F4A /* RileyLinkDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB0BD1CBB4E3200422F4A /* RileyLinkDeviceManager.swift */; };
 		43722FB11CB9F7640038B7F2 /* RileyLinkKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 43722FB01CB9F7640038B7F2 /* RileyLinkKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43722FB81CB9F7640038B7F2 /* RileyLinkKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43722FAE1CB9F7630038B7F2 /* RileyLinkKit.framework */; };
 		43722FBF1CB9F7640038B7F2 /* RileyLinkKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43722FBE1CB9F7640038B7F2 /* RileyLinkKitTests.swift */; };
@@ -315,6 +316,7 @@
 		434AB0931CBA0DF600422F4A /* PumpOpsSynchronous.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PumpOpsSynchronous.swift; sourceTree = "<group>"; };
 		434AB0941CBA0DF600422F4A /* PumpState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PumpState.swift; sourceTree = "<group>"; };
 		434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTimeInterval.swift; sourceTree = "<group>"; };
+		434AB0BD1CBB4E3200422F4A /* RileyLinkDeviceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RileyLinkDeviceManager.swift; sourceTree = "<group>"; };
 		43722FAE1CB9F7630038B7F2 /* RileyLinkKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RileyLinkKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		43722FB01CB9F7640038B7F2 /* RileyLinkKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RileyLinkKit.h; sourceTree = "<group>"; };
 		43722FB21CB9F7640038B7F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -642,10 +644,11 @@
 				43722FB01CB9F7640038B7F2 /* RileyLinkKit.h */,
 				43722FB21CB9F7640038B7F2 /* Info.plist */,
 				434AB0911CBA0DF600422F4A /* Either.swift */,
+				434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */,
 				434AB0921CBA0DF600422F4A /* PumpOps.swift */,
 				434AB0931CBA0DF600422F4A /* PumpOpsSynchronous.swift */,
 				434AB0941CBA0DF600422F4A /* PumpState.swift */,
-				434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */,
+				434AB0BD1CBB4E3200422F4A /* RileyLinkDeviceManager.swift */,
 			);
 			path = RileyLinkKit;
 			sourceTree = "<group>";
@@ -1379,6 +1382,7 @@
 				434AB0961CBA0DF600422F4A /* PumpOps.swift in Sources */,
 				434AB0981CBA0DF600422F4A /* PumpState.swift in Sources */,
 				434AB0971CBA0DF600422F4A /* PumpOpsSynchronous.swift in Sources */,
+				434AB0BE1CBB4E3200422F4A /* RileyLinkDeviceManager.swift in Sources */,
 				434AB09E1CBA28F100422F4A /* NSTimeInterval.swift in Sources */,
 				434AB0951CBA0DF600422F4A /* Either.swift in Sources */,
 			);

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		434AB0981CBA0DF600422F4A /* PumpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB0941CBA0DF600422F4A /* PumpState.swift */; };
 		434AB09E1CBA28F100422F4A /* NSTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */; };
 		43523ED71CC2C558001850F1 /* NSData+Conversion.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E535E91991E36700C2AC49 /* NSData+Conversion.m */; };
+		43523ED81CC2C820001850F1 /* UIAlertView+Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = C1AA39931AB6804000BC9E33 /* UIAlertView+Blocks.m */; };
 		43722FB11CB9F7640038B7F2 /* RileyLinkKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 43722FB01CB9F7640038B7F2 /* RileyLinkKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43722FB81CB9F7640038B7F2 /* RileyLinkKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43722FAE1CB9F7630038B7F2 /* RileyLinkKit.framework */; };
 		43722FBF1CB9F7640038B7F2 /* RileyLinkKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43722FBE1CB9F7640038B7F2 /* RileyLinkKitTests.swift */; };
@@ -1361,6 +1362,7 @@
 				430D650B1CB89FC000FCA750 /* SendAndListenCmd.m in Sources */,
 				430D65051CB89FC000FCA750 /* GetVersionCmd.m in Sources */,
 				430D650D1CB89FC000FCA750 /* SendPacketCmd.m in Sources */,
+				43523ED81CC2C820001850F1 /* UIAlertView+Blocks.m in Sources */,
 				430D650F1CB89FC000FCA750 /* UpdateRegisterCmd.m in Sources */,
 				430D65071CB89FC000FCA750 /* ReceivingPacketCmd.m in Sources */,
 			);

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		434AB0981CBA0DF600422F4A /* PumpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB0941CBA0DF600422F4A /* PumpState.swift */; };
 		434AB09E1CBA28F100422F4A /* NSTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */; };
 		434AB0BE1CBB4E3200422F4A /* RileyLinkDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB0BD1CBB4E3200422F4A /* RileyLinkDeviceManager.swift */; };
+		434AB0C61CBCB41500422F4A /* RileyLinkDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB0C51CBCB41500422F4A /* RileyLinkDevice.swift */; };
+		434AB0C71CBCB76400422F4A /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EAD6BA1C826B92006DBA60 /* NSData.swift */; };
 		43722FB11CB9F7640038B7F2 /* RileyLinkKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 43722FB01CB9F7640038B7F2 /* RileyLinkKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43722FB81CB9F7640038B7F2 /* RileyLinkKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43722FAE1CB9F7630038B7F2 /* RileyLinkKit.framework */; };
 		43722FBF1CB9F7640038B7F2 /* RileyLinkKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43722FBE1CB9F7640038B7F2 /* RileyLinkKitTests.swift */; };
@@ -317,6 +319,7 @@
 		434AB0941CBA0DF600422F4A /* PumpState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PumpState.swift; sourceTree = "<group>"; };
 		434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTimeInterval.swift; sourceTree = "<group>"; };
 		434AB0BD1CBB4E3200422F4A /* RileyLinkDeviceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RileyLinkDeviceManager.swift; sourceTree = "<group>"; };
+		434AB0C51CBCB41500422F4A /* RileyLinkDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RileyLinkDevice.swift; sourceTree = "<group>"; };
 		43722FAE1CB9F7630038B7F2 /* RileyLinkKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RileyLinkKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		43722FB01CB9F7640038B7F2 /* RileyLinkKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RileyLinkKit.h; sourceTree = "<group>"; };
 		43722FB21CB9F7640038B7F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -648,6 +651,7 @@
 				434AB0921CBA0DF600422F4A /* PumpOps.swift */,
 				434AB0931CBA0DF600422F4A /* PumpOpsSynchronous.swift */,
 				434AB0941CBA0DF600422F4A /* PumpState.swift */,
+				434AB0C51CBCB41500422F4A /* RileyLinkDevice.swift */,
 				434AB0BD1CBB4E3200422F4A /* RileyLinkDeviceManager.swift */,
 			);
 			path = RileyLinkKit;
@@ -1380,6 +1384,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				434AB0961CBA0DF600422F4A /* PumpOps.swift in Sources */,
+				434AB0C61CBCB41500422F4A /* RileyLinkDevice.swift in Sources */,
+				434AB0C71CBCB76400422F4A /* NSData.swift in Sources */,
 				434AB0981CBA0DF600422F4A /* PumpState.swift in Sources */,
 				434AB0971CBA0DF600422F4A /* PumpOpsSynchronous.swift in Sources */,
 				434AB0BE1CBB4E3200422F4A /* RileyLinkDeviceManager.swift in Sources */,

--- a/RileyLinkBLEKit/RileyLinkBLEDevice.m
+++ b/RileyLinkBLEKit/RileyLinkBLEDevice.m
@@ -65,7 +65,7 @@
     cmdDispatchGroup = dispatch_group_create();
     idleDetectDispatchGroup = dispatch_group_create();
 
-    _idleTimeout = 60 * 1000;
+    _idleTimeout = 63 * 1000;
     _timerTickEnabled = YES;
 
     incomingPackets = [NSMutableArray array];

--- a/RileyLinkBLEKit/RileyLinkBLEDevice.m
+++ b/RileyLinkBLEKit/RileyLinkBLEDevice.m
@@ -65,7 +65,7 @@
     cmdDispatchGroup = dispatch_group_create();
     idleDetectDispatchGroup = dispatch_group_create();
 
-    _idleTimeout = 63 * 1000;
+    _idleTimeout = 60 * 1000;
     _timerTickEnabled = YES;
 
     incomingPackets = [NSMutableArray array];

--- a/RileyLinkKit/PumpOps.swift
+++ b/RileyLinkKit/PumpOps.swift
@@ -143,8 +143,9 @@ public class PumpOps: NSObject {
       }
     }
   }
-  
-  internal func tunePump(completion: (Either<FrequencyScanResults, ErrorType>) -> Void)  {
+
+  // TODO: Internal scope
+  public func tunePump(completion: (Either<FrequencyScanResults, ErrorType>) -> Void)  {
     device.runSession { (session) -> Void in
       let ops = PumpOpsSynchronous(pumpState: self.pumpState, session: session)
       do {

--- a/RileyLinkKit/PumpOps.swift
+++ b/RileyLinkKit/PumpOps.swift
@@ -144,7 +144,7 @@ public class PumpOps: NSObject {
     }
   }
   
-  public func tunePump(completion: (Either<FrequencyScanResults, ErrorType>) -> Void)  {
+  internal func tunePump(completion: (Either<FrequencyScanResults, ErrorType>) -> Void)  {
     device.runSession { (session) -> Void in
       let ops = PumpOpsSynchronous(pumpState: self.pumpState, session: session)
       do {

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -15,7 +15,7 @@ public enum PumpCommsError: ErrorType {
   case RFCommsFailure(String)
   case UnknownPumpModel
   case RileyLinkTimeout
-  case UnknownResponse
+  case UnknownResponse(String)
 }
 
 
@@ -52,7 +52,7 @@ class PumpOpsSynchronous {
     }
 
     guard let data = cmd.receivedPacket.data, message = PumpMessage(rxData: data) where message.address == msg.address else {
-      throw PumpCommsError.UnknownResponse
+      throw PumpCommsError.UnknownResponse("Sent \(msg.txData) and received \(cmd.receivedPacket.data ?? NSData())")
     }
 
     return message
@@ -67,7 +67,7 @@ class PumpOpsSynchronous {
     let shortResponse = try sendAndListen(shortPowerMessage, timeoutMS: 15000, repeatCount: 200, msBetweenPackets: 0, retryCount: 0)
     
     guard shortResponse.messageType == .PumpAck else {
-      throw PumpCommsError.UnknownResponse
+      throw PumpCommsError.UnknownResponse("Wakeup shortResponse: \(shortResponse.txData)")
     }
     NSLog("Pump acknowledged wakeup!")
 
@@ -75,10 +75,10 @@ class PumpOpsSynchronous {
     let longResponse = try sendAndListen(longPowerMessage)
     
     guard longResponse.messageType == .PumpAck else {
-      throw PumpCommsError.UnknownResponse
+      throw PumpCommsError.UnknownResponse("Wakeup longResponse: \(longResponse.txData)")
     }
 
-    NSLog("Power on for %d minutes", duration.minutes)
+    NSLog("Power on for %.0f minutes", duration.minutes)
     pump.awakeUntil = NSDate(timeIntervalSinceNow: duration)
   }
 
@@ -89,13 +89,13 @@ class PumpOpsSynchronous {
     let shortResponse = try sendAndListen(shortMsg)
     
     guard shortResponse.messageType == .PumpAck else {
-      throw PumpCommsError.UnknownResponse
+      throw PumpCommsError.UnknownResponse(String(shortResponse.txData))
     }
     
     let response = try sendAndListen(msg)
 
     guard response.messageType == responseMessageType else {
-      throw PumpCommsError.UnknownResponse
+      throw PumpCommsError.UnknownResponse(String(response.txData))
     }
 
     return response
@@ -113,7 +113,7 @@ class PumpOpsSynchronous {
     let response = try sendAndListen(msg)
 
     guard response.messageType == messageType, let body = response.messageBody as? T else {
-      throw PumpCommsError.UnknownResponse
+      throw PumpCommsError.UnknownResponse(String(response.txData))
     }
     return body
   }
@@ -156,13 +156,13 @@ class PumpOpsSynchronous {
     let shortResponse = try sendAndListen(makePumpMessage(.ChangeTime))
 
     guard shortResponse.messageType == .PumpAck else {
-      throw PumpCommsError.UnknownResponse
+      throw PumpCommsError.UnknownResponse("changeTime shortResponse: \(shortResponse.txData)")
     }
 
     let response = try sendAndListen(messageGenerator())
 
     guard response.messageType == .PumpAck else {
-      throw PumpCommsError.UnknownResponse
+      throw PumpCommsError.UnknownResponse("changeTime response: \(response.txData)")
     }
   }
   

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -137,7 +137,7 @@ class PumpOpsSynchronous {
 
         let response: ReadTempBasalCarelinkMessageBody = try getMessageBodyWithType(.ReadTempBasal)
 
-        if response.timeRemaining == duration {
+        if response.timeRemaining == duration && response.rateType == .Absolute {
           return response
         } else {
           lastError = PumpCommsError.RFCommsFailure("Could not verify TempBasal on attempt \(attempt)")

--- a/RileyLinkKit/PumpState.swift
+++ b/RileyLinkKit/PumpState.swift
@@ -12,7 +12,7 @@ import MinimedKit
 
 public class PumpState: NSObject {
   public let pumpID: String
-  public var timeZone: NSTimeZone = NSTimeZone.localTimeZone()
+  public var timeZone: NSTimeZone = NSTimeZone.defaultTimeZone()
   public var pumpModel: PumpModel?
   public var lastHistoryDump: NSDate?
   public var awakeUntil: NSDate?

--- a/RileyLinkKit/PumpState.swift
+++ b/RileyLinkKit/PumpState.swift
@@ -9,8 +9,9 @@
 import UIKit
 import MinimedKit
 
+
 public class PumpState: NSObject {
-  public var pumpID: String
+  public let pumpID: String
   public var timeZone: NSTimeZone = NSTimeZone.localTimeZone()
   public var pumpModel: PumpModel?
   public var lastHistoryDump: NSDate?

--- a/RileyLinkKit/RileyLinkDevice.swift
+++ b/RileyLinkKit/RileyLinkDevice.swift
@@ -104,7 +104,7 @@ public class RileyLinkDevice {
 
   // MARK: -
 
-  private var device: RileyLinkBLEDevice
+  internal var device: RileyLinkBLEDevice
 
   @objc private func receivedDeviceNotification(note: NSNotification) {
     switch note.name {

--- a/RileyLinkKit/RileyLinkDevice.swift
+++ b/RileyLinkKit/RileyLinkDevice.swift
@@ -8,19 +8,102 @@
 
 import Foundation
 import CoreBluetooth
+import MinimedKit
 import RileyLinkBLEKit
 
 
 public class RileyLinkDevice {
 
-  private var device: RileyLinkBLEDevice
+  enum Error: ErrorType {
+    case ConfigurationError
+  }
+
+  public static let DidReceiveIdleMessageNotification = "com.rileylink.RileyLinkKit.RileyLinkDeviceDidReceiveIdleMessageNotification"
+
+  public static let IdleMessageDataKey = "com.rileylink.RileyLinkKit.RileyLinkDeviceIdleMessageData"
+
+  public internal(set) var pumpState: PumpState?
+
+  public var lastIdle: NSDate? {
+    return device.lastIdle
+  }
+
+  public private(set) var lastTuned: NSDate?
+
+  public private(set) var radioFrequency: Double?
+
+  public var name: String? {
+    return device.name
+  }
+
+  public var RSSI: Int? {
+    return device.RSSI?.integerValue
+  }
 
   public var peripheral: CBPeripheral {
     return device.peripheral
   }
 
-  internal init(BLEDevice: RileyLinkBLEDevice) {
+  internal init(BLEDevice: RileyLinkBLEDevice, pumpState: PumpState?) {
     self.device = BLEDevice
+    self.pumpState = pumpState
+
+    NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(receivedDeviceNotification(_:)), name: nil, object: BLEDevice)
+  }
+
+  // MARK: - Device commands
+
+  public func assertIdleListening() {
+    device.assertIdleListening()
+  }
+
+  public func syncPumpTime(resultHandler: (ErrorType?) -> Void) {
+    if let ops = ops {
+      ops.setTime({ () -> NSDateComponents in
+          let calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)!
+          return calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: NSDate())
+        },
+        completion: { (error) in
+          if error == nil {
+            ops.pumpState.timeZone = NSTimeZone.defaultTimeZone()
+          }
+
+          resultHandler(error)
+        }
+      )
+    } else {
+      resultHandler(Error.ConfigurationError)
+    }
+  }
+
+  // TODO:
+  public func tunePumpWithResultHandler(resultHandler: ([String: AnyObject]) -> Void) {
+    resultHandler([:])
+  }
+
+  public var ops: PumpOps? {
+    if let pumpState = pumpState {
+      return PumpOps(pumpState: pumpState, device: device)
+    } else {
+      return nil
+    }
+  }
+
+  // MARK: -
+
+  private var device: RileyLinkBLEDevice
+
+  @objc private func receivedDeviceNotification(note: NSNotification) {
+    switch note.name {
+    case RILEYLINK_EVENT_PACKET_RECEIVED:
+      if let packet = note.userInfo?["packet"] as? RFPacket, pumpID = pumpState?.pumpID, data = packet.data, message = PumpMessage(rxData: data) where message.address.hexadecimalString == pumpID {
+        NSNotificationCenter.defaultCenter().postNotificationName(self.dynamicType.DidReceiveIdleMessageNotification, object: self, userInfo: [self.dynamicType.IdleMessageDataKey: data])
+      }
+    case RILEYLINK_EVENT_DEVICE_CONNECTED:
+      device.enableIdleListeningOnChannel(0)
+    default:
+      break
+    }
   }
 
 }

--- a/RileyLinkKit/RileyLinkDevice.swift
+++ b/RileyLinkKit/RileyLinkDevice.swift
@@ -1,0 +1,26 @@
+//
+//  RileyLinkDevice.swift
+//  Naterade
+//
+//  Created by Nathan Racklyeft on 4/10/16.
+//  Copyright © 2016 Nathan Racklyeft. All rights reserved.
+//
+
+import Foundation
+import CoreBluetooth
+import RileyLinkBLEKit
+
+
+public class RileyLinkDevice {
+
+  private var device: RileyLinkBLEDevice
+
+  public var peripheral: CBPeripheral {
+    return device.peripheral
+  }
+
+  internal init(BLEDevice: RileyLinkBLEDevice) {
+    self.device = BLEDevice
+  }
+
+}

--- a/RileyLinkKit/RileyLinkDevice.swift
+++ b/RileyLinkKit/RileyLinkDevice.swift
@@ -76,9 +76,22 @@ public class RileyLinkDevice {
     }
   }
 
-  // TODO:
-  public func tunePumpWithResultHandler(resultHandler: ([String: AnyObject]) -> Void) {
-    resultHandler([:])
+  public func tunePumpWithResultHandler(resultHandler: (Either<FrequencyScanResults, ErrorType>) -> Void) {
+    if let ops = ops {
+      ops.tunePump { (result) in
+        switch result {
+        case .Success(let scanResults):
+          self.lastTuned = NSDate()
+          self.radioFrequency = scanResults.bestFrequency
+        case .Failure:
+          break
+        }
+
+        resultHandler(result)
+      }
+    } else {
+      resultHandler(.Failure(Error.ConfigurationError))
+    }
   }
 
   public var ops: PumpOps? {

--- a/RileyLinkKit/RileyLinkDeviceManager.swift
+++ b/RileyLinkKit/RileyLinkDeviceManager.swift
@@ -1,0 +1,102 @@
+//
+//  RileyLinkDeviceManager.swift
+//  RileyLink
+//
+//  Created by Nathan Racklyeft on 4/10/16.
+//  Copyright © 2016 Pete Schwamb. All rights reserved.
+//
+
+import Foundation
+import RileyLinkBLEKit
+
+
+public class RileyLinkDeviceManager {
+
+  public static let DidDiscoverDeviceNotification = "com.rileylink.RileyLinkKit.DidDiscoverDeviceNotification"
+
+  public static let ConnectionStateDidChangeNotification = "com.rileylink.RileyLinkKit.ConnectionStateDidChangeNotification"
+
+  public static let RileyLinkDeviceKey = "com.rileylink.RileyLinkKit.RileyLinkDevice"
+
+  public enum ReadyState {
+    case NeedsConfiguration
+    case Ready(PumpState)
+  }
+
+  public var readyState: ReadyState
+
+  public init(pumpState: PumpState?, autoConnectIDs: Set<String>) {
+
+    if let pumpState = pumpState {
+      readyState = .Ready(pumpState)
+    } else {
+      readyState = .NeedsConfiguration
+    }
+
+    self.autoConnectIDs = autoConnectIDs
+
+    NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(discoveredBLEDevice(_:)), name: RILEYLINK_EVENT_LIST_UPDATED, object: BLEManager)
+
+    NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(connectionStateDidChange(_:)), name: RILEYLINK_EVENT_DEVICE_CONNECTED, object: BLEManager)
+
+    NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(connectionStateDidChange(_:)), name: RILEYLINK_EVENT_DEVICE_DISCONNECTED, object: BLEManager)
+  }
+
+  private var autoConnectIDs: Set<String>
+
+  public var deviceScanningEnabled: Bool {
+    get {
+      return BLEManager.scanningEnabled
+    }
+    set {
+      BLEManager.scanningEnabled = newValue
+    }
+  }
+
+  private var _devices: [RileyLinkDevice] = []
+
+  public var devices: [RileyLinkDevice] {
+    return _devices
+  }
+
+  public var firstConnectedDevice: RileyLinkDevice? {
+    if let index = _devices.indexOf({ $0.peripheral.state == .Connected }) {
+      return _devices[index]
+    } else {
+      return nil
+    }
+  }
+
+  public func connectDevice(device: RileyLinkDevice) {
+    BLEManager.connectPeripheral(device.peripheral)
+  }
+
+  public func disconnectDevice(device: RileyLinkDevice) {
+    BLEManager.disconnectPeripheral(device.peripheral)
+  }
+
+  private let BLEManager = RileyLinkBLEManager()
+
+  // MARK: - RileyLinkBLEManager
+
+  @objc private func discoveredBLEDevice(note: NSNotification) {
+    if let BLEDevice = note.userInfo?["device"] as? RileyLinkBLEDevice {
+      let device = RileyLinkDevice(BLEDevice: BLEDevice)
+
+      _devices.append(device)
+
+      NSNotificationCenter.defaultCenter().postNotificationName(self.dynamicType.DidDiscoverDeviceNotification, object: self, userInfo: [self.dynamicType.RileyLinkDeviceKey: device])
+
+    }
+  }
+
+  @objc private func connectionStateDidChange(note: NSNotification) {
+    if let BLEDevice = note.object as? RileyLinkBLEDevice,
+      index = _devices.indexOf({ $0.peripheral == BLEDevice.peripheral }) {
+      let device = _devices[index]
+
+      NSNotificationCenter.defaultCenter().postNotificationName(self.dynamicType.ConnectionStateDidChangeNotification, object: self, userInfo: [self.dynamicType.RileyLinkDeviceKey: device])
+    }
+  }
+
+}

--- a/RileyLinkKit/RileyLinkDeviceManager.swift
+++ b/RileyLinkKit/RileyLinkDeviceManager.swift
@@ -18,21 +18,16 @@ public class RileyLinkDeviceManager {
 
   public static let RileyLinkDeviceKey = "com.rileylink.RileyLinkKit.RileyLinkDevice"
 
-  public enum ReadyState {
-    case NeedsConfiguration
-    case Ready(PumpState)
+  public var pumpState: PumpState? {
+    didSet {
+      for device in _devices {
+        device.pumpState = pumpState
+      }
+    }
   }
 
-  public var readyState: ReadyState
-
   public init(pumpState: PumpState?, autoConnectIDs: Set<String>) {
-
-    if let pumpState = pumpState {
-      readyState = .Ready(pumpState)
-    } else {
-      readyState = .NeedsConfiguration
-    }
-
+    self.pumpState = pumpState
     self.autoConnectIDs = autoConnectIDs
 
     NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(discoveredBLEDevice(_:)), name: RILEYLINK_EVENT_LIST_UPDATED, object: BLEManager)
@@ -81,7 +76,7 @@ public class RileyLinkDeviceManager {
 
   @objc private func discoveredBLEDevice(note: NSNotification) {
     if let BLEDevice = note.userInfo?["device"] as? RileyLinkBLEDevice {
-      let device = RileyLinkDevice(BLEDevice: BLEDevice)
+      let device = RileyLinkDevice(BLEDevice: BLEDevice, pumpState: pumpState)
 
       _devices.append(device)
 

--- a/RileyLinkKit/RileyLinkDeviceManager.swift
+++ b/RileyLinkKit/RileyLinkDeviceManager.swift
@@ -28,7 +28,8 @@ public class RileyLinkDeviceManager {
 
   public init(pumpState: PumpState?, autoConnectIDs: Set<String>) {
     self.pumpState = pumpState
-    self.autoConnectIDs = autoConnectIDs
+
+    BLEManager.autoConnectIds = autoConnectIDs
 
     NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(discoveredBLEDevice(_:)), name: RILEYLINK_EVENT_LIST_UPDATED, object: BLEManager)
 
@@ -37,14 +38,20 @@ public class RileyLinkDeviceManager {
     NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(connectionStateDidChange(_:)), name: RILEYLINK_EVENT_DEVICE_DISCONNECTED, object: BLEManager)
   }
 
-  private var autoConnectIDs: Set<String>
-
   public var deviceScanningEnabled: Bool {
     get {
       return BLEManager.scanningEnabled
     }
     set {
       BLEManager.scanningEnabled = newValue
+    }
+  }
+
+  public var timerTickEnabled = true {
+    didSet {
+      for device in _devices {
+        device.device.timerTickEnabled = timerTickEnabled
+      }
     }
   }
 
@@ -76,6 +83,8 @@ public class RileyLinkDeviceManager {
 
   @objc private func discoveredBLEDevice(note: NSNotification) {
     if let BLEDevice = note.userInfo?["device"] as? RileyLinkBLEDevice {
+      BLEDevice.timerTickEnabled = timerTickEnabled
+
       let device = RileyLinkDevice(BLEDevice: BLEDevice, pumpState: pumpState)
 
       _devices.append(device)


### PR DESCRIPTION
This is an nearly-exact port of the interfaces I've been using in Naterade since August of last year. It provides a high-level interface for working with RileyLink devices and running pump commands.

Here's an example of where my `LoopDataManager` [enacts its recommended temp basal](https://github.com/loudnate/naterade-ios/blob/rileylinkkit/Naterade/Managers/LoopDataManager.swift#L432-L442)
