### PR TITLE
Added beepType options to cancel and configure alerts command

### DIFF
--- a/OmniKit/MessageBlocks/CancelDeliveryCommand.swift
+++ b/OmniKit/MessageBlocks/CancelDeliveryCommand.swift
@@ -26,17 +26,33 @@ public struct CancelDeliveryCommand : MessageBlock {
         }
     }
     
-    public enum CancelType {
-        case normal
-        case suspend
+    public struct BeepType: OptionSet {
+        public let rawValue: UInt8
         
-        var rawValue: UInt8 {
-            switch self {
-            case .normal:
-                return 0x6
-            case .suspend:
-                return 0x0
-            }
+        static let noBeep = BeepType(rawValue: 0)
+        static let beepBeepBeepBeep = BeepType(rawValue: 1)
+        static let bipBeepBipBeepBipBeepBipBeep = BeepType(rawValue: 2)
+        static let bipBip = BeepType(rawValue: 3)
+        static let beep = BeepType(rawValue: 4)
+        static let beepBeepBeep = BeepType(rawValue: 5)
+        static let beeeeeep = BeepType(rawValue: 6)
+        static let bipBipBipbipBipBip = BeepType(rawValue: 7)
+        static let beeepBeeep = BeepType(rawValue: 8)
+        
+        static let all: BeepType = [
+            .noBeep,
+            .beepBeepBeepBeep,
+            .bipBeepBipBeepBipBeepBipBeep,
+            .bipBip,
+            .beep,
+            .beepBeepBeep,
+            .beeeeeep,
+            .bipBipBipbipBipBip,
+            .beeepBeeep
+        ]
+        
+        public init(rawValue: UInt8) {
+            self.rawValue = rawValue
         }
     }
     
@@ -61,7 +77,7 @@ public struct CancelDeliveryCommand : MessageBlock {
     
     public let deliveryType: DeliveryType
     
-    public let cancelType: CancelType
+    public let beepType: BeepType
     
     let nonce: UInt32
     
@@ -71,7 +87,7 @@ public struct CancelDeliveryCommand : MessageBlock {
             5,
             ])
         data.appendBigEndian(nonce)
-        data.append((cancelType.rawValue << 4) + deliveryType.rawValue)
+        data.append((beepType.rawValue << 4) + deliveryType.rawValue)
         return data
     }
     
@@ -81,14 +97,12 @@ public struct CancelDeliveryCommand : MessageBlock {
         }
         self.nonce = encodedData[2...].toBigEndian(UInt32.self)
         self.deliveryType = DeliveryType(rawValue: encodedData[6] & 0xf)
-        
-        let unknownHighBits = encodedData[6] >> 4
-        cancelType = unknownHighBits == 0 ? .suspend : .normal
+        self.beepType = BeepType(rawValue: encodedData[6] >> 4)
     }
     
-    public init(nonce: UInt32, deliveryType: DeliveryType, cancelType: CancelType = .normal) {
+    public init(nonce: UInt32, deliveryType: DeliveryType, beepType: BeepType) {
         self.nonce = nonce
         self.deliveryType = deliveryType
-        self.cancelType = cancelType
+        self.beepType = beepType
     }
 }

--- a/OmniKit/MessageBlocks/CancelDeliveryCommand.swift
+++ b/OmniKit/MessageBlocks/CancelDeliveryCommand.swift
@@ -26,34 +26,16 @@ public struct CancelDeliveryCommand : MessageBlock {
         }
     }
     
