### PR TITLE
History time fix

### DIFF
--- a/MinimedKit/PumpEventType.swift
+++ b/MinimedKit/PumpEventType.swift
@@ -22,9 +22,11 @@ public enum PumpEventType: UInt8 {
     case ChangeTime = 0x17
     case JournalEntryPumpLowBattery = 0x19
     case Battery = 0x1a
+    case SetAutoOff = 0x1b
     case Suspend = 0x1e
     case Resume = 0x1f
     case Rewind = 0x21
+    case ClearSettings = 0x22
     case ChangeChildBlockEnable = 0x23
     case ChangeMaxBolus = 0x24
     case EnableDisableRemote = 0x26
@@ -42,10 +44,15 @@ public enum PumpEventType: UInt8 {
     case JournalEntryExerciseMarker = 0x41
     case JournalEntryInsulinMarker = 0x42
     case JournalEntryOtherMarker = 0x43
+    case ChangeBolusWizardSetup = 0x4f
     case ChangeSensorSetup2 = 0x50
+    case RestoreMystery51 = 0x51
+    case RestoreMystery52 = 0x52
+    case RestoreMystery54 = 0x54
+    case RestoreMystery55 = 0x55
     case ChangeSensorRateOfChangeAlertSetup = 0x56
     case ChangeBolusScrollStepSize = 0x57
-    case ChangeBolusWizardSetup = 0x5a
+    case BolusWizardSetup = 0x5a
     case BolusWizardBolusEstimate = 0x5b
     case UnabsorbedInsulin = 0x5c
     case ChangeVariableBolus = 0x5e
@@ -59,6 +66,7 @@ public enum PumpEventType: UInt8 {
     case ChangeBolusReminderEnable = 0x66
     case ChangeBolusReminderTime = 0x67
     case DeleteBolusReminderTime = 0x68
+    case RestoreMystery69 = 0x69
     case DeleteAlarmClockTime = 0x6a
     case Model522ResultTotals = 0x6d
     case Sara6E = 0x6e
@@ -84,6 +92,8 @@ public enum PumpEventType: UInt8 {
             return ChangeBasalProfilePatternPumpEvent.self
         case .ChangeBasalProfile:
             return ChangeBasalProfilePumpEvent.self
+        case .ChangeBolusWizardSetup:
+            return ChangeBolusWizardSetupPumpEvent.self
         case .CalBGForPH:
             return CalBGForPHPumpEvent.self
         case .AlarmSensor:
@@ -140,8 +150,8 @@ public enum PumpEventType: UInt8 {
             return ChangeSensorRateOfChangeAlertSetupPumpEvent.self
         case .ChangeBolusScrollStepSize:
             return ChangeBolusScrollStepSizePumpEvent.self
-        case .ChangeBolusWizardSetup:
-            return ChangeBolusWizardSetupPumpEvent.self
+        case .BolusWizardSetup:
+            return BolusWizardSetupPumpEvent.self
         case .BolusWizardBolusEstimate:
             return BolusWizardEstimatePumpEvent.self
         case .UnabsorbedInsulin:
@@ -190,6 +200,10 @@ public enum PumpEventType: UInt8 {
             return ChangeCaptureEventEnablePumpEvent.self
         case .SelectBasalProfile:
             return SelectBasalProfilePumpEvent.self
+        case .RestoreMystery54:
+            return RestoreMystery54PumpEvent.self
+        case .RestoreMystery55:
+            return RestoreMystery55PumpEvent.self
         default:
             return PlaceholderPumpEvent.self
         }

--- a/MinimedKit/PumpEventType.swift
+++ b/MinimedKit/PumpEventType.swift
@@ -48,6 +48,7 @@ public enum PumpEventType: UInt8 {
     case ChangeSensorSetup2 = 0x50
     case RestoreMystery51 = 0x51
     case RestoreMystery52 = 0x52
+    case RestoreMystery53 = 0x53
     case RestoreMystery54 = 0x54
     case RestoreMystery55 = 0x55
     case ChangeSensorRateOfChangeAlertSetup = 0x56

--- a/MinimedKit/PumpEvents/BolusWizardSetupPumpEvent.swift
+++ b/MinimedKit/PumpEvents/BolusWizardSetupPumpEvent.swift
@@ -1,25 +1,29 @@
 //
-//  ChangeBolusWizardSetupPumpEvent.swift
+//  BolusWizardSetupPumpEvent.swift
 //  RileyLink
 //
-//  Created by Pete Schwamb on 8/29/16.
+//  Created by Pete Schwamb on 3/8/16.
 //  Copyright © 2016 Pete Schwamb. All rights reserved.
 //
 
 import Foundation
 
-public struct ChangeBolusWizardSetupPumpEvent: TimestampedPumpEvent {
+public struct BolusWizardSetupPumpEvent: TimestampedPumpEvent {
     public let length: Int
     public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
-        length = 39
+        if pumpModel.larger {
+            length = 144
+        } else {
+            length = 124
+        }
         
         guard length <= availableData.length else {
             return nil
         }
-        
+
         rawData = availableData[0..<length]
         
         timestamp = NSDateComponents(pumpEventData: availableData, offset: 2)
@@ -27,7 +31,7 @@ public struct ChangeBolusWizardSetupPumpEvent: TimestampedPumpEvent {
     
     public var dictionaryRepresentation: [String: AnyObject] {
         return [
-            "_type": "ChangeBolusWizardSetup",
+            "_type": "BolusWizardSetup",
         ]
     }
 }

--- a/MinimedKit/PumpEvents/RestoreMystery54PumpEvent.swift
+++ b/MinimedKit/PumpEvents/RestoreMystery54PumpEvent.swift
@@ -1,5 +1,5 @@
 //
-//  ChangeBolusWizardSetupPumpEvent.swift
+//  RestoreMystery54PumpEvent.swift
 //  RileyLink
 //
 //  Created by Pete Schwamb on 8/29/16.
@@ -8,13 +8,13 @@
 
 import Foundation
 
-public struct ChangeBolusWizardSetupPumpEvent: TimestampedPumpEvent {
+public struct RestoreMystery54PumpEvent: TimestampedPumpEvent {
     public let length: Int
     public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
-        length = 39
+        length = 64
         
         guard length <= availableData.length else {
             return nil
@@ -27,7 +27,7 @@ public struct ChangeBolusWizardSetupPumpEvent: TimestampedPumpEvent {
     
     public var dictionaryRepresentation: [String: AnyObject] {
         return [
-            "_type": "ChangeBolusWizardSetup",
+            "_type": "RestoreMystery54",
         ]
     }
 }

--- a/MinimedKit/PumpEvents/RestoreMystery55PumpEvent.swift
+++ b/MinimedKit/PumpEvents/RestoreMystery55PumpEvent.swift
@@ -14,7 +14,7 @@ public struct RestoreMystery55PumpEvent: TimestampedPumpEvent {
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
-        length = 64
+        length = 55
         
         guard length <= availableData.length else {
             return nil

--- a/MinimedKit/PumpEvents/RestoreMystery55PumpEvent.swift
+++ b/MinimedKit/PumpEvents/RestoreMystery55PumpEvent.swift
@@ -1,5 +1,5 @@
 //
-//  ChangeBolusWizardSetupPumpEvent.swift
+//  RestoreMystery55PumpEvent.swift
 //  RileyLink
 //
 //  Created by Pete Schwamb on 8/29/16.
@@ -8,13 +8,13 @@
 
 import Foundation
 
-public struct ChangeBolusWizardSetupPumpEvent: TimestampedPumpEvent {
+public struct RestoreMystery55PumpEvent: TimestampedPumpEvent {
     public let length: Int
     public let rawData: NSData
     public let timestamp: NSDateComponents
     
     public init?(availableData: NSData, pumpModel: PumpModel) {
-        length = 39
+        length = 64
         
         guard length <= availableData.length else {
             return nil
@@ -27,7 +27,7 @@ public struct ChangeBolusWizardSetupPumpEvent: TimestampedPumpEvent {
     
     public var dictionaryRepresentation: [String: AnyObject] {
         return [
-            "_type": "ChangeBolusWizardSetup",
+            "_type": "RestoreMystery55",
         ]
     }
 }

--- a/MinimedKit/PumpModel.swift
+++ b/MinimedKit/PumpModel.swift
@@ -41,6 +41,12 @@ public enum PumpModel: String {
         return generation >= 23
     }
     
+    // On newer pumps, square wave boluses are added to history on start of delivery, and updated in place
+    // when delivery is finished
+    public var appendsSquareWaveToHistoryOnStartOfDelivery: Bool {
+        return generation >= 23
+    }
+    
     var hasLowSuspend: Bool {
         return generation >= 51
     }

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -138,6 +138,9 @@
 		C14FFC671D3D7E390049CF85 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14FFC661D3D7E390049CF85 /* KeychainManager.swift */; };
 		C14FFC691D3D7E560049CF85 /* KeychainManager+RileyLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14FFC681D3D7E560049CF85 /* KeychainManager+RileyLink.swift */; };
 		C14FFC6D1D3D85A40049CF85 /* NSTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14FFC6C1D3D85A40049CF85 /* NSTimeInterval.swift */; };
+		C15AF2AD1D74929D0031FC9D /* ChangeBolusWizardSetupPumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15AF2AC1D74929D0031FC9D /* ChangeBolusWizardSetupPumpEvent.swift */; };
+		C15AF2AF1D7498930031FC9D /* RestoreMystery54PumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15AF2AE1D7498930031FC9D /* RestoreMystery54PumpEvent.swift */; };
+		C15AF2B11D7498DD0031FC9D /* RestoreMystery55PumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15AF2B01D7498DD0031FC9D /* RestoreMystery55PumpEvent.swift */; };
 		C16843741CF009E600D53CCD /* SettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16843721CF009E600D53CCD /* SettingsTableViewController.swift */; };
 		C16843751CF009E600D53CCD /* TextFieldTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16843731CF009E600D53CCD /* TextFieldTableViewController.swift */; };
 		C16843771CF00C0100D53CCD /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16843761CF00C0100D53CCD /* SwitchTableViewCell.swift */; };
@@ -194,7 +197,7 @@
 		C1842C151C8FA45100DB42AC /* ChangeChildBlockEnablePumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1842BEB1C8FA45100DB42AC /* ChangeChildBlockEnablePumpEvent.swift */; };
 		C1842C161C8FA45100DB42AC /* ChangeCarbUnitsPumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1842BEC1C8FA45100DB42AC /* ChangeCarbUnitsPumpEvent.swift */; };
 		C1842C171C8FA45100DB42AC /* ChangeCaptureEventEnablePumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1842BED1C8FA45100DB42AC /* ChangeCaptureEventEnablePumpEvent.swift */; };
-		C1842C181C8FA45100DB42AC /* ChangeBolusWizardSetupPumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1842BEE1C8FA45100DB42AC /* ChangeBolusWizardSetupPumpEvent.swift */; };
+		C1842C181C8FA45100DB42AC /* BolusWizardSetupPumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1842BEE1C8FA45100DB42AC /* BolusWizardSetupPumpEvent.swift */; };
 		C1842C191C8FA45100DB42AC /* ChangeBolusScrollStepSizePumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1842BEF1C8FA45100DB42AC /* ChangeBolusScrollStepSizePumpEvent.swift */; };
 		C1842C1A1C8FA45100DB42AC /* ChangeBolusReminderTimePumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1842BF01C8FA45100DB42AC /* ChangeBolusReminderTimePumpEvent.swift */; };
 		C1842C1B1C8FA45100DB42AC /* ChangeBolusReminderEnablePumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1842BF11C8FA45100DB42AC /* ChangeBolusReminderEnablePumpEvent.swift */; };
