### PR TITLE
Ensure services are discovered when restoring a peripheral

### DIFF
--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -295,7 +295,7 @@
 		430D64E81CB85A4300FCA750 /* RileyLinkBLEDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RileyLinkBLEDevice.h; sourceTree = "<group>"; };
 		430D64E91CB85A4300FCA750 /* RileyLinkBLEDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = RileyLinkBLEDevice.m; sourceTree = "<group>"; tabWidth = 2; };
 		430D64EA1CB85A4300FCA750 /* RileyLinkBLEManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RileyLinkBLEManager.h; sourceTree = "<group>"; };
-		430D64EB1CB85A4300FCA750 /* RileyLinkBLEManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RileyLinkBLEManager.m; sourceTree = "<group>"; };
+		430D64EB1CB85A4300FCA750 /* RileyLinkBLEManager.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = RileyLinkBLEManager.m; sourceTree = "<group>"; tabWidth = 2; };
 		430D64F01CB89FC000FCA750 /* CmdBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CmdBase.h; sourceTree = "<group>"; };
 		430D64F11CB89FC000FCA750 /* CmdBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CmdBase.m; sourceTree = "<group>"; };
 		430D64F21CB89FC000FCA750 /* GetPacketCmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GetPacketCmd.h; sourceTree = "<group>"; };

--- a/RileyLinkBLEKit/RileyLinkBLEManager.m
+++ b/RileyLinkBLEKit/RileyLinkBLEManager.m
@@ -131,6 +131,7 @@
     [_centralManager connectPeripheral:peripheral options:nil];
   } else {
     NSLog(@"Skipped request to connect to %@:%@", _centralManager, peripheral);
+    [self centralManager:_centralManager didConnectPeripheral:peripheral];
   }
   
   [self addPeripheralToAutoConnectList:peripheral];


### PR DESCRIPTION
peripherals in CBPeripheralStateConnecting could fall into a bad state

Fixes #86