-    public struct BeepType: OptionSet {
-        public let rawValue: UInt8
-        
-        static let noBeep = BeepType(rawValue: 0)
-        static let beepBeepBeepBeep = BeepType(rawValue: 1)
-        static let bipBeepBipBeepBipBeepBipBeep = BeepType(rawValue: 2)
-        static let bipBip = BeepType(rawValue: 3)
-        static let beep = BeepType(rawValue: 4)
-        static let beepBeepBeep = BeepType(rawValue: 5)
-        static let beeeeeep = BeepType(rawValue: 6)
-        static let bipBipBipbipBipBip = BeepType(rawValue: 7)
-        static let beeepBeeep = BeepType(rawValue: 8)
-        
-        static let all: BeepType = [
-            .noBeep,
-            .beepBeepBeepBeep,
-            .bipBeepBipBeepBipBeepBipBeep,
-            .bipBip,
-            .beep,
-            .beepBeepBeep,
-            .beeeeeep,
-            .bipBipBipbipBipBip,
-            .beeepBeeep
-        ]
-        
-        public init(rawValue: UInt8) {
-            self.rawValue = rawValue
-        }
+    public enum BeepType: UInt8 {
+        case noBeep = 0
+        case beepBeepBeepBeep = 1
+        case bipBeepBipBeepBipBeepBipBeep = 2
+        case bipBip = 3
+        case beep = 4
+        case beepBeepBeep = 5
+        case beeeeeep = 6
+        case bipBipBipbipBipBip = 7
+        case beeepBeeep = 8
     }
     
     // ID1:1f00ee84 PTYPE:PDM SEQ:26 ID2:1f00ee84 B9:ac BLEN:7 MTYPE:1f05 BODY:e1f78752078196 CRC:03
@@ -97,7 +79,7 @@ public struct CancelDeliveryCommand : MessageBlock {
         }
         self.nonce = encodedData[2...].toBigEndian(UInt32.self)
         self.deliveryType = DeliveryType(rawValue: encodedData[6] & 0xf)
-        self.beepType = BeepType(rawValue: encodedData[6] >> 4)
+        self.beepType = BeepType(rawValue: encodedData[6] >> 4)!
     }
     
     public init(nonce: UInt32, deliveryType: DeliveryType, beepType: BeepType) {

--- a/OmniKit/MessageBlocks/CancelDeliveryCommand.swift
+++ b/OmniKit/MessageBlocks/CancelDeliveryCommand.swift
@@ -26,18 +26,6 @@ public struct CancelDeliveryCommand : MessageBlock {
         }
     }
     
-    public enum BeepType: UInt8 {
-        case noBeep = 0
-        case beepBeepBeepBeep = 1
-        case bipBeepBipBeepBipBeepBipBeep = 2
-        case bipBip = 3
-        case beep = 4
-        case beepBeepBeep = 5
-        case beeeeeep = 6
-        case bipBipBipbipBipBip = 7
-        case beeepBeeep = 8
-    }
-    
     // ID1:1f00ee84 PTYPE:PDM SEQ:26 ID2:1f00ee84 B9:ac BLEN:7 MTYPE:1f05 BODY:e1f78752078196 CRC:03
     
     // Cancel bolus
@@ -59,7 +47,7 @@ public struct CancelDeliveryCommand : MessageBlock {
     
     public let deliveryType: DeliveryType
     
-    public let beepType: BeepType
+    public let beepType: ConfigureAlertsCommand.BeepType
     
     let nonce: UInt32
     
@@ -79,10 +67,10 @@ public struct CancelDeliveryCommand : MessageBlock {
         }
         self.nonce = encodedData[2...].toBigEndian(UInt32.self)
         self.deliveryType = DeliveryType(rawValue: encodedData[6] & 0xf)
-        self.beepType = BeepType(rawValue: encodedData[6] >> 4)!
+        self.beepType = ConfigureAlertsCommand.BeepType(rawValue: encodedData[6] >> 4)!
     }
     
