### PR TITLE
Fix precision of reservoir value

### DIFF
--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -169,7 +169,7 @@ public class NightscoutUploader: NSObject {
                 "timestamp": pumpDateStr,
                 "bolusiob": status.iob,
             ],
-            "reservoir": status.reservoirRemainingUnits,
+            "reservoir": Double(round(status.reservoirRemainingUnits*1000)/1000,
             "battery": [
                 "percent": status.batteryRemainingPercent
             ]


### PR DESCRIPTION
Nightscout was showing many more digits of precision than desired, due to float representation rounding.  Maybe this is nightscout's responsibility, but it's easier for me to tackle it here.
