### PR TITLE
Timezone handling for pump status uploads

### DIFF
--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -142,12 +142,17 @@ public class NightscoutUploader: NSObject {
             nsStatus["uploader"] = ["battery":uploaderDevice.batteryLevel * 100]
         }
         
-        let pumpDate = TimeFormat.timestampStr(status.pumpDateComponents)
+        guard let pumpDate = status.pumpDateComponents.date else {
+            NSLog("Pump date not set (or timezone missing) in pump status message!")
+            return
+        }
+        
+        let pumpDateStr = TimeFormat.timestampStrFromDate(pumpDate)
         
         nsStatus["pump"] = [
-            "clock": pumpDate,
+            "clock": pumpDateStr,
             "iob": [
-                "timestamp": pumpDate,
+                "timestamp": pumpDateStr,
                 "bolusiob": status.iob,
             ],
             "reservoir": status.reservoirRemainingUnits,
@@ -176,9 +181,9 @@ public class NightscoutUploader: NSObject {
                 "type": "sgv"
             ]
             if let sensorDateComponents = status.glucoseDateComponents,
-                let sensorDate = TimeFormat.timestampAsLocalDate(sensorDateComponents) {
+                let sensorDate = sensorDateComponents.date {
                 entry["date"] = sensorDate.timeIntervalSince1970 * 1000
-                entry["dateString"] = TimeFormat.timestampStr(sensorDateComponents)
+                entry["dateString"] = TimeFormat.timestampStrFromDate(sensorDate)
             }
             switch status.previousGlucose {
             case .Active(glucose: let previousGlucose):

--- a/NightscoutUploadKit/TimeFormat.swift
+++ b/NightscoutUploadKit/TimeFormat.swift
@@ -10,20 +10,6 @@ import Foundation
 
 class TimeFormat: NSObject {
     private static var formatterISO8601 = NSDateFormatter.ISO8601DateFormatter()
-
-    static func timestampAsLocalDate(comps: NSDateComponents) -> NSDate? {
-        let cal = comps.calendar ?? NSCalendar.currentCalendar()
-        cal.timeZone = comps.timeZone ?? NSTimeZone.localTimeZone()
-        return cal.dateFromComponents(comps)
-    }
-    
-    static func timestampStr(comps: NSDateComponents) -> String {
-        if let date = timestampAsLocalDate(comps) {
-            return formatterISO8601.stringFromDate(date)
-        } else {
-            return "Invalid"
-        }
-    }
     
     static func timestampStrFromDate(date: NSDate) -> String {
         return formatterISO8601.stringFromDate(date)

--- a/RileyLink/DeviceDataManager.swift
+++ b/RileyLink/DeviceDataManager.swift
@@ -174,6 +174,7 @@ class DeviceDataManager {
     
     private func updatePumpStatus(status: MySentryPumpStatusMessageBody, fromDevice device: RileyLinkDevice) {
         status.pumpDateComponents.timeZone = pumpTimeZone
+        status.glucoseDateComponents?.timeZone = pumpTimeZone
         
         if status != latestPumpStatus {
             latestPumpStatus = status


### PR DESCRIPTION
Use configured pump timezone to interpret dates from mysentry packets when uploading to Nightscout
