### PR TITLE
Breaks up long history entries into 1023 chars

### DIFF
--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -464,7 +464,17 @@ class PumpOpsSynchronous {
                     throw error
                 }
             }
-            
+            if true {
+                let logString = NSString(format: "Fetched page %d: %@", pageNum, pageData as NSData ) 
+                let sz = logString.length
+                var idx = 0 
+                while idx < sz {
+                    let jmp = sz - idx > 1023 ? 1023 : sz - idx 
+                    NSLog( logString.substring(with: NSRange( location:idx, length: jmp ))) 
+                    idx += jmp 
+                }   
+            }   
+
             NSLog("Fetched page %d: %@", pageNum, pageData as NSData)
             let page = try HistoryPage(pageData: pageData, pumpModel: pumpModel)
 

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -475,7 +475,6 @@ class PumpOpsSynchronous {
                 }   
             }   
 
-            NSLog("Fetched page %d: %@", pageNum, pageData as NSData)
             let page = try HistoryPage(pageData: pageData, pumpModel: pumpModel)
 
             for event in page.events.reversed() {


### PR DESCRIPTION
There is a limit in ios10 of 1k for NSLog entries.  This will ensure that the history pages are fullly displayed
