### PR TITLE
Add paged cgm data to nightscout

### DIFF
--- a/MinimedKit/GlucoseEvents/CalBGForGHGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/CalBGForGHGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CalBGForGHGlucoseEvent : GlucoseEvent {
+public struct CalBGForGHGlucoseEvent: GlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/DataEndGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/DataEndGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct DataEndGlucoseEvent : RelativeTimestampedGlucoseEvent {
+public struct DataEndGlucoseEvent: RelativeTimestampedGlucoseEvent {
     public let length: Int
     public let rawData: Data
     public var timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/DateTimeChangeGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/DateTimeChangeGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct DateTimeChangeGlucoseEvent : GlucoseEvent {
+public struct DateTimeChangeGlucoseEvent: GlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/Fokko7GlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/Fokko7GlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Fokko7GlucoseEvent : GlucoseEvent {
+public struct Fokko7GlucoseEvent: GlucoseEvent {
     public let length: Int
     public let rawData: Data
     public var timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/GlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/GlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol GlucoseEvent : DictionaryRepresentable {
+public protocol GlucoseEvent: DictionaryRepresentable {
     
     init?(availableData: Data)
     

--- a/MinimedKit/GlucoseEvents/GlucoseSensorDataGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/GlucoseSensorDataGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct GlucoseSensorDataGlucoseEvent : RelativeTimestampedGlucoseEvent {
+public struct GlucoseSensorDataGlucoseEvent: RelativeTimestampedGlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let sgv: Int

--- a/MinimedKit/GlucoseEvents/NineteenSomethingGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/NineteenSomethingGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct NineteenSomethingGlucoseEvent : RelativeTimestampedGlucoseEvent {
+public struct NineteenSomethingGlucoseEvent: RelativeTimestampedGlucoseEvent {
     public let length: Int
     public let rawData: Data
     public var timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/ReferenceTimestampedGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/ReferenceTimestampedGlucoseEvent.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// An event that supplies timestamp information that can be used to calculate a RelativeTimestampedGlucoseEvent
-public protocol ReferenceTimestampedGlucoseEvent : GlucoseEvent {
+public protocol ReferenceTimestampedGlucoseEvent: GlucoseEvent {
     
 }
 

--- a/MinimedKit/GlucoseEvents/RelativeTimestampedGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/RelativeTimestampedGlucoseEvent.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// An event that requires timestamp information from a ReferenceTimestampGlucoseEvent
-public protocol RelativeTimestampedGlucoseEvent : GlucoseEvent {
+public protocol RelativeTimestampedGlucoseEvent: GlucoseEvent {
     
     var timestamp: DateComponents {
         get set

--- a/MinimedKit/GlucoseEvents/SensorCalFactorGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/SensorCalFactorGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct SensorCalFactorGlucoseEvent : ReferenceTimestampedGlucoseEvent {
+public struct SensorCalFactorGlucoseEvent: ReferenceTimestampedGlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/SensorCalGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/SensorCalGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct SensorCalGlucoseEvent : RelativeTimestampedGlucoseEvent {
+public struct SensorCalGlucoseEvent: RelativeTimestampedGlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let waiting: String

--- a/MinimedKit/GlucoseEvents/SensorStatusGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/SensorStatusGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct SensorStatusGlucoseEvent : GlucoseEvent {
+public struct SensorStatusGlucoseEvent: GlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/SensorSyncGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/SensorSyncGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct SensorSyncGlucoseEvent : GlucoseEvent {
+public struct SensorSyncGlucoseEvent: GlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/SensorTimestampGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/SensorTimestampGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct SensorTimestampGlucoseEvent : ReferenceTimestampedGlucoseEvent {
+public struct SensorTimestampGlucoseEvent: ReferenceTimestampedGlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/SensorWeakSignalGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/SensorWeakSignalGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct SensorWeakSignalGlucoseEvent : RelativeTimestampedGlucoseEvent {
+public struct SensorWeakSignalGlucoseEvent: RelativeTimestampedGlucoseEvent {
     public let length: Int
     public let rawData: Data
     public var timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/TenSomethingGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/TenSomethingGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TenSomethingGlucoseEvent : ReferenceTimestampedGlucoseEvent {
+public struct TenSomethingGlucoseEvent: ReferenceTimestampedGlucoseEvent {
     public let length: Int
     public let rawData: Data
     public let timestamp: DateComponents

--- a/MinimedKit/GlucoseEvents/UnknownGlucoseEvent.swift
+++ b/MinimedKit/GlucoseEvents/UnknownGlucoseEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UnknownGlucoseEvent : GlucoseEvent {
+public struct UnknownGlucoseEvent: GlucoseEvent {
     public let length: Int
     public let rawData: Data
     public var timestamp: DateComponents

--- a/MinimedKit/GlucosePage.swift
+++ b/MinimedKit/GlucosePage.swift
@@ -51,7 +51,7 @@ public class GlucosePage {
         func addTimestampsToEvents(startTimestamp: DateComponents, eventsNeedingTimestamp: [RelativeTimestampedGlucoseEvent]) -> [GlucoseEvent] {
             var eventsWithTimestamps = [GlucoseEvent]()
             let calendar = Calendar.current
-            var date : Date = calendar.date(from: startTimestamp)!
+            var date: Date = calendar.date(from: startTimestamp)!
             for var event in eventsNeedingTimestamp {
                 if !(event is NineteenSomethingGlucoseEvent) {
                     date = calendar.date(byAdding: Calendar.Component.minute, value: 5, to: date)!

--- a/MinimedKit/TimestampedGlucoseEvent.swift
+++ b/MinimedKit/TimestampedGlucoseEvent.swift
@@ -24,7 +24,7 @@ public struct TimestampedGlucoseEvent {
 
 
 extension TimestampedGlucoseEvent: DictionaryRepresentable {
-    public var dictionaryRepresentation: [String : Any] {
+    public var dictionaryRepresentation: [String: Any] {
         var dict = glucoseEvent.dictionaryRepresentation
         
         dict["timestamp"] = DateFormatter.ISO8601DateFormatter().string(from: date)

--- a/NightscoutUploadKit/NightscoutEntry.swift
+++ b/NightscoutUploadKit/NightscoutEntry.swift
@@ -1,0 +1,76 @@
+//
+//  NightscoutEntry.swift
+//  RileyLink
+//
+//  Created by Timothy Mecklem on 11/5/16.
+//  Copyright © 2016 Pete Schwamb. All rights reserved.
+//
+
+import Foundation
+import MinimedKit
+
+public class NightscoutEntry : DictionaryRepresentable {
+    
+    public enum GlucoseType: String {
+        case Meter
+        case Sensor
+    }
+    
+    let timestamp: Date
+    let glucose: Int
+    let previousSGV: Int?
+    let previousSGVNotActive: Bool?
+    let direction : String?
+    let device: String
+    let glucoseType : GlucoseType
+    
+    init(glucose: Int, timestamp: Date, device: String, glucoseType: GlucoseType,
+         previousSGV: Int? = nil, previousSGVNotActive: Bool? = nil, direction: String? = nil) {
+        
+        self.glucose = glucose
+        self.timestamp = timestamp
+        self.device = device
+        self.previousSGV = previousSGV
+        self.previousSGVNotActive = previousSGVNotActive
+        self.direction = direction
+        self.glucoseType = glucoseType
+    }
+    
+    convenience init?(event: TimestampedGlucoseEvent, device: String) {
+        if let glucoseSensorData = event.glucoseEvent as? GlucoseSensorDataGlucoseEvent {
+            self.init(glucose: glucoseSensorData.sgv, timestamp: event.date, device: device, glucoseType: .Sensor)
+        }
+        return nil
+    }
+    
+    public var dictionaryRepresentation: [String: Any] {
+        var representation : [String : Any] = [
+            "device": device,
+            "date": timestamp.timeIntervalSince1970 * 1000,
+            "dateString": TimeFormat.timestampStrFromDate(timestamp)
+        ]
+        
+        switch glucoseType {
+        case .Meter:
+            representation["type"] = "mbg"
+            representation["mbg"] = glucose
+        case .Sensor:
+            representation["type"] = "sgv"
+            representation["sgv"] = glucose
+        }
+        
+        if let direction = direction {
+            representation["direction"] = direction
+        }
+        
+        if let previousSGV = previousSGV {
+            representation["previousSGV"] = previousSGV
+        }
+        
+        if let previousSGVNotActive = previousSGVNotActive {
+            representation["previousSGVNotActive"] = previousSGVNotActive
+        }
+        
+        return representation
+    }
+}

--- a/NightscoutUploadKit/NightscoutEntry.swift
+++ b/NightscoutUploadKit/NightscoutEntry.swift
@@ -16,7 +16,7 @@ public class NightscoutEntry : DictionaryRepresentable {
         case Sensor
     }
     
-    let timestamp: Date
+    public let timestamp: Date
     let glucose: Int
     let previousSGV: Int?
     let previousSGVNotActive: Bool?

--- a/NightscoutUploadKit/NightscoutEntry.swift
+++ b/NightscoutUploadKit/NightscoutEntry.swift
@@ -39,8 +39,9 @@ public class NightscoutEntry : DictionaryRepresentable {
     convenience init?(event: TimestampedGlucoseEvent, device: String) {
         if let glucoseSensorData = event.glucoseEvent as? GlucoseSensorDataGlucoseEvent {
             self.init(glucose: glucoseSensorData.sgv, timestamp: event.date, device: device, glucoseType: .Sensor)
+        } else {
+            return nil
         }
-        return nil
     }
     
     public var dictionaryRepresentation: [String: Any] {

--- a/NightscoutUploadKit/NightscoutEntry.swift
+++ b/NightscoutUploadKit/NightscoutEntry.swift
@@ -9,7 +9,7 @@
 import Foundation
 import MinimedKit
 
-public class NightscoutEntry : DictionaryRepresentable {
+public class NightscoutEntry: DictionaryRepresentable {
     
     public enum GlucoseType: String {
         case Meter
@@ -20,9 +20,9 @@ public class NightscoutEntry : DictionaryRepresentable {
     let glucose: Int
     let previousSGV: Int?
     let previousSGVNotActive: Bool?
-    let direction : String?
+    let direction: String?
     let device: String
-    let glucoseType : GlucoseType
+    let glucoseType: GlucoseType
     
     init(glucose: Int, timestamp: Date, device: String, glucoseType: GlucoseType,
          previousSGV: Int? = nil, previousSGVNotActive: Bool? = nil, direction: String? = nil) {
@@ -45,7 +45,7 @@ public class NightscoutEntry : DictionaryRepresentable {
     }
     
     public var dictionaryRepresentation: [String: Any] {
-        var representation : [String : Any] = [
+        var representation: [String: Any] = [
             "device": device,
             "date": timestamp.timeIntervalSince1970 * 1000,
             "dateString": TimeFormat.timestampStrFromDate(timestamp)

--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -123,7 +123,7 @@ public class NightscoutUploader {
             }
         }
         
-        var timestamp : Date? = nil
+        var timestamp: Date? = nil
         
         if let lastEntry = entries.last {
             timestamp = lastEntry.timestamp
@@ -255,8 +255,8 @@ public class NightscoutUploader {
                 return
             }
             
-            let previousSGV : Int?
-            let previousSGVNotActive : Bool?
+            let previousSGV: Int?
+            let previousSGVNotActive: Bool?
             
             switch status.previousGlucose {
             case .active(glucose: let previousGlucose):
@@ -266,7 +266,7 @@ public class NightscoutUploader {
                 previousSGV = nil
                 previousSGVNotActive = true
             }
-            let direction : String = {
+            let direction: String = {
                 switch status.glucoseTrend {
                 case .up:
                     return "SingleUp"

--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -113,10 +113,10 @@ public class NightscoutUploader {
     /**
      Enqueues pump glucose events for upload, with automatic retry management.
      
-     - parameter events:    An array of timestamped glucose events. Only types with known Nightscout mappings will be uploaded.
+     - parameter events:    An array of timestamped glucose events. Only sensor glucose data will be uploaded.
      - parameter source:    The device identifier to display in Nightscout
      */
-    public func processGlucoseEvents(_ events: [TimestampedGlucoseEvent], source: String) {
+    public func processGlucoseEvents(_ events: [TimestampedGlucoseEvent], source: String) -> Date? {
         for event in events {
             if let entry = NightscoutEntry(event: event, device: source) {
                 entries.append(entry)
@@ -124,6 +124,11 @@ public class NightscoutUploader {
         }
         
         self.flushAll()
+        
+        if let lastEntry = entries.last {
+            return lastEntry.timestamp
+        }
+        return nil
     }
 
     /**

--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -123,12 +123,15 @@ public class NightscoutUploader {
             }
         }
         
-        self.flushAll()
+        var timestamp : Date? = nil
         
         if let lastEntry = entries.last {
-            return lastEntry.timestamp
+            timestamp = lastEntry.timestamp
         }
-        return nil
+        
+        self.flushAll()
+        
+        return timestamp
     }
 
     /**

--- a/NightscoutUploadKit/Treatments/NightscoutTreatment.swift
+++ b/NightscoutUploadKit/Treatments/NightscoutTreatment.swift
@@ -8,7 +8,7 @@
 
 import MinimedKit
 
-public class NightscoutTreatment : DictionaryRepresentable {
+public class NightscoutTreatment: DictionaryRepresentable {
     
     public enum GlucoseType: String {
         case Meter

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		541688DB1DB820BF005B1891 /* ReadCurrentGlucosePageMessageBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541688DA1DB820BF005B1891 /* ReadCurrentGlucosePageMessageBodyTests.swift */; };
 		541688DD1DB82213005B1891 /* ReadCurrentGlucosePageMessageBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541688DC1DB82213005B1891 /* ReadCurrentGlucosePageMessageBody.swift */; };
 		541688DF1DB82E72005B1891 /* TimestampedGlucoseEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541688DE1DB82E72005B1891 /* TimestampedGlucoseEvent.swift */; };
+		546145C11DCEB47600DC6DEB /* NightscoutEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546145C01DCEB47600DC6DEB /* NightscoutEntry.swift */; };
 		54A840D11DB85D0600B1F202 /* UnknownGlucoseEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A840D01DB85D0600B1F202 /* UnknownGlucoseEvent.swift */; };
 		54BC44731DB46A5200340EED /* GlucosePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BC44721DB46A5200340EED /* GlucosePageTests.swift */; };
 		54BC44751DB46B0A00340EED /* GlucosePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BC44741DB46B0A00340EED /* GlucosePage.swift */; };
@@ -511,6 +512,7 @@
 		541688DA1DB820BF005B1891 /* ReadCurrentGlucosePageMessageBodyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadCurrentGlucosePageMessageBodyTests.swift; sourceTree = "<group>"; };
 		541688DC1DB82213005B1891 /* ReadCurrentGlucosePageMessageBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadCurrentGlucosePageMessageBody.swift; sourceTree = "<group>"; };
 		541688DE1DB82E72005B1891 /* TimestampedGlucoseEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimestampedGlucoseEvent.swift; sourceTree = "<group>"; };
+		546145C01DCEB47600DC6DEB /* NightscoutEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NightscoutEntry.swift; sourceTree = "<group>"; };
 		54A840D01DB85D0600B1F202 /* UnknownGlucoseEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownGlucoseEvent.swift; sourceTree = "<group>"; };
 		54BC44721DB46A5200340EED /* GlucosePageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucosePageTests.swift; sourceTree = "<group>"; };
 		54BC44741DB46B0A00340EED /* GlucosePage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucosePage.swift; sourceTree = "<group>"; };
@@ -1359,6 +1361,7 @@
 				C1B3830F1CD0665D00CE7782 /* Info.plist */,
 				C13D15591DAACE8400ADC044 /* Either.swift */,
 				43F348051D596270009933DC /* HKUnit.swift */,
+				546145C01DCEB47600DC6DEB /* NightscoutEntry.swift */,
 				C1842C2A1C90DFB600DB42AC /* NightscoutPumpEvents.swift */,
 				C1842C281C908A3C00DB42AC /* NightscoutUploader.swift */,
 				C1B4A94D1D1C423D003B8985 /* NSUserDefaults.swift */,
@@ -2203,6 +2206,7 @@
 				43B0ADC91D1268B300AAD278 /* TimeFormat.swift in Sources */,
 				C1AF21E21D4838C90088C41D /* DeviceStatus.swift in Sources */,
 				C1B383281CD0668600CE7782 /* NightscoutUploader.swift in Sources */,
+				546145C11DCEB47600DC6DEB /* NightscoutEntry.swift in Sources */,
 				C1AF21F41D4901220088C41D /* TempBasalNightscoutTreatment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RileyLink/Config.h
+++ b/RileyLink/Config.h
@@ -22,5 +22,6 @@
 @property (nonatomic, nullable, strong) NSSet *autoConnectIds;
 @property (nonatomic, assign) NSInteger pumpRegion;
 @property (nonatomic, assign) BOOL uploadEnabled;
+@property (nonatomic, assign) BOOL fetchCGMEnabled;
 
 @end

--- a/RileyLink/Config.m
+++ b/RileyLink/Config.m
@@ -112,6 +112,14 @@
     [[NSUserDefaults standardUserDefaults] setBool:uploadEnabled forKey:@"uploadEnabled"];
 }
 
+- (BOOL) fetchCGMEnabled {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"fetchCGMEnabled"];
+}
+
+- (void) setFetchCGMEnabled:(BOOL)fetchCGMEnabled {
+    [[NSUserDefaults standardUserDefaults] setBool:fetchCGMEnabled forKey:@"fetchCGMEnabled"];
+}
+
 - (NSInteger) pumpRegion {
     return [[NSUserDefaults standardUserDefaults] integerForKey:@"pumpRegion"];
 }

--- a/RileyLink/DeviceDataManager.swift
+++ b/RileyLink/DeviceDataManager.swift
@@ -377,7 +377,7 @@ class DeviceDataManager {
             switch response {
             case .success(let events):
                 NSLog("fetchGlucoseHistory succeeded.")
-                if let latestEntryDate : Date = self.handleNewGlucoseHistoryEvents(events, device: device) {
+                if let latestEntryDate: Date = self.handleNewGlucoseHistoryEvents(events, device: device) {
                     self.lastGlucoseEntry = latestEntryDate
                 }
                 

--- a/RileyLink/DeviceDataManager.swift
+++ b/RileyLink/DeviceDataManager.swift
@@ -461,6 +461,5 @@ class DeviceDataManager {
 
 extension Notification.Name {
     static let PumpEventsUpdated = Notification.Name(rawValue: "com.rileylink.notification.PumpEventsUpdated")
-    static let GlucoseEventsUpdated = Notification.Name(rawValue: "com.rileylink.notification.GlucoseEventsUpdated")
 }
 

--- a/RileyLink/View Controllers/SettingsTableViewController.swift
+++ b/RileyLink/View Controllers/SettingsTableViewController.swift
@@ -40,7 +40,8 @@ class SettingsTableViewController: UITableViewController, TextFieldTableViewCont
         case pumpID = 0
         case pumpRegion
         case nightscout
-        static let count = 3
+        case fetchCGM
+        static let count = 4
     }
     
     fileprivate var dataManager: DeviceDataManager {
@@ -90,22 +91,33 @@ class SettingsTableViewController: UITableViewController, TextFieldTableViewCont
                 return switchCell
             }
         case .configuration:
-            let configCell = tableView.dequeueReusableCell(withIdentifier: ConfigCellIdentifier, for: indexPath)
 
             switch ConfigurationRow(rawValue: indexPath.row)! {
             case .pumpID:
+                let configCell = tableView.dequeueReusableCell(withIdentifier: ConfigCellIdentifier, for: indexPath)
                 configCell.textLabel?.text = NSLocalizedString("Pump ID", comment: "The title text for the pump ID config value")
                 configCell.detailTextLabel?.text = DeviceDataManager.sharedManager.pumpID ?? TapToSetString
+                cell = configCell
             case .pumpRegion:
+                let configCell = tableView.dequeueReusableCell(withIdentifier: ConfigCellIdentifier, for: indexPath)
                 configCell.textLabel?.text = NSLocalizedString("Pump Region", comment: "The title text for the pump Region config value")
                 configCell.detailTextLabel?.text = String(describing: DeviceDataManager.sharedManager.pumpRegion)
+                cell = configCell
             case .nightscout:
+                let configCell = tableView.dequeueReusableCell(withIdentifier: ConfigCellIdentifier, for: indexPath)
                 let nightscoutService = dataManager.remoteDataManager.nightscoutService
                 
                 configCell.textLabel?.text = nightscoutService.title
                 configCell.detailTextLabel?.text = nightscoutService.siteURL?.absoluteString ?? TapToSetString
+                cell = configCell
+            case .fetchCGM:
+                let switchCell = tableView.dequeueReusableCell(withIdentifier: SwitchTableViewCell.className, for: indexPath) as! SwitchTableViewCell
+            
+                switchCell.`switch`?.isOn = Config.sharedInstance().fetchCGMEnabled
+                switchCell.titleLabel.text = NSLocalizedString("Fetch CGM", comment: "The title text for the pull cgm Data cell")
+                switchCell.`switch`?.addTarget(self, action: #selector(fetchCGMEnabledChanged(_:)), for: .valueChanged)
+                cell = switchCell
             }
-            cell = configCell
         }
         return cell
     }
@@ -147,6 +159,8 @@ class SettingsTableViewController: UITableViewController, TextFieldTableViewCont
                 }
                 
                 show(vc, sender: indexPath)
+            default:
+                break
             }
         case .upload, .about:
             break
@@ -186,10 +200,16 @@ class SettingsTableViewController: UITableViewController, TextFieldTableViewCont
         }
     }
 
-    // MARK: - Uploader mangement
+    // MARK: - Uploader management
 
     func uploadEnabledChanged(_ sender: UISwitch) {
         Config.sharedInstance().uploadEnabled = sender.isOn
+    }
+
+    // MARK: - CGM Page Fetching Management
+
+    func fetchCGMEnabledChanged(_ sender: UISwitch) {
+        Config.sharedInstance().fetchCGMEnabled = sender.isOn
     }
 
     // MARK: - TextFieldTableViewControllerDelegate


### PR DESCRIPTION
Summary: This PR adds cgm page uploads to nightscout

Hot on the heels of the most recent release (https://github.com/ps2/rileylink_ios/releases/tag/v0.12.6) which enables fetching recent glucose history on 522 and 722 pumps, this PR enables uploading that cgm data to Nightscout.

Needs discussion/resolution
- [ ] Should we do something like recent-missing-entries in openaps and avoid uploading everything every time?
- [ ] Should using cgm page data be restricted only to x22 model pumps or used also on other pumps to augment the MySentry alert data?
- [ ] Is there a way to detect that a pump isn't using cgm or should we explicitly enable enlite cgm fetching via a UI toggle?