@@ -508,6 +511,9 @@
 		C14FFC661D3D7E390049CF85 /* KeychainManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		C14FFC681D3D7E560049CF85 /* KeychainManager+RileyLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "KeychainManager+RileyLink.swift"; sourceTree = "<group>"; };
 		C14FFC6C1D3D85A40049CF85 /* NSTimeInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTimeInterval.swift; sourceTree = "<group>"; };
+		C15AF2AC1D74929D0031FC9D /* ChangeBolusWizardSetupPumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangeBolusWizardSetupPumpEvent.swift; sourceTree = "<group>"; };
+		C15AF2AE1D7498930031FC9D /* RestoreMystery54PumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoreMystery54PumpEvent.swift; sourceTree = "<group>"; };
+		C15AF2B01D7498DD0031FC9D /* RestoreMystery55PumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoreMystery55PumpEvent.swift; sourceTree = "<group>"; };
 		C16843721CF009E600D53CCD /* SettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableViewController.swift; sourceTree = "<group>"; };
 		C16843731CF009E600D53CCD /* TextFieldTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewController.swift; sourceTree = "<group>"; };
 		C16843761CF00C0100D53CCD /* SwitchTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchTableViewCell.swift; sourceTree = "<group>"; };
@@ -565,7 +571,7 @@
 		C1842BEB1C8FA45100DB42AC /* ChangeChildBlockEnablePumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChangeChildBlockEnablePumpEvent.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C1842BEC1C8FA45100DB42AC /* ChangeCarbUnitsPumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChangeCarbUnitsPumpEvent.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C1842BED1C8FA45100DB42AC /* ChangeCaptureEventEnablePumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChangeCaptureEventEnablePumpEvent.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		C1842BEE1C8FA45100DB42AC /* ChangeBolusWizardSetupPumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChangeBolusWizardSetupPumpEvent.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		C1842BEE1C8FA45100DB42AC /* BolusWizardSetupPumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BolusWizardSetupPumpEvent.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C1842BEF1C8FA45100DB42AC /* ChangeBolusScrollStepSizePumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChangeBolusScrollStepSizePumpEvent.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C1842BF01C8FA45100DB42AC /* ChangeBolusReminderTimePumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChangeBolusReminderTimePumpEvent.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C1842BF11C8FA45100DB42AC /* ChangeBolusReminderEnablePumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChangeBolusReminderEnablePumpEvent.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -1042,6 +1048,7 @@
 				C1842BC81C8F968B00DB42AC /* BGReceivedPumpEvent.swift */,
 				C1842BC21C8E931E00DB42AC /* BolusNormalPumpEvent.swift */,
 				C12198B21C8F730700BC374C /* BolusWizardEstimatePumpEvent.swift */,
