### PR TITLE
update RileyLink app version to reflect updated since master 7.1

### DIFF
--- a/RileyLink/RileyLink-Info.plist
+++ b/RileyLink/RileyLink-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.1</string>
+	<string>0.7.2d</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
 (as …7.2d)

propose updating dev branch info string to reflect it's more recent than production 7.1 and it's dev branch.
