### PR TITLE
Add ReadCurrentPageNumber event

### DIFF
--- a/MinimedKit/MessageType.swift
+++ b/MinimedKit/MessageType.swift
@@ -29,6 +29,7 @@ public enum MessageType: UInt8 {
     case getPumpModel                 = 0x8d
     case readTempBasal                = 0x98
     case getGlucosePage               = 0x9A
+    case readCurrentPageNumber        = 0x9d
     case readSettings                 = 0xc0
     case readCurrentGlucosePage       = 0xcd
     case readPumpStatus               = 0xce
@@ -67,6 +68,8 @@ public enum MessageType: UInt8 {
             return ReadPumpStatusMessageBody.self
         case .readCurrentGlucosePage:
             return ReadCurrentGlucosePageMessageBody.self
+        case .readCurrentPageNumber:
+            return ReadCurrentPageNumberMessageBody.self
         case .getGlucosePage:
             return GetGlucosePageMessageBody.self
         default:

--- a/MinimedKit/Messages/ReadCurrentPageNumberMessageBody.swift
+++ b/MinimedKit/Messages/ReadCurrentPageNumberMessageBody.swift
@@ -1,0 +1,37 @@
+//
+//  ReadCurrentPageNumberMessageBody.swift
+//  RileyLink
+//
+//  Created by Jaim Zuber on 2/17/17.
+//  Copyright © 2017 Pete Schwamb. All rights reserved.
+//
+
+import Foundation
+
+public class ReadCurrentPageNumberMessageBody : MessageBody {
+    public static var length: Int = 64
+    public let pageNum: Int
+
+    let rxData: Data
+    
+    public var txData: Data {
+        return rxData
+    }
+ 
+    // Partially implemented from https://github.com/bewest/decoding-carelink/blob/master/decocare/commands.py#L575
+    public required init?(rxData: Data) {
+        var page = 0
+        
+        //NOTE: Page Number  is likely 4 bytes little endian but anything longer that one byte is not implemented
+        if rxData.count > 1 {
+            page = Int(rxData[0])
+        }
+        
+        if page < 0 || page > 36 {
+            page = 36
+        }
+        
+        pageNum = page
+        self.rxData = rxData
+    }
+}

--- a/MinimedKit/Messages/ReadCurrentPageNumberMessageBody.swift
+++ b/MinimedKit/Messages/ReadCurrentPageNumberMessageBody.swift
@@ -8,15 +8,8 @@
 
 import Foundation
 
-public class ReadCurrentPageNumberMessageBody : MessageBody {
-    public static var length: Int = 64
+public class ReadCurrentPageNumberMessageBody : CarelinkLongMessageBody {
     public let pageNum: Int
-
-    let rxData: Data
-    
-    public var txData: Data {
-        return rxData
-    }
  
     // Partially implemented from https://github.com/bewest/decoding-carelink/blob/master/decocare/commands.py#L575
     public required init?(rxData: Data) {
@@ -32,6 +25,6 @@ public class ReadCurrentPageNumberMessageBody : MessageBody {
         }
         
         pageNum = page
-        self.rxData = rxData
+        super.init(rxData: rxData)
     }
 }

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2B19B9881DF3EF68006AB65F /* NewTimePumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B19B9871DF3EF68006AB65F /* NewTimePumpEvent.swift */; };
+		2FDE1A071E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDE1A061E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift */; };
 		430D64CE1CB855AB00FCA750 /* RileyLinkBLEKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 430D64CD1CB855AB00FCA750 /* RileyLinkBLEKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		430D64D51CB855AB00FCA750 /* RileyLinkBLEKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 430D64CB1CB855AB00FCA750 /* RileyLinkBLEKit.framework */; };
 		430D64DC1CB855AB00FCA750 /* RileyLinkBLEKitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D64DB1CB855AB00FCA750 /* RileyLinkBLEKitTests.m */; };
@@ -450,6 +451,7 @@
 
 /* Begin PBXFileReference section */
 		2B19B9871DF3EF68006AB65F /* NewTimePumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewTimePumpEvent.swift; sourceTree = "<group>"; };
+		2FDE1A061E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadCurrentPageNumberMessageBody.swift; sourceTree = "<group>"; };
 		430D64CB1CB855AB00FCA750 /* RileyLinkBLEKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RileyLinkBLEKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		430D64CD1CB855AB00FCA750 /* RileyLinkBLEKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RileyLinkBLEKit.h; sourceTree = "<group>"; };
 		430D64CF1CB855AB00FCA750 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1469,6 +1471,7 @@
 				43CA932C1CB8CFA1000026B5 /* ReadTempBasalCarelinkMessageBody.swift */,
 				43CA932D1CB8CFA1000026B5 /* ReadTimeCarelinkMessageBody.swift */,
 				C1EAD6C41C826B92006DBA60 /* UnknownMessageBody.swift */,
+				2FDE1A061E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift */,
 			);
 			path = Messages;
 			sourceTree = "<group>";
@@ -2085,6 +2088,7 @@
 				C1842BC31C8E931E00DB42AC /* BolusNormalPumpEvent.swift in Sources */,
 				541688DD1DB82213005B1891 /* ReadCurrentGlucosePageMessageBody.swift in Sources */,
 				43CA932F1CB8CFA1000026B5 /* ReadTimeCarelinkMessageBody.swift in Sources */,
+				2FDE1A071E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift in Sources */,
 				54BC44781DB46C7D00340EED /* GlucoseEvent.swift in Sources */,
 				546A85D01DF7BB8B00733213 /* SensorPacketGlucoseEvent.swift in Sources */,
 				C1842BFD1C8FA45100DB42AC /* ResumePumpEvent.swift in Sources */,


### PR DESCRIPTION
Create ReadCurrentPageNumber event

Partially tested but returns a correct page number for page numbers that fit within 1 byte. This was implemented when implemented a (now removed) caching feature. @ps2 asked to keep this command in.