### PR TITLE
Refactor out event translate

### DIFF
--- a/NightscoutUploadKit/NightscoutPumpEvents.swift
+++ b/NightscoutUploadKit/NightscoutPumpEvents.swift
@@ -9,9 +9,9 @@
 import Foundation
 import MinimedKit
 
-class NightscoutPumpEvents: NSObject {
+public class NightscoutPumpEvents: NSObject {
     
-    class func translate(_ events: [TimestampedHistoryEvent], eventSource: String) -> [NightscoutTreatment] {
+    public class func translate(_ events: [TimestampedHistoryEvent], eventSource: String, includeCarbs: Bool = true) -> [NightscoutTreatment] {
         var results = [NightscoutTreatment]()
         var lastBolusWizard: BolusWizardEstimatePumpEvent?
         var lastBolusWizardDate: Date?
@@ -34,7 +34,11 @@ class NightscoutPumpEvents: NSObject {
                 var carbs = 0
                 var ratio = 0.0
                 
-                if let wizard = lastBolusWizard, let bwDate = lastBolusWizardDate , event.date.timeIntervalSince(bwDate) <= 2 {
+                if let wizard = lastBolusWizard,
+                    let bwDate = lastBolusWizardDate,
+                    event.date.timeIntervalSince(bwDate) <= 2,
+                    includeCarbs
+                    {
                     carbs = wizard.carbohydrates
                     ratio = wizard.carbRatio
                 }

--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -134,29 +134,6 @@ public class NightscoutUploader {
         return timestamp
     }
 
-    /**
-     Attempts to upload pump history events.
-     
-     This method will not retry if the network task failed.
-     
-     - parameter pumpEvents: An array of timestamped history events. Only types with known Nightscout mappings will be uploaded.
-     - parameter source:     The device identifier to display in Nightscout
-     - parameter pumpModel:  The pump model info associated with the events
-     - parameter completionHandler: A closure to execute when the task completes. It has a single argument for any error that might have occurred during the upload.
-     */
-    public func upload(_ pumpEvents: [TimestampedHistoryEvent], forSource source: String, from pumpModel: PumpModel, completionHandler: @escaping (Error?) -> Void) {
-        let treatments = NightscoutPumpEvents.translate(pumpEvents, eventSource: source).map { $0.dictionaryRepresentation }
-
-        postToNS(treatments, endpoint: defaultNightscoutTreatmentPath) { (result) in
-            switch result {
-            case .success( _):
-                completionHandler(nil)
-            case .failure(let error):
-                completionHandler(error)
-            }
-        }
-    }
-
     /// Attempts to upload nightscout treatment objects.
     /// This method will not retry if the network task failed.
     ///


### PR DESCRIPTION
Allow more external control over how events from pump are translated into ns events.
Remove upload that uses TimestampedHistoryEvent, in favor of upload that takes NightscoutTreatments