### PR TITLE
JournalEntryOther

### DIFF
--- a/MinimedKit/PumpEventType.swift
+++ b/MinimedKit/PumpEventType.swift
@@ -39,6 +39,7 @@ public enum PumpEventType: UInt8 {
     case BGReceived = 0x3f
     case JournalEntryMealMarker = 0x40
     case JournalEntryExerciseMarker = 0x41
+    case JournalEntryOtherMarker = 0x43
     case ChangeSensorSetup2 = 0x50
     case ChangeSensorRateOfChangeAlertSetup = 0x56
     case ChangeBolusScrollStepSize = 0x57
@@ -184,7 +185,7 @@ public enum PumpEventType: UInt8 {
         case .SelectBasalProfile:
             return SelectBasalProfilePumpEvent.self
         default:
-            return UnknownPumpEvent.self
+            return PlaceholderPumpEvent.self
         }
     }
 }

--- a/MinimedKit/PumpEvents/PlaceholderPumpEvent.swift
+++ b/MinimedKit/PumpEvents/PlaceholderPumpEvent.swift
@@ -13,7 +13,6 @@ public struct PlaceholderPumpEvent: TimestampedPumpEvent {
     public let length: Int
     public let rawData: NSData
     public let timestamp: NSDateComponents
-    public let name: String
 
     public init?(availableData: NSData, pumpModel: PumpModel) {
         length = 7
@@ -23,19 +22,19 @@ public struct PlaceholderPumpEvent: TimestampedPumpEvent {
         }
         
         rawData = availableData[0..<length]
-
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
-        
+    }
+
+    public var dictionaryRepresentation: [String: AnyObject] {
+        let name: String
         if let type = PumpEventType(rawValue: rawData[0] as UInt8) {
             name = String(type).componentsSeparatedByString(".").last!
         } else {
             name = "UnknownPumpEvent(\(rawData[0] as UInt8))"
         }
-    }
-
-    public var dictionaryRepresentation: [String: AnyObject] {
+        
         return [
-            "_type": "\(name)",
+            "_type": name,
         ]
     }
 }

--- a/MinimedKit/PumpEvents/PlaceholderPumpEvent.swift
+++ b/MinimedKit/PumpEvents/PlaceholderPumpEvent.swift
@@ -1,5 +1,5 @@
 //
-//  UnknownPumpEvent.swift
+//  PlaceholderPumpEvent.swift
 //  RileyLink
 //
 //  Created by Nate Racklyeft on 6/20/16.
@@ -9,10 +9,11 @@
 import Foundation
 
 
-public struct UnknownPumpEvent: TimestampedPumpEvent {
+public struct PlaceholderPumpEvent: TimestampedPumpEvent {
     public let length: Int
     public let rawData: NSData
     public let timestamp: NSDateComponents
+    public let name: String
 
     public init?(availableData: NSData, pumpModel: PumpModel) {
         length = 7
@@ -20,15 +21,21 @@ public struct UnknownPumpEvent: TimestampedPumpEvent {
         guard length <= availableData.length else {
             return nil
         }
-
+        
         rawData = availableData[0..<length]
 
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
+        
+        if let type = PumpEventType(rawValue: rawData[0] as UInt8) {
+            name = String(type).componentsSeparatedByString(".").last!
+        } else {
+            name = "UnknownPumpEvent(\(rawData[0] as UInt8))"
+        }
     }
 
     public var dictionaryRepresentation: [String: AnyObject] {
         return [
-            "_type": "UnknownPumpEvent(\(rawData[0] as UInt8))",
+            "_type": "\(name)",
         ]
     }
 }

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		43722FC41CB9F7640038B7F2 /* RileyLinkKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 43722FAE1CB9F7630038B7F2 /* RileyLinkKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		43722FCB1CB9F7DB0038B7F2 /* MinimedKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C10D9BC11C8269D500378342 /* MinimedKit.framework */; };
 		43722FCC1CB9F7DB0038B7F2 /* RileyLinkBLEKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 430D64CB1CB855AB00FCA750 /* RileyLinkBLEKit.framework */; };
-		438D39221D19011700D40CA4 /* UnknownPumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438D39211D19011700D40CA4 /* UnknownPumpEvent.swift */; };
+		438D39221D19011700D40CA4 /* PlaceholderPumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438D39211D19011700D40CA4 /* PlaceholderPumpEvent.swift */; };
 		439731271CF21C3C00F474E5 /* RileyLinkDeviceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439731261CF21C3C00F474E5 /* RileyLinkDeviceTableViewCell.swift */; };
 		43A068EC1CF6BA6900F9EFE4 /* ReadRemainingInsulinMessageBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A068EB1CF6BA6900F9EFE4 /* ReadRemainingInsulinMessageBodyTests.swift */; };
 		43B0ADC01D0FC03200AAD278 /* NSDateComponentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B0ADBF1D0FC03200AAD278 /* NSDateComponentsTests.swift */; };
@@ -389,7 +389,7 @@
 		43722FB71CB9F7640038B7F2 /* RileyLinkKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RileyLinkKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		43722FBE1CB9F7640038B7F2 /* RileyLinkKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RileyLinkKitTests.swift; sourceTree = "<group>"; };
 		43722FC01CB9F7640038B7F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		438D39211D19011700D40CA4 /* UnknownPumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownPumpEvent.swift; sourceTree = "<group>"; };
+		438D39211D19011700D40CA4 /* PlaceholderPumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceholderPumpEvent.swift; sourceTree = "<group>"; };
 		439731261CF21C3C00F474E5 /* RileyLinkDeviceTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RileyLinkDeviceTableViewCell.swift; sourceTree = "<group>"; };
 		43A068EB1CF6BA6900F9EFE4 /* ReadRemainingInsulinMessageBodyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadRemainingInsulinMessageBodyTests.swift; sourceTree = "<group>"; };
 		43B0ADBF1D0FC03200AAD278 /* NSDateComponentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDateComponentsTests.swift; sourceTree = "<group>"; };
@@ -1023,7 +1023,7 @@
 				C1842BE31C8FA45100DB42AC /* TempBasalPumpEvent.swift */,
 				C12198AC1C8F332500BC374C /* TimestampedPumpEvent.swift */,
 				C1842BC01C8E8B2500DB42AC /* UnabsorbedInsulinPumpEvent.swift */,
-				438D39211D19011700D40CA4 /* UnknownPumpEvent.swift */,
+				438D39211D19011700D40CA4 /* PlaceholderPumpEvent.swift */,
 			);
 			path = PumpEvents;
 			sourceTree = "<group>";
@@ -1660,7 +1660,7 @@
 				C1842C1E1C8FA45100DB42AC /* ChangeBasalProfilePumpEvent.swift in Sources */,
 				C14D2B051C9F5D5800C98E4C /* TempBasalDurationPumpEvent.swift in Sources */,
 				C1842C151C8FA45100DB42AC /* ChangeChildBlockEnablePumpEvent.swift in Sources */,
-				438D39221D19011700D40CA4 /* UnknownPumpEvent.swift in Sources */,
+				438D39221D19011700D40CA4 /* PlaceholderPumpEvent.swift in Sources */,
 				C1EAD6B41C826B6D006DBA60 /* MessageBody.swift in Sources */,
 				C1842C001C8FA45100DB42AC /* JournalEntryPumpLowReservoirPumpEvent.swift in Sources */,
 				C1842BCF1C8F9E5100DB42AC /* PumpAlarmPumpEvent.swift in Sources */,


### PR DESCRIPTION
Allow use of placeholder enum types for 7 byte pump events, while still keeping a useful event type name in the dictionary rep.
