### PR TITLE
Tune updates

### DIFF
--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -421,8 +421,8 @@ class PumpOpsSynchronous {
             results.bestFrequency = sortedTrials.first!.frequencyMHz
             try setBaseFrequency(results.bestFrequency)
         } else {
-            throw PumpCommsError.RFCommsFailure("No pump responses during scan")
             try setBaseFrequency(middleFreq)
+            throw PumpCommsError.RFCommsFailure("No pump responses during scan")
         }
         
         return results

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -138,7 +138,7 @@ class PumpOpsSynchronous {
             let msg = makePumpMessage(.GetPumpModel)
             let response = try sendAndListen(msg, retryCount: 1)
             
-            if response.messageType == .GetPumpModel && (response.messageBody as? GetPumpModelCarelinkMessageBody) != nil {
+            if response.messageType == .GetPumpModel && response.messageBody is GetPumpModelCarelinkMessageBody {
                 return true
             }
         } catch {

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -377,9 +377,11 @@ class PumpOpsSynchronous {
         
         var results = FrequencyScanResults()
         
+        let middleFreq = frequencies[frequencies.count / 2]
+        
         do {
             // Needed to put the pump in listen mode
-            try setBaseFrequency(frequencies[frequencies.count / 2])
+            try setBaseFrequency(middleFreq)
             try wakeup()
         } catch {
             // Continue anyway; the pump likely heard us, even if we didn't hear it.
@@ -420,6 +422,7 @@ class PumpOpsSynchronous {
             try setBaseFrequency(results.bestFrequency)
         } else {
             throw PumpCommsError.RFCommsFailure("No pump responses during scan")
+            try setBaseFrequency(middleFreq)
         }
         
         return results


### PR DESCRIPTION
The pump keeps listening for over a minute after the last comms.  We can avoid sending out hundreds of wake packets by doing a small, 1-2 packet model check to see if the pump is still listening, and extend the wake timeout window. 

Also included in the PR are a couple changes for tuning:  if we need to tune, start in the middle of the frequency range, to increase our chances of waking the pump, and if we fail to find the pump, don't leave the frequency at the end of the range. 