+				C1842BEE1C8FA45100DB42AC /* BolusWizardSetupPumpEvent.swift */,
 				C1842BC61C8F8DC200DB42AC /* CalBGForPHPumpEvent.swift */,
 				C1842BF91C8FA45100DB42AC /* ChangeAlarmClockEnablePumpEvent.swift */,
 				C1842BF81C8FA45100DB42AC /* ChangeAlarmClockTimePumpEvent.swift */,
@@ -1054,7 +1061,7 @@
 				C1842BF11C8FA45100DB42AC /* ChangeBolusReminderEnablePumpEvent.swift */,
 				C1842BF01C8FA45100DB42AC /* ChangeBolusReminderTimePumpEvent.swift */,
 				C1842BEF1C8FA45100DB42AC /* ChangeBolusScrollStepSizePumpEvent.swift */,
-				C1842BEE1C8FA45100DB42AC /* ChangeBolusWizardSetupPumpEvent.swift */,
+				C15AF2AC1D74929D0031FC9D /* ChangeBolusWizardSetupPumpEvent.swift */,
 				C1842BED1C8FA45100DB42AC /* ChangeCaptureEventEnablePumpEvent.swift */,
 				C1842BEC1C8FA45100DB42AC /* ChangeCarbUnitsPumpEvent.swift */,
 				C1842BEB1C8FA45100DB42AC /* ChangeChildBlockEnablePumpEvent.swift */,
