### PR TITLE
Better error handling

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -350,14 +350,13 @@ public class MinimedPumpManager: RileyLinkPumpManager, PumpManager {
             self.pumpOps.runSession(withName: "Fetch Pump History", using: device) { (session) in
                 do {
                     guard let startDate = self.pumpManagerDelegate?.startDateToFilterNewPumpEvents(for: self) else {
-                        assertionFailure("pumpManagerDelegate cannot be nil")
-                        throw PumpManagerError.configuration(MinimedPumpManagerError.noDelegate)
+                        preconditionFailure("pumpManagerDelegate cannot be nil")
                     }
 
                     let (events, model) = try session.getHistoryEvents(since: startDate)
 
                     self.pumpManagerDelegate?.pumpManager(self, didReadPumpEvents: events.pumpEvents(from: model), completion: { (error) in
-                        if error != nil {
+                        if error == nil {
                             self.lastAddedPumpEvents = Date()
                         }
 
@@ -420,7 +419,7 @@ public class MinimedPumpManager: RileyLinkPumpManager, PumpManager {
                     let status = try session.getCurrentPumpStatus()
                     guard var date = status.clock.date else {
                         assertionFailure("Could not interpret a valid date from \(status.clock) in the system calendar")
-                        return
+                        throw PumpManagerError.configuration(MinimedPumpManagerError.noDate)
                     }
 
                     // Check if the clock should be reset

--- a/MinimedKit/PumpManager/MinimedPumpManagerError.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManagerError.swift
@@ -9,8 +9,7 @@ import Foundation
 
 public enum MinimedPumpManagerError: Error {
     case noRileyLink
-    case noDate
-    case noDelegate
+    case noDate  // TODO: This is less of an error and more of a precondition/assertion state
     case tuneFailed(LocalizedError)
 }
 
@@ -22,10 +21,19 @@ extension MinimedPumpManagerError: LocalizedError {
             return nil
         case .noDate:
             return nil
-        case .noDelegate:
+        case .tuneFailed(let error):
+            return [NSLocalizedString("RileyLink radio tune failed", comment: "Error description"), error.errorDescription].compactMap({ $0 }).joined(separator: ": ")
+        }
+    }
+
+    public var failureReason: String? {
+        switch self {
+        case .noRileyLink:
+            return nil
+        case .noDate:
             return nil
         case .tuneFailed(let error):
-            return [NSLocalizedString("RileyLink radio tune failed", comment: "Error description"), error.errorDescription].compactMap({ $0 }).joined(separator: ". ")
+            return error.failureReason
         }
     }
 
@@ -35,10 +43,8 @@ extension MinimedPumpManagerError: LocalizedError {
             return NSLocalizedString("Make sure your RileyLink is nearby and powered on", comment: "Recovery suggestion")
         case .noDate:
             return nil
-        case .noDelegate:
-            return nil
-        case .tuneFailed(_):
-            return nil
+        case .tuneFailed(let error):
+            return error.recoverySuggestion
         }
     }
 }

--- a/MinimedKit/PumpManager/PumpMessageSender.swift
+++ b/MinimedKit/PumpManager/PumpMessageSender.swift
@@ -69,6 +69,7 @@ extension PumpMessageSender {
     ///   - retryCount: The number of times to repeat the send & listen sequence
     /// - Returns: The expected response message body
     /// - Throws:
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -104,6 +105,7 @@ extension PumpMessageSender {
     ///   - retryCount: The number of times to repeat the send & listen sequence
     /// - Returns: The message reply
     /// - Throws: An error describing a failure in the sending or receiving of a message:
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -112,8 +114,7 @@ extension PumpMessageSender {
         let rfPacket = try sendAndListenForPacket(message, repeatCount: repeatCount, timeout: timeout, retryCount: retryCount)
 
         guard let packet = MinimedPacket(encodedData: rfPacket.data) else {
-            // TODO: Change error to better reflect that this is an encoding or CRC error
-            throw PumpOpsError.unknownResponse(rx: rfPacket.data, during: message)
+            throw PumpOpsError.couldNotDecode(rx: rfPacket.data, during: message)
         }
 
         guard let response = PumpMessage(rxData: packet.data) else {

--- a/MinimedKit/PumpManager/PumpOpsError.swift
+++ b/MinimedKit/PumpManager/PumpOpsError.swift
@@ -21,6 +21,7 @@ public enum PumpCommandError: Error {
 
 public enum PumpOpsError: Error {
     case bolusInProgress
+    case couldNotDecode(rx: Data, during: CustomStringConvertible)
     case crosstalk(PumpMessage, during: CustomStringConvertible)
     case deviceError(LocalizedError)
     case noResponse(during: CustomStringConvertible)
@@ -38,6 +39,8 @@ extension PumpOpsError: LocalizedError {
         switch self {
         case .bolusInProgress:
             return nil
+        case .couldNotDecode:
+            return NSLocalizedString("Decoding Error", comment: "Error description")
         case .crosstalk:
             return nil
         case .deviceError:
@@ -64,27 +67,29 @@ extension PumpOpsError: LocalizedError {
     public var failureReason: String? {
         switch self {
         case .bolusInProgress:
-            return NSLocalizedString("A bolus is already in progress.", comment: "Communications error for a bolus currently running")
+            return NSLocalizedString("A bolus is already in progress", comment: "Communications error for a bolus currently running")
+        case .couldNotDecode(rx: let data, during: let during):
+            return String(format: NSLocalizedString("Invalid response during %1$@: %2$@", comment: "Format string for failure reason. (1: The operation being performed) (2: The response data)"), String(describing: during), data.hexadecimalString)
         case .crosstalk:
-            return NSLocalizedString("Comms with another pump detected.", comment: "")
+            return NSLocalizedString("Comms with another pump detected", comment: "")
         case .noResponse:
-            return NSLocalizedString("Pump did not respond.", comment: "")
+            return NSLocalizedString("Pump did not respond", comment: "")
         case .pumpSuspended:
-            return NSLocalizedString("Pump is suspended.", comment: "")
+            return NSLocalizedString("Pump is suspended", comment: "")
         case .rfCommsFailure(let msg):
             return msg
         case .unexpectedResponse:
-            return NSLocalizedString("Pump responded unexpectedly.", comment: "")
+            return NSLocalizedString("Pump responded unexpectedly", comment: "")
         case .unknownPumpErrorCode(let code):
-            return String(format: NSLocalizedString("Unknown pump error code: %1$@.", comment: "The format string description of an unknown pump error code. (1: The specific error code raw value)"), String(describing: code))
+            return String(format: NSLocalizedString("Unknown pump error code: %1$@", comment: "The format string description of an unknown pump error code. (1: The specific error code raw value)"), String(describing: code))
         case .unknownPumpModel(let model):
-            return String(format: NSLocalizedString("Unknown pump model: %@.", comment: ""), model)
+            return String(format: NSLocalizedString("Unknown pump model: %@", comment: ""), model)
         case .unknownResponse(rx: let data, during: let during):
             return String(format: NSLocalizedString("Unknown response during %1$@: %2$@", comment: "Format string for an unknown response. (1: The operation being performed) (2: The response data)"), String(describing: during), data.hexadecimalString)
         case .pumpError(let errorCode):
             return String(describing: errorCode)
         case .deviceError(let error):
-            return [error.errorDescription, error.failureReason].compactMap({ $0 }).joined(separator: ". ")
+            return [error.errorDescription, error.failureReason].compactMap({ $0 }).joined(separator: ": ")
         }
     }
 

--- a/RileyLinkBLEKit/PeripheralManagerError.swift
+++ b/RileyLinkBLEKit/PeripheralManagerError.swift
@@ -34,6 +34,19 @@ extension PeripheralManagerError: LocalizedError {
         switch self {
         case .cbPeripheralError(let error as NSError):
             return error.localizedFailureReason
+        case .unknownCharacteristic:
+            return NSLocalizedString("The RileyLink was temporarily disconnected", comment: "Failure reason: unknown peripheral characteristic")
+        default:
+            return nil
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .cbPeripheralError(let error as NSError):
+            return error.localizedRecoverySuggestion
+        case .unknownCharacteristic:
+            return NSLocalizedString("Make sure the device is nearby, and the issue should resolve automatically", comment: "Recovery suggestion for unknown peripheral characteristic")
         default:
             return nil
         }

--- a/RileyLinkBLEKit/RileyLinkDeviceError.swift
+++ b/RileyLinkBLEKit/RileyLinkDeviceError.swift
@@ -42,4 +42,13 @@ extension RileyLinkDeviceError: LocalizedError {
             return nil
         }
     }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .peripheralManagerError(let error):
+            return error.recoverySuggestion
+        default:
+            return nil
+        }
+    }
 }

--- a/RileyLinkKit/PumpOpsSession.swift
+++ b/RileyLinkKit/PumpOpsSession.swift
@@ -47,6 +47,7 @@ extension PumpOpsSession {
     ///
     /// - Throws:
     ///     - PumpCommandError.command containing:
+    ///         - PumpOpsError.couldNotDecode
     ///         - PumpOpsError.crosstalk
     ///         - PumpOpsError.deviceError
     ///         - PumpOpsError.noResponse
@@ -90,6 +91,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///         - PumpOpsError.couldNotDecode
     ///         - PumpOpsError.crosstalk
     ///         - PumpOpsError.deviceError
     ///         - PumpOpsError.noResponse
@@ -138,6 +140,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -163,6 +166,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -176,6 +180,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -189,6 +194,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -205,6 +211,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -224,6 +231,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -247,6 +255,7 @@ extension PumpOpsSession {
     }
 
     /// - Throws:
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -259,6 +268,7 @@ extension PumpOpsSession {
     }
 
     /// - Throws:
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -272,6 +282,7 @@ extension PumpOpsSession {
     }
 
     /// - Throws:
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -308,6 +319,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -692,6 +704,7 @@ extension PumpOpsSession {
     ///
     /// - Parameter watchdogID: A 3-byte address for the watchdog device.
     /// - Throws:
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse
@@ -715,8 +728,7 @@ extension PumpOpsSession {
         }
 
         guard let packet = MinimedPacket(encodedData: encodedData) else {
-            // TODO: Change error to better reflect that this is an encoding or CRC error
-            throw PumpOpsError.unknownResponse(rx: encodedData, during: "Watchdog listening")
+            throw PumpOpsError.couldNotDecode(rx: encodedData, during: "Watchdog listening")
         }
         
         guard let findMessage = PumpMessage(rxData: packet.data) else {
@@ -932,6 +944,7 @@ extension PumpOpsSession {
     /// - Throws:
     ///     - PumpCommandError.command
     ///     - PumpCommandError.arguments
+    ///     - PumpOpsError.couldNotDecode
     ///     - PumpOpsError.crosstalk
     ///     - PumpOpsError.deviceError
     ///     - PumpOpsError.noResponse

--- a/RileyLinkKit/es.lproj/Localizable.strings
+++ b/RileyLinkKit/es.lproj/Localizable.strings
@@ -17,7 +17,7 @@
 "%1$@%2$@%3$@" = "%1$@%2$@%3$@";
 
 /* Communications error for a bolus currently running */
-"A bolus is already in progress." = "Un bolo ya está en progreso...";
+"A bolus is already in progress" = "Un bolo ya está en progreso";
 
 /* The title of the cell describing an awake radio */
 "Awake Until" = "Despierto hasta";
@@ -89,7 +89,7 @@
 "Get Pump Model" = "Obtener Modelo de Microinfusadora";
 
 /* Recovery instruction for a certain bolus failure */
-"It is safe to retry." = "Es seguro intentarlo de nuevo.";
+"It is safe to retry" = "Es seguro intentarlo de nuevo.";
 
 /* The title of the cell describing an awake radio */
 "Last Awake" = "último despierto";

--- a/RileyLinkKit/ru.lproj/Localizable.strings
+++ b/RileyLinkKit/ru.lproj/Localizable.strings
@@ -17,7 +17,7 @@
 "%1$@%2$@%3$@" = "%1$@%2$@%3$@";
 
 /* Communications error for a bolus currently running */
-"A bolus is already in progress." = "Болюс уже подается";
+"A bolus is already in progress" = "Болюс уже подается";
 
 /* The title of the cell describing an awake radio */
 "Awake Until" = "Рабочее состояние до";
@@ -89,7 +89,7 @@
 "Get Pump Model" = "Получить модель помпы";
 
 /* Recovery instruction for a certain bolus failure */
-"It is safe to retry." = "Можно повторить без опасений";
+"It is safe to retry" = "Можно повторить без опасений";
 
 /* The title of the cell describing an awake radio */
 "Last Awake" = "Недавнее состояние активности";


### PR DESCRIPTION
Fixes a backwards logic check when tracking last history read. This is a low-impact bug; the result is that users with Pump Event as their history source were doing an additional history fetch after every temp basal.

Also adds a separate error (and resolves a long-standing TODO) for packet decoding failures.