### PR TITLE
Timezone handling for pump status uploads

### DIFF
--- a/MinimedKit/PumpEvents/AlarmClockReminderPumpEvent.swift
+++ b/MinimedKit/PumpEvents/AlarmClockReminderPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct AlarmClockReminderPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,7 +19,9 @@ public struct AlarmClockReminderPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
-        
+
+        rawData = availableData[0..<length]
+
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }
     

--- a/MinimedKit/PumpEvents/AlarmSensorPumpEvent.swift
+++ b/MinimedKit/PumpEvents/AlarmSensorPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct AlarmSensorPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct AlarmSensorPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/BGReceivedPumpEvent.swift
+++ b/MinimedKit/PumpEvents/BGReceivedPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct BGReceivedPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     public let amount: Int
     public let meter: String
@@ -20,6 +21,8 @@ public struct BGReceivedPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         func d(idx:Int) -> Int {
             return Int(availableData[idx] as UInt8)

--- a/MinimedKit/PumpEvents/BasalProfileStartPumpEvent.swift
+++ b/MinimedKit/PumpEvents/BasalProfileStartPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct BasalProfileStartPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     let rate: Double
     let profileIndex: Int
@@ -22,6 +23,8 @@ public struct BasalProfileStartPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         func d(idx:Int) -> Int {
             return Int(availableData[idx] as UInt8)

--- a/MinimedKit/PumpEvents/BatteryPumpEvent.swift
+++ b/MinimedKit/PumpEvents/BatteryPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct BatteryPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct BatteryPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/BolusNormalPumpEvent.swift
+++ b/MinimedKit/PumpEvents/BolusNormalPumpEvent.swift
@@ -16,6 +16,7 @@ public struct BolusNormalPumpEvent: TimestampedPumpEvent {
     }
 
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     public var unabsorbedInsulinRecord: UnabsorbedInsulinPumpEvent?
     public let amount: Double
@@ -43,6 +44,8 @@ public struct BolusNormalPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         if pumpModel.larger {
             timestamp = NSDateComponents(pumpEventData: availableData, offset: 8)

--- a/MinimedKit/PumpEvents/BolusWizardEstimatePumpEvent.swift
+++ b/MinimedKit/PumpEvents/BolusWizardEstimatePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct BolusWizardEstimatePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     public let carbohydrates: Int
     public let bloodGlucose: Int
@@ -37,22 +38,13 @@ public struct BolusWizardEstimatePumpEvent: TimestampedPumpEvent {
         } else {
             length = 20
         }
-        
-        if length >= availableData.length {
-            carbohydrates = 0
-            bloodGlucose = 0
-            foodEstimate = 0
-            correctionEstimate = 0
-            bolusEstimate = 0
-            unabsorbedInsulinTotal = 0
-            bgTargetLow = 0
-            bgTargetHigh = 0
-            insulinSensitivity = 0
-            carbRatio = 0
-            timestamp = NSDateComponents()
+
+        guard length <= availableData.length else {
             return nil
         }
-        
+
+        rawData = availableData[0..<length]
+
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
         
         if pumpModel.larger {

--- a/MinimedKit/PumpEvents/CalBGForPHPumpEvent.swift
+++ b/MinimedKit/PumpEvents/CalBGForPHPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct CalBGForPHPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     public let amount: Int
     
@@ -19,6 +20,8 @@ public struct CalBGForPHPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         func d(idx:Int) -> Int {
             return Int(availableData[idx] as UInt8)

--- a/MinimedKit/PumpEvents/ChangeAlarmClockEnablePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeAlarmClockEnablePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeAlarmClockEnablePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeAlarmClockEnablePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeAlarmClockTimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeAlarmClockTimePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeAlarmClockTimePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeAlarmClockTimePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeAlarmNotifyModePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeAlarmNotifyModePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeAlarmNotifyModePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeAlarmNotifyModePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeAudioBolusPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeAudioBolusPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeAudioBolusPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeAudioBolusPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeBGReminderEnablePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeBGReminderEnablePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeBGReminderEnablePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeBGReminderEnablePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeBGReminderOffsetPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeBGReminderOffsetPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeBGReminderOffsetPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeBGReminderOffsetPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeBasalProfilePatternPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeBasalProfilePatternPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeBasalProfilePatternPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeBasalProfilePatternPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeBasalProfilePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeBasalProfilePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeBasalProfilePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeBasalProfilePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeBolusReminderEnablePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeBolusReminderEnablePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeBolusReminderEnablePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeBolusReminderEnablePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeBolusReminderTimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeBolusReminderTimePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeBolusReminderTimePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeBolusReminderTimePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeBolusScrollStepSizePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeBolusScrollStepSizePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeBolusScrollStepSizePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeBolusScrollStepSizePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeBolusWizardSetupPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeBolusWizardSetupPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeBolusWizardSetupPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -22,6 +23,8 @@ public struct ChangeBolusWizardSetupPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeCaptureEventEnablePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeCaptureEventEnablePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeCaptureEventEnablePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeCaptureEventEnablePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeCarbUnitsPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeCarbUnitsPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeCarbUnitsPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeCarbUnitsPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeChildBlockEnablePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeChildBlockEnablePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeChildBlockEnablePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeChildBlockEnablePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeMaxBasalPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeMaxBasalPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeMaxBasalPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeMaxBasalPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeMaxBolusPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeMaxBolusPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeMaxBolusPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeMaxBolusPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeOtherDeviceIDPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeOtherDeviceIDPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeOtherDeviceIDPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeOtherDeviceIDPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeParadigmLinkIDPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeParadigmLinkIDPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeParadigmLinkIDPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeParadigmLinkIDPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeReservoirWarningTimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeReservoirWarningTimePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeReservoirWarningTimePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeReservoirWarningTimePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeSensorRateOfChangeAlertSetupPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeSensorRateOfChangeAlertSetupPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeSensorRateOfChangeAlertSetupPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeSensorRateOfChangeAlertSetupPumpEvent: TimestampedPumpEvent 
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeSensorSetup2PumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeSensorSetup2PumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeSensorSetup2PumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeSensorSetup2PumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeTempBasalTypePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeTempBasalTypePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeTempBasalTypePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let basalType: String
     public let timestamp: NSDateComponents
     
@@ -23,6 +24,8 @@ public struct ChangeTempBasalTypePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         basalType = d(1) == 1 ? "percent" : "absolute"
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)

--- a/MinimedKit/PumpEvents/ChangeTimeFormatPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeTimeFormatPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeTimeFormatPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeTimeFormatPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeTimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeTimePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeTimePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     public let oldTimestamp: NSDateComponents
 
@@ -23,6 +24,8 @@ public struct ChangeTimePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         oldTimestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 9)

--- a/MinimedKit/PumpEvents/ChangeVariableBolusPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeVariableBolusPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeVariableBolusPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeVariableBolusPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeWatchdogEnablePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeWatchdogEnablePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeWatchdogEnablePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeWatchdogEnablePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ChangeWatchdogMarriageProfilePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeWatchdogMarriageProfilePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ChangeWatchdogMarriageProfilePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ChangeWatchdogMarriageProfilePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/ClearAlarmPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ClearAlarmPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ClearAlarmPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ClearAlarmPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/DeleteAlarmClockTimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/DeleteAlarmClockTimePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct DeleteAlarmClockTimePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct DeleteAlarmClockTimePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/DeleteBolusReminderTimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/DeleteBolusReminderTimePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct DeleteBolusReminderTimePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct DeleteBolusReminderTimePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/DeleteOtherDeviceIDPumpEvent.swift
+++ b/MinimedKit/PumpEvents/DeleteOtherDeviceIDPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct DeleteOtherDeviceIDPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct DeleteOtherDeviceIDPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/EnableDisableRemotePumpEvent.swift
+++ b/MinimedKit/PumpEvents/EnableDisableRemotePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct EnableDisableRemotePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct EnableDisableRemotePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/JournalEntryExerciseMarkerPumpEvent.swift
+++ b/MinimedKit/PumpEvents/JournalEntryExerciseMarkerPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct JournalEntryExerciseMarkerPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct JournalEntryExerciseMarkerPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/JournalEntryPumpLowBatteryPumpEvent.swift
+++ b/MinimedKit/PumpEvents/JournalEntryPumpLowBatteryPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct JournalEntryPumpLowBatteryPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct JournalEntryPumpLowBatteryPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/JournalEntryPumpLowReservoirPumpEvent.swift
+++ b/MinimedKit/PumpEvents/JournalEntryPumpLowReservoirPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct JournalEntryPumpLowReservoirPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct JournalEntryPumpLowReservoirPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/Model522ResultTotalsPumpEvent.swift
+++ b/MinimedKit/PumpEvents/Model522ResultTotalsPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct Model522ResultTotalsPumpEvent: PumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct Model522ResultTotalsPumpEvent: PumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventBytes: availableData[1..<3])
     }

--- a/MinimedKit/PumpEvents/PrimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/PrimePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct PrimePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     let amount: Double
     let primeType: String
@@ -21,6 +22,8 @@ public struct PrimePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         func d(idx:Int) -> Int {
             return Int(availableData[idx] as UInt8)

--- a/MinimedKit/PumpEvents/PumpAlarmPumpEvent.swift
+++ b/MinimedKit/PumpEvents/PumpAlarmPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct PumpAlarmPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     let rawType: Int
     
@@ -19,6 +20,8 @@ public struct PumpAlarmPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         rawType = Int(availableData[1] as UInt8)
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 4)

--- a/MinimedKit/PumpEvents/PumpEvent.swift
+++ b/MinimedKit/PumpEvents/PumpEvent.swift
@@ -11,7 +11,11 @@ import Foundation
 public protocol PumpEvent : DictionaryRepresentable {
     
     init?(availableData: NSData, pumpModel: PumpModel)
-    
+
+    var rawData: NSData {
+        get
+    }
+
     var length: Int {
         get
     }

--- a/MinimedKit/PumpEvents/ResultDailyTotalPumpEvent.swift
+++ b/MinimedKit/PumpEvents/ResultDailyTotalPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ResultDailyTotalPumpEvent: PumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     let validDateStr: String
     
@@ -24,6 +25,8 @@ public struct ResultDailyTotalPumpEvent: PumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         let dateComponents = NSDateComponents(pumpEventBytes: availableData[5..<7])
         validDateStr = String(format: "%04d-%02d-%02d", dateComponents.year, dateComponents.month, dateComponents.day)

--- a/MinimedKit/PumpEvents/ResumePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ResumePumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct ResumePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct ResumePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/RewindPumpEvent.swift
+++ b/MinimedKit/PumpEvents/RewindPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct RewindPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct RewindPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/Sara6EPumpEvent.swift
+++ b/MinimedKit/PumpEvents/Sara6EPumpEvent.swift
@@ -11,6 +11,7 @@ import Foundation
 public struct Sara6EPumpEvent: PumpEvent {
     
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     let validDateStr: String
     
@@ -19,11 +20,11 @@ public struct Sara6EPumpEvent: PumpEvent {
         
         // Sometimes we encounter this at the end of a page, and it can be less characters???
         // need at least 16, I think.
-        if 16 > availableData.length {
-            timestamp = NSDateComponents()
-            validDateStr = "Invalid"
+        guard 16 <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<min(length, availableData.length)]
 
         let dateComponents = NSDateComponents(pumpEventBytes: availableData[1..<3])
         validDateStr = String(format: "%04d-%02d-%02d", dateComponents.year, dateComponents.month, dateComponents.day)

--- a/MinimedKit/PumpEvents/SelectBasalProfilePumpEvent.swift
+++ b/MinimedKit/PumpEvents/SelectBasalProfilePumpEvent.swift
@@ -11,6 +11,7 @@ import Foundation
 
 public struct SelectBasalProfilePumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
 
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -19,6 +20,8 @@ public struct SelectBasalProfilePumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
 
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/SuspendPumpEvent.swift
+++ b/MinimedKit/PumpEvents/SuspendPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct SuspendPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
@@ -18,6 +19,8 @@ public struct SuspendPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
     }

--- a/MinimedKit/PumpEvents/TempBasalDurationPumpEvent.swift
+++ b/MinimedKit/PumpEvents/TempBasalDurationPumpEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct TempBasalDurationPumpEvent: TimestampedPumpEvent {
     public let length: Int
+    public let rawData: NSData
     public let duration: Int
     public let timestamp: NSDateComponents
     
@@ -23,6 +24,8 @@ public struct TempBasalDurationPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         duration = d(1) * 30
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)

--- a/MinimedKit/PumpEvents/TempBasalPumpEvent.swift
+++ b/MinimedKit/PumpEvents/TempBasalPumpEvent.swift
@@ -17,6 +17,7 @@ public struct TempBasalPumpEvent: TimestampedPumpEvent {
     
     
     public let length: Int
+    public let rawData: NSData
     public let rateType: RateType
     public let rate: Double
     public let timestamp: NSDateComponents
@@ -31,6 +32,8 @@ public struct TempBasalPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         rateType = (d(7) >> 3) == 0 ? .Absolute : .Percent
         if rateType == .Absolute {

--- a/MinimedKit/PumpEvents/UnabsorbedInsulinPumpEvent.swift
+++ b/MinimedKit/PumpEvents/UnabsorbedInsulinPumpEvent.swift
@@ -28,6 +28,7 @@ public struct UnabsorbedInsulinPumpEvent: PumpEvent {
     }
     
     public let length: Int
+    public let rawData: NSData
     
     public let records: [Record]
     
@@ -38,6 +39,8 @@ public struct UnabsorbedInsulinPumpEvent: PumpEvent {
         guard length <= availableData.length else {
             return nil
         }
+
+        rawData = availableData[0..<length]
         
         func d(idx:Int) -> Int {
             return Int(availableData[idx] as UInt8)

--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -142,12 +142,17 @@ public class NightscoutUploader: NSObject {
             nsStatus["uploader"] = ["battery":uploaderDevice.batteryLevel * 100]
         }
         
-        let pumpDate = TimeFormat.timestampStr(status.pumpDateComponents)
+        guard let pumpDate = status.pumpDateComponents.date else {
+            NSLog("Pump date not set (or timezone missing) in pump status message!")
+            return
+        }
+        
+        let pumpDateStr = TimeFormat.timestampStrFromDate(pumpDate)
         
         nsStatus["pump"] = [
-            "clock": pumpDate,
+            "clock": pumpDateStr,
             "iob": [
-                "timestamp": pumpDate,
+                "timestamp": pumpDateStr,
                 "bolusiob": status.iob,
             ],
             "reservoir": status.reservoirRemainingUnits,
@@ -176,9 +181,9 @@ public class NightscoutUploader: NSObject {
                 "type": "sgv"
             ]
             if let sensorDateComponents = status.glucoseDateComponents,
-                let sensorDate = TimeFormat.timestampAsLocalDate(sensorDateComponents) {
+                let sensorDate = sensorDateComponents.date {
                 entry["date"] = sensorDate.timeIntervalSince1970 * 1000
-                entry["dateString"] = TimeFormat.timestampStr(sensorDateComponents)
+                entry["dateString"] = TimeFormat.timestampStrFromDate(sensorDate)
             }
             switch status.previousGlucose {
             case .Active(glucose: let previousGlucose):

--- a/NightscoutUploadKit/TimeFormat.swift
+++ b/NightscoutUploadKit/TimeFormat.swift
@@ -10,20 +10,6 @@ import Foundation
 
 class TimeFormat: NSObject {
     private static var formatterISO8601 = NSDateFormatter.ISO8601DateFormatter()
-
-    static func timestampAsLocalDate(comps: NSDateComponents) -> NSDate? {
-        let cal = comps.calendar ?? NSCalendar.currentCalendar()
-        cal.timeZone = comps.timeZone ?? NSTimeZone.localTimeZone()
-        return cal.dateFromComponents(comps)
-    }
-    
-    static func timestampStr(comps: NSDateComponents) -> String {
-        if let date = timestampAsLocalDate(comps) {
-            return formatterISO8601.stringFromDate(date)
-        } else {
-            return "Invalid"
-        }
-    }
     
     static func timestampStrFromDate(date: NSDate) -> String {
         return formatterISO8601.stringFromDate(date)

--- a/RileyLink/DeviceDataManager.swift
+++ b/RileyLink/DeviceDataManager.swift
@@ -174,6 +174,7 @@ class DeviceDataManager {
     
     private func updatePumpStatus(status: MySentryPumpStatusMessageBody, fromDevice device: RileyLinkDevice) {
         status.pumpDateComponents.timeZone = pumpTimeZone
+        status.glucoseDateComponents?.timeZone = pumpTimeZone
         
         if status != latestPumpStatus {
             latestPumpStatus = status


### PR DESCRIPTION
Use configured pump timezone to interpret dates from mysentry packets when uploading to Nightscout