-    public init(nonce: UInt32, deliveryType: DeliveryType, beepType: BeepType) {
+    public init(nonce: UInt32, deliveryType: DeliveryType, beepType: ConfigureAlertsCommand.BeepType) {
         self.nonce = nonce
         self.deliveryType = deliveryType
         self.beepType = beepType

--- a/OmniKit/MessageBlocks/ConfigureAlertsCommand.swift
+++ b/OmniKit/MessageBlocks/ConfigureAlertsCommand.swift
@@ -95,7 +95,8 @@ public struct ConfigureAlertsCommand : MessageBlock {
                 let minutes = UInt16(duration.minutes)
                 data.appendBigEndian(minutes)
             }
-            data.appendBigEndian(UInt16(beepType.rawValue) << 8 + UInt16(beepRepeat))
+            data.append(UInt8(beepType.rawValue))
+            data.append(UInt8(beepRepeat))
 
             return data
         }
@@ -135,8 +136,11 @@ public struct ConfigureAlertsCommand : MessageBlock {
             } else {
                 self.expirationType = .time(TimeInterval(minutes: Double(yyyy)))
             }
-            
-            self.beepType = BeepType(rawValue: encodedData[4])!
+            let beepTypeBits = encodedData[4]
+            guard let beepType = BeepType(rawValue: beepTypeBits) else {
+                throw MessageError.unknownValue(value: beepTypeBits, typeDescription: "beepType")
+            }
+            self.beepType = beepType
             
             self.beepRepeat = Int(encodedData[5])
  

--- a/OmniKit/MessageBlocks/ConfigureAlertsCommand.swift
+++ b/OmniKit/MessageBlocks/ConfigureAlertsCommand.swift
@@ -136,9 +136,10 @@ public struct ConfigureAlertsCommand : MessageBlock {
             } else {
                 self.expirationType = .time(TimeInterval(minutes: Double(yyyy)))
             }
+            
             let beepTypeBits = encodedData[4]
             guard let beepType = BeepType(rawValue: beepTypeBits) else {
-                throw MessageError.unknownValue(value: beepTypeBits, typeDescription: "beepType")
+                throw MessageError.unknownValue(value: beepTypeBits, typeDescription: "BeepType")
             }
             self.beepType = beepType
             

--- a/OmniKit/MessageBlocks/ConfigureAlertsCommand.swift
+++ b/OmniKit/MessageBlocks/ConfigureAlertsCommand.swift
@@ -64,7 +64,7 @@ public struct ConfigureAlertsCommand : MessageBlock {
         let audible: Bool
         let duration: TimeInterval
         let beepType: BeepType
-        let beepRepeat: Int
+        let beepRepeat: UInt8
         let autoOffModifier: Bool
         
         static let length = 6
@@ -95,13 +95,13 @@ public struct ConfigureAlertsCommand : MessageBlock {
                 let minutes = UInt16(duration.minutes)
                 data.appendBigEndian(minutes)
             }
-            data.append(UInt8(beepType.rawValue))
-            data.append(UInt8(beepRepeat))
+            data.append(beepType.rawValue)
+            data.append(beepRepeat)
 
             return data
         }
         
-        public init(alertType: AlertType, audible: Bool, autoOffModifier: Bool, duration: TimeInterval, expirationType: ExpirationType, beepType: BeepType, beepRepeat: Int) {
+        public init(alertType: AlertType, audible: Bool, autoOffModifier: Bool, duration: TimeInterval, expirationType: ExpirationType, beepType: BeepType, beepRepeat: UInt8) {
             self.alertType = alertType
             self.audible = audible
             self.autoOffModifier = autoOffModifier
@@ -142,7 +142,7 @@ public struct ConfigureAlertsCommand : MessageBlock {
             }
             self.beepType = beepType
             
-            self.beepRepeat = Int(encodedData[5])
+            self.beepRepeat = encodedData[5]
  
         }
     }

--- a/OmniKit/PodCommsSession.swift
+++ b/OmniKit/PodCommsSession.swift
@@ -70,14 +70,14 @@ public class PodCommsSession {
 
     public func configurePod() throws {
         //4c00 00c8 0102
-        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .lowReservoir, audible: true, autoOffModifier: false, duration: 0, expirationType: .reservoir(volume: 20), beepType: 0x0102)
+        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .lowReservoir, audible: true, autoOffModifier: false, duration: 0, expirationType: .reservoir(volume: 20), beepType: .beepBeepBeepBeep, beepRepeat: 2)
         
         let configureAlerts1 = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations:[alertConfig1])
         let _: StatusResponse = try send([configureAlerts1])
         podState.advanceToNextNonce()
         
         //7837 0005 0802
-        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible:true, autoOffModifier: false, duration: .minutes(55), expirationType: .time(.minutes(5)), beepType: 0x0802)
+        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible:true, autoOffModifier: false, duration: .minutes(55), expirationType: .time(.minutes(5)), beepType: .beeepBeeep, beepRepeat: 2)
         let configureAlerts2 = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations:[alertConfig2])
         let _: StatusResponse = try send([configureAlerts2])
         podState.advanceToNextNonce()
