### PR TITLE
Fix parsing of date fields in mysentry pump status records

### DIFF
--- a/MinimedKit/Extensions/NSDateComponents.swift
+++ b/MinimedKit/Extensions/NSDateComponents.swift
@@ -13,12 +13,12 @@ extension NSDateComponents {
     convenience init(mySentryBytes: [UInt8]) {
         self.init()
 
-        hour   = Int(mySentryBytes[0])
-        minute = Int(mySentryBytes[1])
-        second = Int(mySentryBytes[2])
+        hour   = Int(mySentryBytes[0] & 0b00011111)
+        minute = Int(mySentryBytes[1] & 0b00111111)
+        second = Int(mySentryBytes[2] & 0b00111111)
         year   = Int(mySentryBytes[3]) + 2000
-        month  = Int(mySentryBytes[4])
-        day    = Int(mySentryBytes[5])
+        month  = Int(mySentryBytes[4] & 0b00001111)
+        day    = Int(mySentryBytes[5] & 0b00011111)
 
         calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)
     }

--- a/MinimedKit/Messages/MySentryPumpStatusMessageBody.swift
+++ b/MinimedKit/Messages/MySentryPumpStatusMessageBody.swift
@@ -76,6 +76,11 @@ public enum SensorReading {
     }
 }
 
+public enum ClockType {
+    case TwentyFourHour
+    case TwelveHour
+}
+
 
 /**
  Describes a status message sent periodically from the pump to any paired MySentry devices
@@ -113,6 +118,7 @@ public struct MySentryPumpStatusMessageBody: MessageBody, DictionaryRepresentabl
     public let previousGlucose: SensorReading
     public let sensorAgeHours: Int
     public let sensorRemainingHours: Int
+    public let clockType: ClockType
     
     public let nextSensorCalibrationDateComponents: NSDateComponents?
     
@@ -128,6 +134,9 @@ public struct MySentryPumpStatusMessageBody: MessageBody, DictionaryRepresentabl
         sequence = rxData[0]
 
         let pumpDateComponents = NSDateComponents(mySentryBytes: rxData[2...7])
+        
+        let hourByte: UInt8 = rxData[2]
+        clockType = ((hourByte & 0b10000000) > 0) ? .TwentyFourHour : .TwelveHour
         
         guard let calendar = pumpDateComponents.calendar where pumpDateComponents.isValidDateInCalendar(calendar) else {
             return nil

--- a/MinimedKitTests/MySentryPumpStatusMessageBodyTests.swift
+++ b/MinimedKitTests/MySentryPumpStatusMessageBodyTests.swift
@@ -215,5 +215,35 @@ class MySentryPumpStatusMessageBodyTests: XCTestCase {
         
         XCTAssertEqual(GlucoseTrend.Flat, body.glucoseTrend)
     }
-    
+ 
+    func testClockType24Hour() {
+        let message = PumpMessage(rxData: NSData(hexadecimalString: "a295099004b6d5971f1510070a013f3a0002dd020105bd08880825000502000755171e0010070a00008d")!)!
+        
+        let body = message.messageBody as! MySentryPumpStatusMessageBody
+        
+        let dateComponents = NSDateComponents()
+        dateComponents.calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)
+        dateComponents.year = 2016
+        dateComponents.month = 7
+        dateComponents.day = 10
+        dateComponents.hour = 23
+        dateComponents.minute = 31
+        dateComponents.second = 21
+        
+        XCTAssertEqual(dateComponents, body.pumpDateComponents)
+        
+        let glucoseDateComponents = NSDateComponents()
+        glucoseDateComponents.calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)
+        glucoseDateComponents.year = 2016
+        glucoseDateComponents.month = 7
+        glucoseDateComponents.day = 10
+        glucoseDateComponents.hour = 23
+        glucoseDateComponents.minute = 30
+        glucoseDateComponents.second = 0
+
+        XCTAssertEqual(glucoseDateComponents, body.glucoseDateComponents)
+        
+        XCTAssertEqual(ClockType.TwentyFourHour, body.clockType)
+    }
+   
 }


### PR DESCRIPTION
And, thanks to @beached for figuring this out: parse new clock type field to denote desired display of 24 hour or 12 hour clock.
