### PR TITLE
Cleanup toward history timezone reconciliation.

### DIFF
--- a/MinimedKit/PumpEvents/BolusNormalPumpEvent.swift
+++ b/MinimedKit/PumpEvents/BolusNormalPumpEvent.swift
@@ -9,23 +9,29 @@
 import Foundation
 
 public class BolusNormalPumpEvent: TimestampedPumpEvent {
+
+    public enum BolusType: String {
+        case Normal
+        case Square
+    }
+
     public let length: Int
     public let timestamp: NSDateComponents
     public var unabsorbedInsulinRecord: UnabsorbedInsulinPumpEvent?
     public let amount: Double
     public let programmed: Double
     public let unabsorbedInsulinTotal: Double
-    public let bolusType: String
-    public let duration: Int
+    public let type: BolusType
+    public let duration: NSTimeInterval
     
     public required init?(availableData: NSData, pumpModel: PumpModel) {
         
-        func d(idx:Int) -> Int {
-            return Int(availableData[idx] as UInt8)
+        func doubleValueFromDataAtIndex(index: Int) -> Double {
+            return Double(availableData[index] as UInt8)
         }
         
-        func insulinDecode(a: Int, b: Int) -> Double {
-            return Double((a << 8) + b) / 40.0
+        func decodeInsulinFromBytes(bytes: [UInt8]) -> Double {
+            return Double(Int(bigEndianBytes: bytes)) / Double(pumpModel.strokesPerUnit)
         }
         
         if pumpModel.larger {
@@ -40,18 +46,18 @@ public class BolusNormalPumpEvent: TimestampedPumpEvent {
         
         if pumpModel.larger {
             timestamp = TimeFormat.parse5ByteDate(availableData, offset: 8)
-            amount = insulinDecode(d(3), b: d(4))
-            programmed = insulinDecode(d(1), b: d(2))
-            unabsorbedInsulinTotal = insulinDecode(d(5), b: d(6))
-            duration = d(7) * 30
+            programmed = decodeInsulinFromBytes(availableData[1...2])
+            amount = decodeInsulinFromBytes(availableData[3...4])
+            unabsorbedInsulinTotal = decodeInsulinFromBytes(availableData[5...6])
+            duration = NSTimeInterval(minutes: 30 * doubleValueFromDataAtIndex(7))
         } else {
             timestamp = TimeFormat.parse5ByteDate(availableData, offset: 4)
-            amount = Double(d(2))/10.0
-            programmed = Double(d(1))/10.0
-            duration = d(3) * 30
+            programmed = decodeInsulinFromBytes([availableData[1]])
+            amount = decodeInsulinFromBytes([availableData[2]])
+            duration = NSTimeInterval(minutes: 30 * doubleValueFromDataAtIndex(3))
             unabsorbedInsulinTotal = 0
         }
-        bolusType = duration > 0 ? "square" : "normal"
+        type = duration > 0 ? .Square : .Normal
     }
     
     public var dictionaryRepresentation: [String: AnyObject] {
@@ -59,9 +65,9 @@ public class BolusNormalPumpEvent: TimestampedPumpEvent {
             "_type": "BolusNormal",
             "amount": amount,
             "programmed": programmed,
-            "type": bolusType,
+            "type": type.rawValue,
             "timestamp": TimeFormat.timestampStr(timestamp),
-            ]
+        ]
         
         if let unabsorbedInsulinRecord = unabsorbedInsulinRecord {
             dictionary["appended"] = unabsorbedInsulinRecord.dictionaryRepresentation

--- a/MinimedKit/PumpEvents/ChangeTimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeTimePumpEvent.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-public class ChangeTimePumpEvent: PumpEvent {
+public class ChangeTimePumpEvent: TimestampedPumpEvent {
     public let length: Int
-    let timestamp: NSDateComponents
+    public let timestamp: NSDateComponents
     
     public required init?(availableData: NSData, pumpModel: PumpModel) {
         length = 14

--- a/MinimedKitTests/HistoryPageTests.swift
+++ b/MinimedKitTests/HistoryPageTests.swift
@@ -102,7 +102,8 @@ class HistoryPageTests: XCTestCase {
             
             let bolus = events[1] as! BolusNormalPumpEvent
             XCTAssertEqual(bolus.amount, 3.2)
-            XCTAssertEqual(bolus.bolusType, "normal")
+
+            XCTAssertEqual(bolus.type, BolusNormalPumpEvent.BolusType.Normal)
             XCTAssertEqual(bolus.duration, 0)
             XCTAssertEqual(bolus.programmed, 3.2)
             XCTAssertEqual(bolus.unabsorbedInsulinTotal, 0.9)
@@ -174,7 +175,7 @@ class HistoryPageTests: XCTestCase {
             
             let bolus = events[0] as! BolusNormalPumpEvent
             XCTAssertEqual(bolus.amount, 2.05)
-            XCTAssertEqual(bolus.bolusType, "normal")
+            XCTAssertEqual(bolus.type, BolusNormalPumpEvent.BolusType.Normal)
             XCTAssertEqual(bolus.duration, 0)
             XCTAssertEqual(bolus.programmed, 2.05)
             XCTAssertEqual(bolus.unabsorbedInsulinTotal, 0.0)

--- a/NightscoutUploadKit/BolusNightscoutTreatment.swift
+++ b/NightscoutUploadKit/BolusNightscoutTreatment.swift
@@ -20,11 +20,11 @@ public class BolusNightscoutTreatment: NightscoutTreatment {
     let amount: Double
     let programmed: Double
     let unabsorbed: Double
-    let duration: Int
+    let duration: NSTimeInterval
     let carbs: Int
     let ratio: Double
     
-    init(timestamp: NSDate, enteredBy: String, bolusType: BolusType, amount: Double, programmed: Double, unabsorbed: Double, duration: Int, carbs: Int, ratio: Double) {
+    init(timestamp: NSDate, enteredBy: String, bolusType: BolusType, amount: Double, programmed: Double, unabsorbed: Double, duration: NSTimeInterval, carbs: Int, ratio: Double) {
         self.bolusType = bolusType
         self.amount = amount
         self.programmed = programmed
@@ -48,7 +48,7 @@ public class BolusNightscoutTreatment: NightscoutTreatment {
         rval["insulin"] = amount
         rval["programmed"] = programmed
         rval["unabsorbed"] = unabsorbed
-        rval["duration"] = duration
+        rval["duration"] = duration.minutes
         return rval
     }
 }

--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -50,12 +50,10 @@ public class NightscoutUploader: NSObject {
         
         // Find valid event times
         var validEventTimes = [NSDate]()
-        for event in events {
-            if event is TimestampedPumpEvent {
-                let timestamp = (event as! TimestampedPumpEvent).timestamp
-                if let date = TimeFormat.timestampAsLocalDate(timestamp) {
-                    validEventTimes.append(date)
-                }
+        for event in events where event is TimestampedPumpEvent {
+            let timestamp = (event as! TimestampedPumpEvent).timestamp
+            if let date = TimeFormat.timestampAsLocalDate(timestamp) {
+                validEventTimes.append(date)
             }
         }
         let newestEventTime = validEventTimes.last
@@ -66,8 +64,7 @@ public class NightscoutUploader: NSObject {
 
         for event in events {
             switch event {
-            case is BolusNormalPumpEvent:
-                let event = event as! BolusNormalPumpEvent
+            case let event as BolusNormalPumpEvent:
                 if let date = TimeFormat.timestampAsLocalDate(event.timestamp) {
                     let deliveryFinishDate = date.dateByAddingTimeInterval(event.duration)
                     if newestEventTime == nil || deliveryFinishDate.compare(newestEventTime!) == .OrderedDescending {

--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -63,16 +63,14 @@ public class NightscoutUploader: NSObject {
         
         // Find the oldest event that might still be updated.
         var oldestUpdatingEventDate: NSDate?
-        let cal = NSCalendar.currentCalendar()
+
         for event in events {
             switch event {
             case is BolusNormalPumpEvent:
                 let event = event as! BolusNormalPumpEvent
                 if let date = TimeFormat.timestampAsLocalDate(event.timestamp) {
-                    let duration = NSDateComponents()
-                    duration.minute = event.duration
-                    let deliveryFinishDate = cal.dateByAddingComponents(duration, toDate: date, options: NSCalendarOptions(rawValue:0))
-                    if newestEventTime == nil || deliveryFinishDate?.compare(newestEventTime!) == .OrderedDescending {
+                    let deliveryFinishDate = date.dateByAddingTimeInterval(event.duration)
+                    if newestEventTime == nil || deliveryFinishDate.compare(newestEventTime!) == .OrderedDescending {
                         // This event might still be updated.
                         oldestUpdatingEventDate = date
                         break

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		43CA93311CB97191000026B5 /* ReadTempBasalCarelinkMessageBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CA93301CB97191000026B5 /* ReadTempBasalCarelinkMessageBodyTests.swift */; };
 		43CA93331CB9726A000026B5 /* ChangeTimeCarelinMessageBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CA93321CB9726A000026B5 /* ChangeTimeCarelinMessageBodyTests.swift */; };
 		43CA93351CB9727F000026B5 /* ChangeTempBasalCarelinkMessageBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CA93341CB9727F000026B5 /* ChangeTempBasalCarelinkMessageBodyTests.swift */; };
+		43D657451D0CF1D500216E20 /* NSTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */; };
+		43D657461D0CF38F00216E20 /* NSTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434AB09D1CBA28F100422F4A /* NSTimeInterval.swift */; };
 		43EC9DCB1B786C6200DB0D18 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 43EC9DCA1B786C6200DB0D18 /* LaunchScreen.xib */; };
 		43FF221C1CB9B9DE00024F30 /* NSDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FF221B1CB9B9DE00024F30 /* NSDateComponents.swift */; };
 		C109DAFF1D0283ED0065F80A /* Crypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C12618451CDB019C0064A849 /* Crypto.framework */; };
@@ -1602,6 +1604,7 @@
 				C1842C241C8FA45100DB42AC /* BatteryPumpEvent.swift in Sources */,
 				C1842C1F1C8FA45100DB42AC /* ChangeBasalProfilePatternPumpEvent.swift in Sources */,
 				C1711A561C94F13400CB25BD /* ButtonPressCarelinkMessageBody.swift in Sources */,
+				43D657451D0CF1D500216E20 /* NSTimeInterval.swift in Sources */,
 				C1842C011C8FA45100DB42AC /* JournalEntryPumpLowBatteryPumpEvent.swift in Sources */,
 				C1842BBD1C8E7C6E00DB42AC /* PumpEvent.swift in Sources */,
 				C1842BCB1C8F9A7200DB42AC /* RewindPumpEvent.swift in Sources */,
@@ -1726,6 +1729,7 @@
 				C1B3832B1CD0668600CE7782 /* BGCheckNightscoutTreatment.swift in Sources */,
 				C1B383291CD0668600CE7782 /* NightscoutPumpEvents.swift in Sources */,
 				C1B3832D1CD0668600CE7782 /* BolusNightscoutTreatment.swift in Sources */,
+				43D657461D0CF38F00216E20 /* NSTimeInterval.swift in Sources */,
 				C1B3832C1CD0668600CE7782 /* MealBolusNightscoutTreatment.swift in Sources */,
 				C1B383281CD0668600CE7782 /* NightscoutUploader.swift in Sources */,
 				C1B3832A1CD0668600CE7782 /* NightscoutTreatment.swift in Sources */,

--- a/RileyLink.xcodeproj/xcshareddata/xcschemes/NightscoutUploadKit.xcscheme
+++ b/RileyLink.xcodeproj/xcshareddata/xcschemes/NightscoutUploadKit.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C1B383131CD0665D00CE7782"
+               BuildableName = "NightscoutUploadKitTests.xctest"
+               BlueprintName = "NightscoutUploadKitTests"
+               ReferencedContainer = "container:RileyLink.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C1B3830A1CD0665D00CE7782"
+            BuildableName = "NightscoutUploadKit.framework"
+            BlueprintName = "NightscoutUploadKit"
+            ReferencedContainer = "container:RileyLink.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -313,8 +313,7 @@ class PumpOpsSynchronous {
             let page = try HistoryPage(pageData: pageData, pumpModel: pumpModel)
             var eventIdxBeforeStartDate = -1
             for (reverseIndex, event) in page.events.reverse().enumerate() {
-                if event is TimestampedPumpEvent {
-                    let event = event as! TimestampedPumpEvent
+                if let event = event as? TimestampedPumpEvent {
                     if let date = TimeFormat.timestampAsLocalDate(event.timestamp) {
                         if date.compare(startDate) == .OrderedAscending  {
                             NSLog("Found event (%@) before startDate(%@)", date, startDate);


### PR DESCRIPTION
I'll probably submit a few of these as I get to them, which should keep reviewing manageable. 

The end goal is to use `PumpState.timeZone` + `ChangeTimePumpEvent` to assign a correct UTC date to each `PumpEvent`, which will maintain correctness during time zone changes by the phone, e.g. DST.