@@ -95,7 +95,7 @@ public class PodCommsSession {
     
     public func finishPrime() throws {
         // 3800 0ff0 0302
-        let alertConfig = ConfigureAlertsCommand.AlertConfiguration(alertType: .expirationAdvisory, audible: false, autoOffModifier: false, duration: .minutes(0), expirationType: .time(.hours(68)), beepType: 0x0302)
+        let alertConfig = ConfigureAlertsCommand.AlertConfiguration(alertType: .expirationAdvisory, audible: false, autoOffModifier: false, duration: .minutes(0), expirationType: .time(.hours(68)), beepType: .bipBip, beepRepeat: 2)
         let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations:[alertConfig])
         let _: StatusResponse = try send([configureAlerts])
         podState.advanceToNextNonce()
@@ -121,7 +121,7 @@ public class PodCommsSession {
         podState.advanceToNextNonce()
     }
     
-    public func cancelDelivery(deliveryType: CancelDeliveryCommand.DeliveryType, beepType:CancelDeliveryCommand.BeepType) throws {
+    public func cancelDelivery(deliveryType: CancelDeliveryCommand.DeliveryType, beepType:ConfigureAlertsCommand.BeepType) throws {
         
         let cancelDelivery = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: deliveryType, beepType: beepType)
         
@@ -161,14 +161,14 @@ public class PodCommsSession {
         // 79a4 10df 0502
         // Pod expires 1 minute short of 3 days
         let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
-        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible: true, autoOffModifier: false, duration: .minutes(164), expirationType: .time(podSoftExpirationTime), beepType: 0x0502)
+        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible: true, autoOffModifier: false, duration: .minutes(164), expirationType: .time(podSoftExpirationTime), beepType: .beepBeepBeep, beepRepeat: 2)
         
         // 2800 1283 0602
         let podHardExpirationTime = TimeInterval(hours:79) - TimeInterval(minutes:1)
-        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .endOfService, audible: true, autoOffModifier: false, duration: .minutes(0), expirationType: .time(podHardExpirationTime), beepType: 0x0602)
+        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .endOfService, audible: true, autoOffModifier: false, duration: .minutes(0), expirationType: .time(podHardExpirationTime), beepType: .beeeeeep, beepRepeat: 2)
         
         // 020f 0000 0202
-        let alertConfig3 = ConfigureAlertsCommand.AlertConfiguration(alertType: .autoOff, audible: false, autoOffModifier: true, duration: .minutes(15), expirationType: .time(0), beepType: 0x0202)
+        let alertConfig3 = ConfigureAlertsCommand.AlertConfiguration(alertType: .autoOff, audible: false, autoOffModifier: true, duration: .minutes(15), expirationType: .time(0), beepType: .bipBeepBipBeepBipBeepBipBeep, beepRepeat: 2) // Would like to change this to be less annoying, for example .bipBipBipbipBipBip
 
         let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations:[alertConfig1, alertConfig2, alertConfig3])
 

--- a/OmniKit/PodCommsSession.swift
+++ b/OmniKit/PodCommsSession.swift
@@ -121,9 +121,9 @@ public class PodCommsSession {
         podState.advanceToNextNonce()
     }
     
-    public func cancelTempBasal() throws {
+    public func cancelDelivery(deliveryType: CancelDeliveryCommand.DeliveryType, beepType:CancelDeliveryCommand.BeepType) throws {
         
-        let cancelDelivery = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .tempBasal)
+        let cancelDelivery = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: deliveryType, beepType: beepType)
         
         let _: StatusResponse = try send([cancelDelivery])
         