@@ -1087,6 +1094,8 @@
 				C1842BCC1C8F9BBD00DB42AC /* PrimePumpEvent.swift */,
 				C1842BCE1C8F9E5100DB42AC /* PumpAlarmPumpEvent.swift */,
 				C1842BBC1C8E7C6E00DB42AC /* PumpEvent.swift */,
+				C15AF2AE1D7498930031FC9D /* RestoreMystery54PumpEvent.swift */,
+				C15AF2B01D7498DD0031FC9D /* RestoreMystery55PumpEvent.swift */,
 				C1842BD41C8FA45100DB42AC /* ResultDailyTotalPumpEvent.swift */,
 				C1842BD31C8FA45100DB42AC /* ResumePumpEvent.swift */,
 				C1842BCA1C8F9A7200DB42AC /* RewindPumpEvent.swift */,
@@ -1737,11 +1746,12 @@
 				C178845D1D4EF3D800405663 /* ReadPumpStatusMessageBody.swift in Sources */,
 				43B0ADCB1D126B1100AAD278 /* SelectBasalProfilePumpEvent.swift in Sources */,
 				C1842C0C1C8FA45100DB42AC /* ChangeTimeFormatPumpEvent.swift in Sources */,
+				C15AF2AF1D7498930031FC9D /* RestoreMystery54PumpEvent.swift in Sources */,
 				C10AB08D1C855613000F102E /* FindDeviceMessageBody.swift in Sources */,
 				C1711A5A1C952D2900CB25BD /* GetPumpModelCarelinkMessageBody.swift in Sources */,
 				C1EB955D1C887FE5002517DF /* HistoryPage.swift in Sources */,
 				C1EAD6CA1C826B92006DBA60 /* MySentryAlertClearedMessageBody.swift in Sources */,
