### PR TITLE
Omnipod testing fix receiver low gain radio rssi

### DIFF
--- a/MinimedKitTests/HistoryPageTests.swift
+++ b/MinimedKitTests/HistoryPageTests.swift
@@ -296,7 +296,7 @@ class HistoryPageTests: XCTestCase {
         XCTAssertEqual(126, events.count)
 
         let alarm = events[9] as! PumpAlarmPumpEvent
-        XCTAssertEqual("unknownType(21)", "\(alarm.alarmType)")
+        XCTAssertEqual("unknownType(rawType: 21)", "\(alarm.alarmType)")
         XCTAssertEqual(DateComponents(gregorianYear: 2007, month: 1, day: 1, hour: 0, minute: 0, second: 0), alarm.timestamp)
 
         let batteryDepletedAlarm = events[13] as! PumpAlarmPumpEvent

--- a/OmniKit/MessageTransport/MessageBlocks/PodInfoFaultEvent.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/PodInfoFaultEvent.swift
@@ -72,9 +72,9 @@ public struct PodInfoFaultEvent : PodInfo, Equatable {
         
         self.reservoirStatusAtFirstLoggedFaultEvent = reservoirStatusAtFirstLoggedFaultEventType
         
-        self.receiverLowGain = encodedData[18] >> 4
+        self.receiverLowGain = encodedData[18] >> 6
         
-        self.radioRSSI =  encodedData[18] & 0xF
+        self.radioRSSI =  encodedData[18] & 0x3F
         
         guard let reservoirStatusAtFirstLoggedFaultEventCheckType = ReservoirStatus(rawValue: encodedData[19] & 0xF) else {
             throw MessageError.unknownValue(value: encodedData[19] & 0xF, typeDescription: "ReservoirStatus")
@@ -103,7 +103,7 @@ extension PodInfoFaultEvent: CustomDebugStringConvertible {
             "timeActive: \(timeActive)",
             "logEventError: \(logEventError)",
             "reservoirStatusAtFirstLoggedFaultEvent: \(reservoirStatusAtFirstLoggedFaultEvent)",
-            "recieverLowGain: \(recieverLowGain)",
+            "receiverLowGain: \(receiverLowGain)",
             "radioRSSI: \(radioRSSI)",
             "reservoirStatusAtFirstLoggedFaultEventCheck: \(reservoirStatusAtFirstLoggedFaultEventCheck)",
             "insulinStateTableCorruption: \(insulinStateTableCorruption)",

--- a/OmniKit/MessageTransport/MessageBlocks/PodInfoFaultEvent.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/PodInfoFaultEvent.swift
@@ -24,8 +24,8 @@ public struct PodInfoFaultEvent : PodInfo, Equatable {
     public let secondaryLoggedFaultEvent: FaultEventCode
     public let logEventError: Bool
     public let reservoirStatusAtFirstLoggedFaultEvent: ReservoirStatus
-    public let receiverLowGain: UInt8
-    public let radioRSSI: UInt8
+    public let receiverLowGain: Int8
+    public let radioRSSI: Int8
     public let reservoirStatusAtFirstLoggedFaultEventCheck: ReservoirStatus
     public let insulinStateTableCorruption: Bool
     public let immediateBolusInProgress: Bool

--- a/OmniKit/MessageTransport/MessageBlocks/PodInfoFaultEvent.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/PodInfoFaultEvent.swift
@@ -72,9 +72,9 @@ public struct PodInfoFaultEvent : PodInfo, Equatable {
         
         self.reservoirStatusAtFirstLoggedFaultEvent = reservoirStatusAtFirstLoggedFaultEventType
         
-        self.receiverLowGain = encodedData[18] >> 6
+        self.receiverLowGain = Int8(encodedData[18] >> 6)
         
-        self.radioRSSI =  encodedData[18] & 0x3F
+        self.radioRSSI =  Int8(encodedData[18] & 0x3F)
         
         guard let reservoirStatusAtFirstLoggedFaultEventCheckType = ReservoirStatus(rawValue: encodedData[19] & 0xF) else {
             throw MessageError.unknownValue(value: encodedData[19] & 0xF, typeDescription: "ReservoirStatus")

--- a/OmniKit/MessageTransport/MessageBlocks/PodInfoFaultEvent.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/PodInfoFaultEvent.swift
@@ -10,21 +10,7 @@ import Foundation
 
 public struct PodInfoFaultEvent : PodInfo, Equatable {
     // https://github.com/openaps/openomni/wiki/Command-02-Status-Error-response
-    
-//    public enum lengthType: UInt8{
-//        case normal = 0x10
-//        case configuredAlerts = 0x13
-//        case faultEvents = 0x16
-//        case dataLog = 0x04*numberOfWords+0x08
-//        case faultDataInitializationTime = 0x11
-//        case hardcodedValues  = 0x5
-//        case resetStatus = numberOfBytes & 0x03
-//        case dumpRecentFlashLog = 0x13
-//        case dumpOlderFlashlog = 0x14
-//
-    // public let numberOfWords: UInt8 = 60
-    // public let numberOfBytes: UInt8 = 10
-    
+        
     public var podInfoType: PodInfoResponseSubType = .faultEvents
     public let reservoirStatus: ReservoirStatus
     public let deliveryType: DeliveryType
@@ -38,7 +24,7 @@ public struct PodInfoFaultEvent : PodInfo, Equatable {
     public let secondaryLoggedFaultEvent: FaultEventCode
     public let logEventError: Bool
     public let reservoirStatusAtFirstLoggedFaultEvent: ReservoirStatus
-    public let recieverLowGain: UInt8
+    public let receiverLowGain: UInt8
     public let radioRSSI: UInt8
     public let reservoirStatusAtFirstLoggedFaultEventCheck: ReservoirStatus
     public let insulinStateTableCorruption: Bool
@@ -86,7 +72,7 @@ public struct PodInfoFaultEvent : PodInfo, Equatable {
         
         self.reservoirStatusAtFirstLoggedFaultEvent = reservoirStatusAtFirstLoggedFaultEventType
         
-        self.recieverLowGain = encodedData[18] >> 4
+        self.receiverLowGain = encodedData[18] >> 4
         
         self.radioRSSI =  encodedData[18] & 0xF
         

--- a/OmniKitTests/PodInfoTests.swift
+++ b/OmniKitTests/PodInfoTests.swift
@@ -123,7 +123,7 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(false, decoded.logEventError)
             XCTAssertEqual(false, decoded.insulinStateTableCorruption)
             XCTAssertEqual(.initialized, decoded.reservoirStatusAtFirstLoggedFaultEvent)
-            XCTAssertEqual(9, decoded.recieverLowGain)
+            XCTAssertEqual(9, decoded.receiverLowGain)
             XCTAssertEqual(5, decoded.radioRSSI)
             XCTAssertEqual(.inactive, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
         } catch (let error) {
@@ -150,7 +150,7 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(false, decoded.logEventError)
             XCTAssertEqual(false, decoded.insulinStateTableCorruption)
             XCTAssertEqual(.readyForInjection, decoded.reservoirStatusAtFirstLoggedFaultEvent)
-            XCTAssertEqual(10, decoded.recieverLowGain)
+            XCTAssertEqual(10, decoded.receiverLowGain)
             XCTAssertEqual(1, decoded.radioRSSI)
             XCTAssertEqual(.readyForInjection, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
         } catch (let error) {
@@ -176,7 +176,7 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(false, decoded.logEventError)
             XCTAssertEqual(false, decoded.insulinStateTableCorruption)
             XCTAssertEqual(.readyForInjection, decoded.reservoirStatusAtFirstLoggedFaultEvent)
-            XCTAssertEqual(10, decoded.recieverLowGain)
+            XCTAssertEqual(10, decoded.receiverLowGain)
             XCTAssertEqual(14, decoded.radioRSSI)
             XCTAssertEqual(.readyForInjection, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
         } catch (let error) {
@@ -202,7 +202,7 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(false, decoded.logEventError)
             XCTAssertEqual(false, decoded.insulinStateTableCorruption)
             XCTAssertEqual(.pairingSuccess, decoded.reservoirStatusAtFirstLoggedFaultEvent)
-            XCTAssertEqual(10, decoded.recieverLowGain)
+            XCTAssertEqual(10, decoded.receiverLowGain)
             XCTAssertEqual(2, decoded.radioRSSI)
             XCTAssertEqual(.pairingSuccess, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
         } catch (let error) {

--- a/OmniKitTests/PodInfoTests.swift
+++ b/OmniKitTests/PodInfoTests.swift
@@ -106,7 +106,6 @@ class PodInfoTests: XCTestCase {
     
     func testPodInfoNoFaultAlerts() {
         // 02 16 (omitted) // 02 08 01 0000 0a 0038 00 0000 03ff 0087 00 00 00 95 ff 0000
-        
         do {
             // Decode
             let decoded = try PodInfoFaultEvent(encodedData: Data(hexadecimalString: "02080100000a003800000003ff008700000095ff0000")!)
@@ -123,36 +122,35 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(false, decoded.logEventError)
             XCTAssertEqual(false, decoded.insulinStateTableCorruption)
             XCTAssertEqual(.initialized, decoded.reservoirStatusAtFirstLoggedFaultEvent)
-            XCTAssertEqual(9, decoded.receiverLowGain)
-            XCTAssertEqual(5, decoded.radioRSSI)
+            XCTAssertEqual(2, decoded.receiverLowGain)
+            XCTAssertEqual(21, decoded.radioRSSI)
             XCTAssertEqual(.inactive, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
-        
     }
-    
-    func testPodInfoFaultAlert() {
-        // 02 16 02 0d 00 0000 06 0034 5c 0001 03ff 0001 00 00 05 a1 05 0186
+
+    func testPodInfoFaultEventErrorShuttingDown() {
+        // 02 16 (omitted) // 02 0d 00 0000 04 07f2 86 09ff 03ff 0a02 00 00 08 23 08
         do {
             // Decode
-            let decoded = try PodInfoFaultEvent(encodedData: Data(hexadecimalString: "020d0000000600345c000103ff0001000005a1050186")!)
+            let decoded = try PodInfoFaultEvent(encodedData: Data(hexadecimalString: "020d0000000407f28609ff03ff0a020000082308")!)
             XCTAssertEqual(.faultEvents, decoded.podInfoType)
             XCTAssertEqual(.errorEventLoggedShuttingDown, decoded.reservoirStatus)
             XCTAssertEqual(.none, decoded.deliveryType)
             XCTAssertEqual(0000, decoded.insulinNotDelivered)
-            XCTAssertEqual(6, decoded.podMessageCounter)
-            XCTAssertEqual(.deliveryErrorDuringPriming, decoded.originalLoggedFaultEvent.faultType)
-            XCTAssertEqual(0001*60, decoded.faultEventTimeSinceActivation)
+            XCTAssertEqual(4, decoded.podMessageCounter)
+            XCTAssertEqual(.faultEventSetupPodType86, decoded.originalLoggedFaultEvent.faultType)
+            XCTAssertEqual(30660, decoded.faultEventTimeSinceActivation)
             XCTAssertEqual(51.15, decoded.insulinRemaining, accuracy: 0.05)
-            XCTAssertEqual(0001*60, decoded.timeActive, accuracy: 0) // timeActive converts minutes to seconds
+            XCTAssertEqual(120, decoded.timeActive, accuracy: 0) // timeActive converts minutes to seconds
             XCTAssertEqual(.noFaults, decoded.secondaryLoggedFaultEvent.faultType)
             XCTAssertEqual(false, decoded.logEventError)
             XCTAssertEqual(false, decoded.insulinStateTableCorruption)
-            XCTAssertEqual(.readyForInjection, decoded.reservoirStatusAtFirstLoggedFaultEvent)
-            XCTAssertEqual(10, decoded.receiverLowGain)
-            XCTAssertEqual(1, decoded.radioRSSI)
-            XCTAssertEqual(.readyForInjection, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.reservoirStatusAtFirstLoggedFaultEvent)
+            XCTAssertEqual(0, decoded.receiverLowGain)
+            XCTAssertEqual(35, decoded.radioRSSI)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
@@ -176,8 +174,8 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(false, decoded.logEventError)
             XCTAssertEqual(false, decoded.insulinStateTableCorruption)
             XCTAssertEqual(.readyForInjection, decoded.reservoirStatusAtFirstLoggedFaultEvent)
-            XCTAssertEqual(10, decoded.receiverLowGain)
-            XCTAssertEqual(14, decoded.radioRSSI)
+            XCTAssertEqual(2, decoded.receiverLowGain)
+            XCTAssertEqual(46, decoded.radioRSSI)
             XCTAssertEqual(.readyForInjection, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
@@ -202,8 +200,8 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(false, decoded.logEventError)
             XCTAssertEqual(false, decoded.insulinStateTableCorruption)
             XCTAssertEqual(.pairingSuccess, decoded.reservoirStatusAtFirstLoggedFaultEvent)
-            XCTAssertEqual(10, decoded.receiverLowGain)
-            XCTAssertEqual(2, decoded.radioRSSI)
+            XCTAssertEqual(2, decoded.receiverLowGain)
+            XCTAssertEqual(34, decoded.radioRSSI)
             XCTAssertEqual(.pairingSuccess, decoded.reservoirStatusAtFirstLoggedFaultEventCheck)
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")


### PR DESCRIPTION
- Used proper masking of bits to get decode gain value and radio rssi. it now shows the values properly. (35db for example)
- Fixed the receiverLowGain typo
- Removed the unused length enum.