### PR TITLE
Improvements to wake method

### DIFF
--- a/MinimedKit/PumpModel.swift
+++ b/MinimedKit/PumpModel.swift
@@ -47,6 +47,10 @@ public enum PumpModel: String {
         return generation >= 23
     }
     
+    public var hasMySentry: Bool {
+        return generation >= 23
+    }
+    
     var hasLowSuspend: Bool {
         return generation >= 51
     }

--- a/RileyLink/DeviceDataManager.swift
+++ b/RileyLink/DeviceDataManager.swift
@@ -98,7 +98,7 @@ class DeviceDataManager {
         case "timeZone"?:
             Config.sharedInstance().pumpTimeZone = pumpState?.timeZone
         case "pumpModel"?:
-            if let sentrySupported = pumpState?.pumpModel?.larger {
+            if let sentrySupported = pumpState?.pumpModel?.hasMySentry {
                 rileyLinkManager.idleListeningEnabled = sentrySupported
             }
             Config.sharedInstance().pumpModelNumber = pumpState?.pumpModel?.rawValue
@@ -368,7 +368,7 @@ class DeviceDataManager {
                 if let model = PumpModel(rawValue: pumpModelNumber) {
                     pumpState.pumpModel = model
                     
-                    idleListeningEnabled = model.larger
+                    idleListeningEnabled = model.hasMySentry
                 }
             }
             

--- a/RileyLinkBLEKit/RileyLinkBLEDevice.m
+++ b/RileyLinkBLEKit/RileyLinkBLEDevice.m
@@ -464,7 +464,7 @@
 }
 
 - (void) onIdle {
-    if (!runningIdle && idleListeningEnabled && _peripheral.state == CBPeripheralStateConnected && dataCharacteristic != nil) {
+    if (idleListeningEnabled && _peripheral.state == CBPeripheralStateConnected) {
         runningIdle = YES;
         NSLog(@"Starting idle RX");
         GetPacketCmd *cmd = [[GetPacketCmd alloc] init];
@@ -492,7 +492,7 @@
     if (idleListeningEnabled && !runningSession) {
         NSTimeInterval resetIdleAfterInterval = 2.0 * (float)_idleTimeout / 1000.0;
         
-        if (([NSDate dateWithTimeIntervalSinceNow:-resetIdleAfterInterval] > _lastIdle)) {
+        if (!runningIdle || ([NSDate dateWithTimeIntervalSinceNow:-resetIdleAfterInterval] > _lastIdle)) {
             [self onIdle];
         }
     }

--- a/RileyLinkBLEKit/RileyLinkBLEDevice.m
+++ b/RileyLinkBLEKit/RileyLinkBLEDevice.m
@@ -278,7 +278,7 @@
         NSString *foundVersion;
         BOOL versionOK = NO;
         // We run two commands here, to flush out responses to any old commands
-        [s doCmd:cmd withTimeoutMs:1000];
+        [s doCmd:cmd withTimeoutMs:5000];
         if ([s doCmd:cmd withTimeoutMs:1000]) {
             foundVersion = [[NSString alloc] initWithData:cmd.response encoding:NSUTF8StringEncoding];
             NSLog(@"Got version: %@", foundVersion);
@@ -464,7 +464,7 @@
 }
 
 - (void) onIdle {
-    if (idleListeningEnabled && _peripheral.state == CBPeripheralStateConnected) {
+    if (!runningIdle && idleListeningEnabled && _peripheral.state == CBPeripheralStateConnected && dataCharacteristic != nil) {
         runningIdle = YES;
         NSLog(@"Starting idle RX");
         GetPacketCmd *cmd = [[GetPacketCmd alloc] init];
@@ -492,7 +492,7 @@
     if (idleListeningEnabled && !runningSession) {
         NSTimeInterval resetIdleAfterInterval = 2.0 * (float)_idleTimeout / 1000.0;
         
-        if (!runningIdle || ([NSDate dateWithTimeIntervalSinceNow:-resetIdleAfterInterval] > _lastIdle)) {
+        if (([NSDate dateWithTimeIntervalSinceNow:-resetIdleAfterInterval] > _lastIdle)) {
             [self onIdle];
         }
     }

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -29,6 +29,9 @@ class PumpOpsSynchronous {
     private static let standardPumpResponseWindow: UInt16 = 180
     private let expectedMaxBLELatencyMS = 1500
     
+    // After
+    private let minimumTimeBetweenWakeAttempts = NSTimeInterval(minutes: 1)
+    
     let pump: PumpState
     let session: RileyLinkCmdSession
     
@@ -50,7 +53,16 @@ class PumpOpsSynchronous {
         cmd.retryCount = retryCount
         cmd.listenChannel = 0
         
-        let totalTimeout = Int(retryCount) * Int(msBetweenPackets) + Int(timeoutMS) + expectedMaxBLELatencyMS
+        let minTimeBetweenPackets = 12 // At least 12 ms between packets for radio to stop/start
+        
+        let timeBetweenPackets = max(minTimeBetweenPackets, Int(msBetweenPackets))
+        
+        // 16384 = bitrate, 8 = bits per byte, 6/4 = 4b6 encoding, 1000 = ms in 1s
+        let singlePacketSendTime = (Double(msg.txData.length * 8) * 6 / 4 / 16384.0) * 1000
+        
+        let totalSendTime = Double(repeatCount) * (singlePacketSendTime + Double(timeBetweenPackets))
+        
+        let totalTimeout = Int(retryCount+1) * (Int(totalSendTime) + Int(timeoutMS)) + expectedMaxBLELatencyMS
         
         guard session.doCmd(cmd, withTimeoutMs: totalTimeout) else {
             throw PumpCommsError.RileyLinkTimeout
@@ -66,30 +78,41 @@ class PumpOpsSynchronous {
     /**
      Attempts to send initial short wakeup message that kicks off the wakeup process.
 
-     Makes multiple attempts to send this message in order to work around issue w/
-     x22 pump/RileyLink combos not responding to the initial short wakeup message.
-
      If successful, still does not fully wake up the pump - only alerts it such that the
      longer wakeup message can be sent next.
      */
     private func attemptShortWakeUp(attempts: Int = 3) throws {
         var lastError: ErrorType?
-
-        for _ in 0..<attempts {
+        
+        if (pump.lastWakeAttempt != nil && pump.lastWakeAttempt!.timeIntervalSinceNow > -minimumTimeBetweenWakeAttempts) {
+            return
+        }
+        
+        
+        if pump.pumpModel == nil || !pump.pumpModel!.hasMySentry {
+            // Older pumps have a longer sleep cycle between wakeups, so send an initial burst
             do {
                 let shortPowerMessage = makePumpMessage(.PowerOn)
-                let shortResponse = try sendAndListen(shortPowerMessage, timeoutMS: 15000, repeatCount: 255, msBetweenPackets: 0, retryCount: 0)
-
-                if shortResponse.messageType == .PumpAck {
-                    // Pump successfully received and responded to short wakeup message!
-                    return
-                } else {
-                    lastError = PumpCommsError.UnexpectedResponse(shortResponse, from: shortPowerMessage)
-                }
-            } catch let error {
-                lastError = error
+                try sendAndListen(shortPowerMessage, timeoutMS: 1, repeatCount: 255, msBetweenPackets: 0, retryCount: 0)
             }
+            catch { }
         }
+
+        do {
+            let shortPowerMessage = makePumpMessage(.PowerOn)
+            let shortResponse = try sendAndListen(shortPowerMessage, timeoutMS: 12000, repeatCount: 255, msBetweenPackets: 0, retryCount: 0)
+
+            if shortResponse.messageType == .PumpAck {
+                // Pump successfully received and responded to short wakeup message!
+                return
+            } else {
+                lastError = PumpCommsError.UnexpectedResponse(shortResponse, from: shortPowerMessage)
+            }
+        } catch let error {
+            lastError = error
+        }
+
+        pump.lastWakeAttempt = NSDate()
 
         if let lastError = lastError {
             // If all attempts failed, throw the final error

--- a/RileyLinkKit/PumpState.swift
+++ b/RileyLinkKit/PumpState.swift
@@ -59,6 +59,8 @@ public class PumpState {
         return awakeUntil?.timeIntervalSinceNow > 0
     }
     
+    public var lastWakeAttempt: NSDate?
+    
     private func postChangeNotificationForKey(key: String, oldValue: AnyObject?)  {
         var userInfo: [String: AnyObject] = [
             self.dynamicType.PropertyKey: key


### PR DESCRIPTION
Avoid long (sometimes a minute or more) periods of spamming RF caused by many sessions queued up each individually trying to wake the pump.

This can happen when the pump is out of tune with RL, or if the pump is out of range.

With these changes, the queued up sessions skip over the 15s wake cycle, and quickly try to do their comms, error out, and move on.
