### PR TITLE
Handle timestamp offset for bolus wizard usage.

### DIFF
--- a/NightscoutUploadKit/NightscoutPumpEvents.swift
+++ b/NightscoutUploadKit/NightscoutPumpEvents.swift
@@ -14,6 +14,7 @@ class NightscoutPumpEvents: NSObject {
     class func translate(events: [TimestampedHistoryEvent], eventSource: String) -> [NightscoutTreatment] {
         var results = [NightscoutTreatment]()
         var lastBolusWizard: BolusWizardEstimatePumpEvent?
+        var lastBolusWizardDate: NSDate?
         var lastTempBasal: TempBasalPumpEvent?
         for event in events {
             switch event.pumpEvent {
@@ -29,7 +30,7 @@ class NightscoutPumpEvents: NSObject {
                 var carbs = 0
                 var ratio = 0.0
                 
-                if let wizard = lastBolusWizard where wizard.timestamp == bolusNormal.timestamp {
+                if let wizard = lastBolusWizard, bwDate = lastBolusWizardDate where event.date.timeIntervalSinceDate(bwDate) <= 2 {
                     carbs = wizard.carbohydrates
                     ratio = wizard.carbRatio
                 }
@@ -47,6 +48,7 @@ class NightscoutPumpEvents: NSObject {
                 results.append(entry)
             case let bolusWizard as BolusWizardEstimatePumpEvent:
                 lastBolusWizard = bolusWizard
+                lastBolusWizardDate = event.date
             case let tempBasal as TempBasalPumpEvent:
                 lastTempBasal = tempBasal
             case let tempBasalDuration as TempBasalDurationPumpEvent:

--- a/RileyLinkTests/NightscoutPumpEventsTests.swift
+++ b/RileyLinkTests/NightscoutPumpEventsTests.swift
@@ -62,5 +62,37 @@ class NightscoutPumpEventsTests: XCTestCase {
         XCTAssertEqual(bolus.programmed, 3.2)
         XCTAssertEqual(bolus.unabsorbed, 0.9)
     }
-    
+
+    func testBolusWizardAndBolusOffByOneSecond() {
+        let bwEvent = BolusWizardEstimatePumpEvent(
+            availableData: NSData(hexadecimalString: "5b6489340b10102850006e3c64000090000058009064")!,
+            pumpModel: PumpModel.Model523
+            )!
+
+        let bolus = BolusNormalPumpEvent(
+            availableData: NSData(hexadecimalString: "01009000900058008a344b1010")!,
+            pumpModel: PumpModel.Model523
+            )!
+
+        let events: [TimestampedPumpEvent] = [bwEvent, bolus]
+        let timezone = NSTimeZone(forSecondsFromGMT: -5 * 60 * 60)
+
+        let timestampedEvents = events.map({ (e: TimestampedPumpEvent) -> TimestampedHistoryEvent in
+            let timestamp = e.timestamp
+            timestamp.timeZone = timezone
+            return TimestampedHistoryEvent(pumpEvent: e, date: timestamp.date!)
+        })
+
+
+        let treatments = NightscoutPumpEvents.translate(timestampedEvents, eventSource: "testing")
+        XCTAssertEqual(1, treatments.count)
+        let treatment = treatments[0] as! BolusNightscoutTreatment
+        XCTAssertEqual(treatment.amount, 3.6)
+        XCTAssertEqual(treatment.bolusType, BolusNightscoutTreatment.BolusType.Normal)
+        XCTAssertEqual(treatment.duration, 0)
+        XCTAssertEqual(treatment.programmed, 3.6)
+        XCTAssertEqual(treatment.unabsorbed, 2.2)
+        XCTAssertEqual(treatment.carbs, 40)
+        XCTAssertEqual(treatment.ratio, 11.0)
+    }
 }


### PR DESCRIPTION
As reported by @elnjensen, sometimes bolus wizard usages are being reported as plain boluses.  From the history dumps we saw that this happens when the bolus and bolus wizard events are offset by a second.

This patch handles that case by allowing up to a 2 second difference between the bolus wizard and bolus event.
