### PR TITLE
Misinterpretation of event times before pump reset

### DIFF
--- a/MinimedKit/PumpEvents/ChangeTimePumpEvent.swift
+++ b/MinimedKit/PumpEvents/ChangeTimePumpEvent.swift
@@ -30,7 +30,7 @@ public struct ChangeTimePumpEvent: TimestampedPumpEvent {
         oldTimestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 9)
     }
-    
+
     public var dictionaryRepresentation: [String: AnyObject] {
         return [
             "_type": "ChangeTime",

--- a/MinimedKit/PumpEvents/PumpAlarmPumpEvent.swift
+++ b/MinimedKit/PumpEvents/PumpAlarmPumpEvent.swift
@@ -8,11 +8,22 @@
 
 import Foundation
 
+public enum PumpAlarmType: Int {
+    case BatteryOutLimitExceeded = 3
+    case NoDelivery              = 4
+    case BatteryDepleted         = 5
+    case DeviceReset             = 16
+    case ReprogramError          = 61
+    case EmptyReservoir          = 62
+    case UnknownType             = -1
+}
+
 public struct PumpAlarmPumpEvent: TimestampedPumpEvent {
     public let length: Int
     public let rawData: NSData
     public let timestamp: NSDateComponents
-    let rawType: Int
+    public let alarmType: PumpAlarmType
+    public let rawType: Int
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
         length = 9
@@ -24,13 +35,29 @@ public struct PumpAlarmPumpEvent: TimestampedPumpEvent {
         rawData = availableData[0..<length]
         
         rawType = Int(availableData[1] as UInt8)
+        
+        if let alarmType = PumpAlarmType(rawValue: rawType) {
+            self.alarmType = alarmType
+        } else {
+            self.alarmType = .UnknownType
+        }
+        
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 4)
     }
     
     public var dictionaryRepresentation: [String: AnyObject] {
+        let typeDescription: String
+        
+        if self.alarmType == .UnknownType {
+            typeDescription = "Device Alarm(\(rawType))"
+        } else {
+            typeDescription = "\(self.alarmType)"
+        }
+        
         return [
             "_type": "AlarmPump",
             "rawType": rawType,
+            "alarm": typeDescription,
         ]
     }
 }

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -366,6 +366,16 @@ class PumpOpsSynchronous {
                             events.insert(TimestampedHistoryEvent(pumpEvent: event, date: date), atIndex: 0)
                         }
                     }
+                    
+                    if let alarm = event as? PumpAlarmPumpEvent {
+                        switch alarm.alarmType {
+                        case .BatteryDepleted, .BatteryOutLimitExceeded, .DeviceReset:
+                            print("Found clock loss in pump history.  Ending history fetch.")
+                            break pages
+                        default:
+                            break
+                        }
+                    }
                 }
 
                 if let event = event as? ChangeTimePumpEvent {


### PR DESCRIPTION
If the pump loses its sense of time, through a battery out too long event, or from a battery drained event, we aren't able to reliably figure out the actual time of events before the reset.

This change makes history fetching stop when it gets to this kind of event.  Otherwise, it typically interprets all the events as in the far future, and keeps fetching more pages until it (usually) errors out. 

The page where this was first observed (was page 2; fetching continued until page 11 and errored out):

```
5c0800b8c11ce0c101013c013c00000059eb567a1033004bf5165a100016014bf5165a10330079cc175a1000160179cc175a10330079e0175a1000160179e0175a10330b70ef175a1000160170ef175a10061503680040600107060a2084004060010706110411114040a1070c150a4600010706050309004040a1071a0005410001070c0505410001071a0119410001076400304100010764001e4200010717003542000107180040c0001b10070000000001870000006e01870500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000021004fc0001b10030000000056c1201b107b0079c1001b1000440033006cc7005b100016016cc7005b10330068dc005b1000160168dc005b10338568e1005b1000160168e1005b1033c56aeb005b100016016aeb005b1033b168f0005b1000160168f0005b1033b968f5005b1000160168f5005b1033be68fa005b1000160168fa005b1033bc69c3015b1000160169c3015b1033c169c8015b1000160169c8015b1033b868cd015b1000160168cd015b1033ae69d2015b1000160169d2015b1033ad69d7015b1000160169d7015b1033c368dc015b1000160168dc015b1033c868e1015b1000160168e1015b1033c169e6015b1000160169e6015b1033b668eb015b1000160168eb015b1033be68f0015b1000160168f0015b1033a468f5015b1000160168f5015b1033ab68fa015b1000160168fa015b1033a869c3025b1000160169c3025b10338968c8025b1000160168c8025b10336c68cd025b1000160168cd025b10336469d2025b1000160169d2025b10336d68d7025b1000160168d7025b10337a68dc025b1000160168dc025b10338968e1025b1000160168e1025b10339968e6025b1000160168e6025b10339268eb025b1000160168eb025b10338168f0025b1000160168f0025b10338369f5025b1000160169f5025b10337768fa025b1000160168fa025b10337668c3035b1000160168c3035b10338068c8035b1000160168c8035b10336768cd035b1000160168cd035b10330069d2035b1000160069d2035b107b0069d2031b10004400336968d7035b1000160168d7035b10338668dc035b1000160168dc035b10337b6ae1035b100016016ae1035b10338668e6035b1000160168e6035b10339668eb035b1000160168eb035b1033c069f0035b1000160169f0035b1033b769f5035b1000160169f5035b10339c69fa035b1000160169fa035b10330068c3045b1000160068c3045b107b0068c3041b10004400338368d2045b1000160168d2045b1033ac68d7045b1000160168d7045b10338769dc045b1000160169dc045b10335f68e1045b1000160168e1045b10330069e6045b1000160069e6045b100000000000bf1d
```
