### PR TITLE
Retry wakeup — more consistent communications for x22 pumps

### DIFF
--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -86,7 +86,6 @@ class PumpOpsSynchronous {
                     lastError = PumpCommsError.UnknownResponse("Wakeup shortResponse: \(shortResponse.txData)")
                 }
             } catch let error {
-                print("Wakeup failure on attempt #\(attempt): \(error)")
                 lastError = error
             }
         }
@@ -102,7 +101,7 @@ class PumpOpsSynchronous {
             return
         }
         
-        try attemptShortWakeUp();
+        try attemptShortWakeUp()
         
         let longPowerMessage = makePumpMessage(.PowerOn, body: PowerOnCarelinkMessageBody(duration: duration))
         let longResponse = try sendAndListen(longPowerMessage)

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -62,18 +62,47 @@ class PumpOpsSynchronous {
         return message
     }
     
+    /**
+     Attempts to send initial short wakeup message that kicks off the wakeup process.
+
+     Makes multiple attempts to send this message in order to work around issue w/
+     x22 pump/RileyLink combos not responding to the initial short wakeup message.
+
+     If successful, still does not fully wake up the pump - only alerts it such that the
+     longer wakeup message can be sent next.
+     */
+    private func attemptShortWakeUp(attempts: Int = 3) throws {
+        var lastError: ErrorType?
+
+        for attempt in 0..<attempts {
+            do {
+                let shortPowerMessage = makePumpMessage(.PowerOn)
+                let shortResponse = try sendAndListen(shortPowerMessage, timeoutMS: 15000, repeatCount: 255, msBetweenPackets: 0, retryCount: 0)
+
+                guard shortResponse.messageType == .PumpAck else {
+                    throw PumpCommsError.UnknownResponse("Wakeup shortResponse: \(shortResponse.txData)")
+                }
+
+                // Pump successfully received and responded to short wakeup message!
+                return
+            } catch let error {
+                print("Wakeup failure on attempt #\(attempt): \(error)")
+                lastError = error
+            }
+        }
+
+        if lastError != nil {
+            // If all attempts failed, throw the final error
+            throw lastError!
+        }
+    }
+
     private func wakeup(duration: NSTimeInterval = NSTimeInterval(minutes: 1)) throws {
         guard !pump.isAwake else {
             return
         }
         
-        let shortPowerMessage = makePumpMessage(.PowerOn)
-        let shortResponse = try sendAndListen(shortPowerMessage, timeoutMS: 15000, repeatCount: 200, msBetweenPackets: 0, retryCount: 0)
-        
-        guard shortResponse.messageType == .PumpAck else {
-            throw PumpCommsError.UnknownResponse("Wakeup shortResponse: \(shortResponse.txData)")
-        }
-        NSLog("Pump acknowledged wakeup!")
+        try attemptShortWakeUp();
         
         let longPowerMessage = makePumpMessage(.PowerOn, body: PowerOnCarelinkMessageBody(duration: duration))
         let longResponse = try sendAndListen(longPowerMessage)

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -79,21 +79,21 @@ class PumpOpsSynchronous {
                 let shortPowerMessage = makePumpMessage(.PowerOn)
                 let shortResponse = try sendAndListen(shortPowerMessage, timeoutMS: 15000, repeatCount: 255, msBetweenPackets: 0, retryCount: 0)
 
-                guard shortResponse.messageType == .PumpAck else {
-                    throw PumpCommsError.UnknownResponse("Wakeup shortResponse: \(shortResponse.txData)")
+                if shortResponse.messageType == .PumpAck {
+                    // Pump successfully received and responded to short wakeup message!
+                    return
+                } else {
+                    lastError = PumpCommsError.UnknownResponse("Wakeup shortResponse: \(shortResponse.txData)")
                 }
-
-                // Pump successfully received and responded to short wakeup message!
-                return
             } catch let error {
                 print("Wakeup failure on attempt #\(attempt): \(error)")
                 lastError = error
             }
         }
 
-        if lastError != nil {
+        if let lastError = lastError {
             // If all attempts failed, throw the final error
-            throw lastError!
+            throw lastError
         }
     }
 


### PR DESCRIPTION
(Apologies if I should base this PR off of a branch other than dev. Lemme know the process you'd prefer.)

As discussed in gitter/slack, this PR adds retry logic to the initial short wakeup attempt, which has been verified by me and aemazaheri to increase likelihood of RL<=>pump communication success.

You and @loudnate know far more than I do about _why_ that is the case ;). Happy to add more findings/context from my experience here if helpful.