@@ -131,8 +131,10 @@ public class PodCommsSession {
     }
     
     public func testingCommands() throws {
-        //try setTempBasal(rate: 1.0, duration: .minutes(30), confidenceReminder: false, programReminderInterval: .minutes(0))
-        try bolus(units: 1)
+        //try setTempBasal(rate: 2.5, duration: .minutes(30), confidenceReminder: false, programReminderInterval: .minutes(0))
+        //try cancelDelivery(deliveryType: .tempBasal, beepType: .noBeep)
+        //try bolus(units: 20)
+        //try cancelDelivery(deliveryType: .bolus, beepType: .bipBip)
     }
     
     public func setTime(basalSchedule: BasalSchedule, timeZone: TimeZone, date: Date) throws {
@@ -198,7 +200,7 @@ public class PodCommsSession {
     
     public func changePod() throws {
         
-        let cancelDelivery = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, cancelType: .suspend)
+        let cancelDelivery = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .beeepBeeep)
         let _: StatusResponse = try send([cancelDelivery])
         podState.advanceToNextNonce()
 

--- a/OmniKitTests/BasalScheduleTests.swift
+++ b/OmniKitTests/BasalScheduleTests.swift
@@ -119,5 +119,21 @@ class BasalScheduleTests: XCTestCase {
         XCTAssertEqual(0.05, rateEntry.rate)
         XCTAssertEqual(TimeInterval(hours: 24), rateEntry.duration, accuracy: 0.001)
     }
+    
+    func testSuspendBasalCommand() {
+        do {
+            // Decode 1f 05 6fede14a 01
+            let cmd = try CancelDeliveryCommand(encodedData: Data(hexadecimalString: "1f056fede14a01")!)
+            XCTAssertEqual(0x6fede14a, cmd.nonce)
+            XCTAssertEqual(.noBeep, cmd.beepType)
+            XCTAssertEqual(.basal, cmd.deliveryType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = CancelDeliveryCommand(nonce: 0x6fede14a, deliveryType: .basal, beepType: .noBeep)
+        XCTAssertEqual("1f056fede14a01", cmd.data.hexadecimalString)
+    }
 }
 

--- a/OmniKitTests/BolusTests.swift
+++ b/OmniKitTests/BolusTests.swift
@@ -1,0 +1,75 @@
+//
+//  BolusTests.swift
+//  OmniKitTests
+//
+//  Created by Eelke Jager on 04/09/2018.
+//  Copyright © 2018 Pete Schwamb. All rights reserved.
+//
+
+import XCTest
+@testable import OmniKit
+
+class BolusTests: XCTestCase {
+    
+    func testSetBolusCommand() {
+        //    2017-09-11T11:07:57.476872 ID1:1f08ced2 PTYPE:PDM SEQ:18 ID2:1f08ced2 B9:18 BLEN:31 MTYPE:1a0e BODY:bed2e16b02010a0101a000340034170d000208000186a0 CRC:fd
+        //    2017-09-11T11:07:57.552574 ID1:1f08ced2 PTYPE:ACK SEQ:19 ID2:1f08ced2 CRC:b8
+        //    2017-09-11T11:07:57.734557 ID1:1f08ced2 PTYPE:CON SEQ:20 CON:00000000000003c0 CRC:a9
+        
+        do {
+            // Decode
+            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a0ebed2e16b02010a0101a000340034")!)
+            XCTAssertEqual(0xbed2e16b, cmd.nonce)
+            
+            if case SetInsulinScheduleCommand.DeliverySchedule.bolus(let units, let multiplier) = cmd.deliverySchedule {
+                XCTAssertEqual(2.6, units)
+                XCTAssertEqual(0x8, multiplier)
+            } else {
+                XCTFail("Expected ScheduleEntry.bolus type")
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: 2.6, multiplier: 0x8)
+        let cmd = SetInsulinScheduleCommand(nonce: 0xbed2e16b, deliverySchedule: scheduleEntry)
+        XCTAssertEqual("1a0ebed2e16b02010a0101a000340034", cmd.data.hexadecimalString)
+    }
+
+    func testBolusExtraCommand() {
+        // 30U bolus
+        // 170d 7c 1770 00030d40 000000000000
+        
+        do {
+            // Decode
+            let cmd = try BolusExtraCommand(encodedData: Data(hexadecimalString: "170d7c177000030d40000000000000")!)
+            XCTAssertEqual(30.0, cmd.units)
+            XCTAssertEqual(0x7c, cmd.byte2)
+            XCTAssertEqual(Data(hexadecimalString: "00030d40"), cmd.unknownSection)
+            
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = BolusExtraCommand(units: 2.6, byte2: 0, unknownSection: Data(hexadecimalString: "000186a0")!)
+        XCTAssertEqual("170d000208000186a0000000000000", cmd.data.hexadecimalString)
+    }
+    
+    func testCancelBolusCommand() {
+        do {
+            // Decode 1f 05 4d91f8ff 64
+            let cmd = try CancelDeliveryCommand(encodedData: Data(hexadecimalString: "1f054d91f8ff64")!)
+            XCTAssertEqual(0x4d91f8ff, cmd.nonce)
+            XCTAssertEqual(.beeeeeep, cmd.beepType)
+            XCTAssertEqual(.bolus, cmd.deliveryType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = CancelDeliveryCommand(nonce: 0x4d91f8ff, deliveryType: .bolus, beepType: .beeeeeep)
+        XCTAssertEqual("1f054d91f8ff64", cmd.data.hexadecimalString)
+    }
+}

--- a/OmniKitTests/MessageTests.swift
+++ b/OmniKitTests/MessageTests.swift
@@ -190,16 +190,16 @@ class MessageTests: XCTestCase {
         // 79a4 10df 0502
         // Pod expires 1 minute short of 3 days
         let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
-        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible: true, autoOffModifier: false, duration: .hours(7), expirationType: .time(podSoftExpirationTime), beepType: 0x0502)
+        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible: true, autoOffModifier: false, duration: .hours(7), expirationType: .time(podSoftExpirationTime), beepType: .beepBeepBeep, beepRepeat: 2)
         XCTAssertEqual("79a410df0502", alertConfig1.data.hexadecimalString)
 
         // 2800 1283 0602
         let podHardExpirationTime = TimeInterval(hours:79) - TimeInterval(minutes:1)
-        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .endOfService, audible: true, autoOffModifier: false, duration: .minutes(0), expirationType: .time(podHardExpirationTime), beepType: 0x0602)
+        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .endOfService, audible: true, autoOffModifier: false, duration: .minutes(0), expirationType: .time(podHardExpirationTime), beepType: .beeeeeep, beepRepeat: 2)
         XCTAssertEqual("280012830602", alertConfig2.data.hexadecimalString)
 
         // 020f 0000 0202
-        let alertConfig3 = ConfigureAlertsCommand.AlertConfiguration(alertType: .autoOff, audible: false, autoOffModifier: true, duration: .minutes(15), expirationType: .time(0), beepType: 0x0202)
+        let alertConfig3 = ConfigureAlertsCommand.AlertConfiguration(alertType: .autoOff, audible: false, autoOffModifier: true, duration: .minutes(15), expirationType: .time(0), beepType: .bipBeepBipBeepBipBeepBipBeep, beepRepeat: 2)
         XCTAssertEqual("020f00000202", alertConfig3.data.hexadecimalString)
         
         let configureAlerts = ConfigureAlertsCommand(nonce: 0xfeb6268b, configurations:[alertConfig1, alertConfig2, alertConfig3])
@@ -217,7 +217,7 @@ class MessageTests: XCTestCase {
             if case ConfigureAlertsCommand.ExpirationType.time(let duration) = config1.expirationType {
                 XCTAssertEqual(podSoftExpirationTime, duration)
             }
-            XCTAssertEqual(0x0502, config1.beepType)
+            XCTAssertEqual(.beepBeepBeep, config1.beepType)
             
             let cfg = try ConfigureAlertsCommand.AlertConfiguration(encodedData: Data(hexadecimalString: "4c0000640102")!)
             XCTAssertEqual(.lowReservoir, cfg.alertType)
@@ -227,7 +227,7 @@ class MessageTests: XCTestCase {
             if case ConfigureAlertsCommand.ExpirationType.reservoir(let volume) = cfg.expirationType {
                 XCTAssertEqual(10, volume)
             }
-            XCTAssertEqual(0x0102, cfg.beepType)
+            XCTAssertEqual(.beepBeepBeepBeep, cfg.beepType)
 
 
         } catch (let error) {

--- a/OmniKitTests/MessageTests.swift
+++ b/OmniKitTests/MessageTests.swift
@@ -150,32 +150,6 @@ class MessageTests: XCTestCase {
         }
     }
     
-    func testSetBolusCommand() {
-        //    2017-09-11T11:07:57.476872 ID1:1f08ced2 PTYPE:PDM SEQ:18 ID2:1f08ced2 B9:18 BLEN:31 MTYPE:1a0e BODY:bed2e16b02010a0101a000340034170d000208000186a0 CRC:fd
-        //    2017-09-11T11:07:57.552574 ID1:1f08ced2 PTYPE:ACK SEQ:19 ID2:1f08ced2 CRC:b8
-        //    2017-09-11T11:07:57.734557 ID1:1f08ced2 PTYPE:CON SEQ:20 CON:00000000000003c0 CRC:a9
-
-        do {
-            // Decode
-            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a0ebed2e16b02010a0101a000340034")!)
-            XCTAssertEqual(0xbed2e16b, cmd.nonce)
-            
-            if case SetInsulinScheduleCommand.DeliverySchedule.bolus(let units, let multiplier) = cmd.deliverySchedule {
-                XCTAssertEqual(2.6, units)
-                XCTAssertEqual(0x8, multiplier)
-            } else {
-                XCTFail("Expected ScheduleEntry.bolus type")
-            }
-        } catch (let error) {
-            XCTFail("message decoding threw error: \(error)")
-        }
-        
-        // Encode
-        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: 2.6, multiplier: 0x8)
-        let cmd = SetInsulinScheduleCommand(nonce: 0xbed2e16b, deliverySchedule: scheduleEntry)
-        XCTAssertEqual("1a0ebed2e16b02010a0101a000340034", cmd.data.hexadecimalString)
-    }
-    
     func testInsertCannula() {
 //        2018-04-03T19:23:14.3d ID1:1f00ee85 PTYPE:PDM SEQ:17 ID2:1f00ee85 B9:38 BLEN:31 BODY:1a0e7e30bf16020065010050000a000a170d000064000186a0 CRC:33
 //        2018-04-03T19:23:14.3d ID1:1f00ee85 PTYPE:ACK SEQ:18 ID2:1f00ee85 CRC:89
@@ -197,27 +171,6 @@ class MessageTests: XCTestCase {
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
-    }
-
-    
-    func testBolusExtraCommand() {
-        // 30U bolus
-        // 170d 7c 1770 00030d40 000000000000
-        
-        do {
-            // Decode
-            let cmd = try BolusExtraCommand(encodedData: Data(hexadecimalString: "170d7c177000030d40000000000000")!)
-            XCTAssertEqual(30.0, cmd.units)
-            XCTAssertEqual(0x7c, cmd.byte2)
-            XCTAssertEqual(Data(hexadecimalString: "00030d40"), cmd.unknownSection)
-
-        } catch (let error) {
-            XCTFail("message decoding threw error: \(error)")
-        }
-        
-        // Encode
-        let cmd = BolusExtraCommand(units: 2.6, byte2: 0, unknownSection: Data(hexadecimalString: "000186a0")!)
-        XCTAssertEqual("170d000208000186a0000000000000", cmd.data.hexadecimalString)
     }
     
     func testStatusResponseAlarmsParsing() {
@@ -280,8 +233,6 @@ class MessageTests: XCTestCase {
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
-
-
     }
 }
 

--- a/OmniKitTests/TempBasalTests.swift
+++ b/OmniKitTests/TempBasalTests.swift
@@ -89,6 +89,37 @@ class TempBasalTests: XCTestCase {
         let cmd = SetInsulinScheduleCommand(nonce: 0x87e8d03a, tempBasalRate: 2, duration: .hours(1.5))
         XCTAssertEqual("1a0e87e8d03a0100cb03384000142014", cmd.data.hexadecimalString)
     }
+
+    func testCancelTempBasalCommand() {
+        do {
+            // Decode 1f 05 f76d34c4 62
+            let cmd = try CancelDeliveryCommand(encodedData: Data(hexadecimalString: "1f05f76d34c462")!)
+            XCTAssertEqual(0xf76d34c4, cmd.nonce)
+            XCTAssertEqual(.beeeeeep, cmd.beepType)
+            XCTAssertEqual(.tempBasal, cmd.deliveryType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = CancelDeliveryCommand(nonce: 0xf76d34c4, deliveryType: .tempBasal, beepType: .beeeeeep)
+        XCTAssertEqual("1f05f76d34c462", cmd.data.hexadecimalString)
+    }
+    
+    func testCancelTempBasalnoBeepCommand() {
+        do {
+            let cmd = try CancelDeliveryCommand(encodedData: Data(hexadecimalString: "1f05f76d34c402")!)
+            XCTAssertEqual(0xf76d34c4, cmd.nonce)
+            XCTAssertEqual(.noBeep, cmd.beepType)
+            XCTAssertEqual(.tempBasal, cmd.deliveryType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = CancelDeliveryCommand(nonce: 0xf76d34c4, deliveryType: .tempBasal, beepType: .noBeep)
+        XCTAssertEqual("1f05f76d34c402", cmd.data.hexadecimalString)
+    }
     
     func testTempBasalExtremeValues() {
         do {


### PR DESCRIPTION
This looks like a lot better PR. ;-)
I've updated cancelDelivery.
Added tests with cancel temp basal and bolus.
Fixed the missing values cancelDelivery variables in the podSessions.

The suspend command still needs to be added into this with this test: 1f 05 b15898b0 `03` which I also have ready, but I wanted to make it testable with a 0x19 command as well.