-				C1842C181C8FA45100DB42AC /* ChangeBolusWizardSetupPumpEvent.swift in Sources */,
+				C1842C181C8FA45100DB42AC /* BolusWizardSetupPumpEvent.swift in Sources */,
 				C1842C201C8FA45100DB42AC /* ChangeAudioBolusPumpEvent.swift in Sources */,
 				C1EAD6B31C826B6D006DBA60 /* AlertType.swift in Sources */,
 				C1842C051C8FA45100DB42AC /* DeleteBolusReminderTimePumpEvent.swift in Sources */,
@@ -1749,6 +1759,7 @@
 				C1842C1D1C8FA45100DB42AC /* ChangeBGReminderEnablePumpEvent.swift in Sources */,
 				C1842C061C8FA45100DB42AC /* DeleteAlarmClockTimePumpEvent.swift in Sources */,
 				C10AB08F1C855F34000F102E /* DeviceLinkMessageBody.swift in Sources */,
+				C15AF2B11D7498DD0031FC9D /* RestoreMystery55PumpEvent.swift in Sources */,
 				C1842C091C8FA45100DB42AC /* ChangeWatchdogEnablePumpEvent.swift in Sources */,
 				C1842BC91C8F968B00DB42AC /* BGReceivedPumpEvent.swift in Sources */,
 				C1842C0F1C8FA45100DB42AC /* ChangeSensorRateOfChangeAlertSetupPumpEvent.swift in Sources */,
@@ -1778,6 +1789,7 @@
 				C1EAD6C51C826B92006DBA60 /* Int.swift in Sources */,
 				C1842C021C8FA45100DB42AC /* JournalEntryExerciseMarkerPumpEvent.swift in Sources */,
 				C1EAD6CB1C826B92006DBA60 /* MySentryAlertMessageBody.swift in Sources */,
+				C15AF2AD1D74929D0031FC9D /* ChangeBolusWizardSetupPumpEvent.swift in Sources */,
 				C1842BC71C8F8DC200DB42AC /* CalBGForPHPumpEvent.swift in Sources */,
 				C1842C251C8FA45100DB42AC /* AlarmSensorPumpEvent.swift in Sources */,
 				C1842BBB1C8E184300DB42AC /* PumpModel.swift in Sources */,

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -337,9 +337,14 @@ class PumpOpsSynchronous {
         var timeAdjustmentInterval: NSTimeInterval = 0
         
         // Going to scan backwards in time through events, so event time should be monotonically decreasing.
-        // One known exception is Square Wave boluses, which can be out of order in the pump history by up
-        // to 8 hours, since they are added at end of delivery, with a timestamp of beginning of delivery
-        let eventTimestampDeltaAllowance = NSTimeInterval(hours: 9)
+        // Exceptions are Square Wave boluses, which can be out of order in the pump history by up
+        // to 8 hours on older pumps, and Normal Boluses, which can be out of order by roughly 4 minutes.
+        let eventTimestampDeltaAllowance: NSTimeInterval
+        if pumpModel.appendsSquareWaveToHistoryOnStartOfDelivery {
+            eventTimestampDeltaAllowance = NSTimeInterval(minutes: 10)
+        } else {
+            eventTimestampDeltaAllowance = NSTimeInterval(hours: 9)
+        }
 
         // Start with some time in the future, to account for the condition when the pump's clock is ahead
         // of ours by a small amount.

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -336,11 +336,15 @@ class PumpOpsSynchronous {
         var events = [TimestampedHistoryEvent]()
         var timeAdjustmentInterval: NSTimeInterval = 0
         
-        // Going to scan backwards in time through events, so event time should be monotonically decreasing
+        // Going to scan backwards in time through events, so event time should be monotonically decreasing.
+        // One known exception is Square Wave boluses, which can be out of order in the pump history by up
+        // to 8 hours, since they are added at end of delivery, with a timestamp of beginning of delivery
+        let eventTimestampDeltaAllowance = NSTimeInterval(hours: 9)
+
         // Start with some time in the future, to account for the condition when the pump's clock is ahead
         // of ours by a small amount.
         var timeCursor = NSDate(timeIntervalSinceNow: NSTimeInterval(minutes: 60))
-        let eventTimestampDeltaAllowance = NSTimeInterval(hours: 9)
+        
 
         pages: for pageNum in 0..<16 {
             NSLog("Fetching page %d", pageNum)


### PR DESCRIPTION
Avoid fetching history events that don't fall on expected timeline, as that indicates a non-recoverable clock change
