### PR TITLE
Fixed BeepRepeat <-> BeepType order in encoding and decoding.

### DIFF
--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -232,14 +232,14 @@ public class PodCommsSession {
 
     public func configurePod() throws {
         //4c00 00c8 0102
-        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .lowReservoir, audible: true, autoOffModifier: false, duration: 0, expirationType: .reservoir(volume: 20), beepType: .beepBeepBeepBeep, beepRepeat: 2)
+        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .lowReservoir, audible: true, autoOffModifier: false, duration: 0, expirationType: .reservoir(volume: 20), beepRepeat: .beepEvery1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .beepBeepBeepBeep)
         
         let configureAlerts1 = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations:[alertConfig1])
         let _: StatusResponse = try send([configureAlerts1])
         podState.advanceToNextNonce()
         
         //7837 0005 0802
-        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible:true, autoOffModifier: false, duration: .minutes(55), expirationType: .time(.minutes(5)), beepType: .beeepBeeep, beepRepeat: 2)
+        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible:true, autoOffModifier: false, duration: .minutes(55), expirationType: .time(.minutes(5)), beepRepeat: .beepEvery1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .beeepBeeep)
         let configureAlerts2 = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations:[alertConfig2])
         let _: StatusResponse = try send([configureAlerts2])
         podState.advanceToNextNonce()
@@ -258,7 +258,7 @@ public class PodCommsSession {
     
     public func finishPrime() throws {
         // 3800 0ff0 0302
-        let alertConfig = ConfigureAlertsCommand.AlertConfiguration(alertType: .expirationAdvisory, audible: false, autoOffModifier: false, duration: .minutes(0), expirationType: .time(.hours(68)), beepType: .bipBip, beepRepeat: 2)
+        let alertConfig = ConfigureAlertsCommand.AlertConfiguration(alertType: .expirationAdvisory, audible: false, autoOffModifier: false, duration: .minutes(0), expirationType: .time(.hours(68)), beepRepeat: .beepEvery1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .bipBip)
         let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations:[alertConfig])
         let _: StatusResponse = try send([configureAlerts])
         podState.advanceToNextNonce()
@@ -407,14 +407,14 @@ public class PodCommsSession {
         // 79a4 10df 0502
         // Pod expires 1 minute short of 3 days
         let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
-        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible: true, autoOffModifier: false, duration: .minutes(164), expirationType: .time(podSoftExpirationTime), beepType: .beepBeepBeep, beepRepeat: 2)
+        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible: true, autoOffModifier: false, duration: .minutes(164), expirationType: .time(podSoftExpirationTime), beepRepeat: .beepEvery1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .beepBeepBeep)
         
         // 2800 1283 0602
         let podHardExpirationTime = TimeInterval(hours:79) - TimeInterval(minutes:1)
-        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .endOfService, audible: true, autoOffModifier: false, duration: .minutes(0), expirationType: .time(podHardExpirationTime), beepType: .beeeeeep, beepRepeat: 2)
+        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .endOfService, audible: true, autoOffModifier: false, duration: .minutes(0), expirationType: .time(podHardExpirationTime), beepRepeat: .beepEvery1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .beeeeeep)
         
         // 020f 0000 0202
-        let alertConfig3 = ConfigureAlertsCommand.AlertConfiguration(alertType: .autoOff, audible: false, autoOffModifier: true, duration: .minutes(15), expirationType: .time(0), beepType: .bipBeepBipBeepBipBeepBipBeep, beepRepeat: 2) // Would like to change this to be less annoying, for example .bipBipBipbipBipBip
+        let alertConfig3 = ConfigureAlertsCommand.AlertConfiguration(alertType: .autoOff, audible: false, autoOffModifier: true, duration: .minutes(15), expirationType: .time(0), beepRepeat: .beepEvery1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .bipBipBipbipBipBip) // Changed this to be less annoying, from .bipBeepBipBeepbiBeepBipBeep
 
         let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations:[alertConfig1, alertConfig2, alertConfig3])
 

--- a/OmniKitTests/MessageTests.swift
+++ b/OmniKitTests/MessageTests.swift
@@ -190,16 +190,16 @@ class MessageTests: XCTestCase {
         // 79a4 10df 0502
         // Pod expires 1 minute short of 3 days
         let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
-        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible: true, autoOffModifier: false, duration: .hours(7), expirationType: .time(podSoftExpirationTime), beepType: .beepBeepBeep, beepRepeat: 2)
+        let alertConfig1 = ConfigureAlertsCommand.AlertConfiguration(alertType: .timerLimit, audible: true, autoOffModifier: false, duration: .hours(7), expirationType: .time(podSoftExpirationTime),  beepRepeat: .beepEvery60minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
         XCTAssertEqual("79a410df0502", alertConfig1.data.hexadecimalString)
 
         // 2800 1283 0602
         let podHardExpirationTime = TimeInterval(hours:79) - TimeInterval(minutes:1)
-        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .endOfService, audible: true, autoOffModifier: false, duration: .minutes(0), expirationType: .time(podHardExpirationTime), beepType: .beeeeeep, beepRepeat: 2)
+        let alertConfig2 = ConfigureAlertsCommand.AlertConfiguration(alertType: .endOfService, audible: true, autoOffModifier: false, duration: .minutes(0), expirationType: .time(podHardExpirationTime), beepRepeat: .beepEvery15minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
         XCTAssertEqual("280012830602", alertConfig2.data.hexadecimalString)
 
         // 020f 0000 0202
-        let alertConfig3 = ConfigureAlertsCommand.AlertConfiguration(alertType: .autoOff, audible: false, autoOffModifier: true, duration: .minutes(15), expirationType: .time(0), beepType: .bipBeepBipBeepBipBeepBipBeep, beepRepeat: 2)
+        let alertConfig3 = ConfigureAlertsCommand.AlertConfiguration(alertType: .autoOff, audible: false, autoOffModifier: true, duration: .minutes(15), expirationType: .time(0), beepRepeat: .beepEvery1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
         XCTAssertEqual("020f00000202", alertConfig3.data.hexadecimalString)
         
         let configureAlerts = ConfigureAlertsCommand(nonce: 0xfeb6268b, configurations:[alertConfig1, alertConfig2, alertConfig3])
@@ -217,7 +217,8 @@ class MessageTests: XCTestCase {
             if case ConfigureAlertsCommand.ExpirationType.time(let duration) = config1.expirationType {
                 XCTAssertEqual(podSoftExpirationTime, duration)
             }
-            XCTAssertEqual(.beepBeepBeep, config1.beepType)
+            XCTAssertEqual(.beepEvery60minutes, config1.beepRepeat)
+            XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, config1.beepType)
             
             let cfg = try ConfigureAlertsCommand.AlertConfiguration(encodedData: Data(hexadecimalString: "4c0000640102")!)
             XCTAssertEqual(.lowReservoir, cfg.alertType)
@@ -227,7 +228,8 @@ class MessageTests: XCTestCase {
             if case ConfigureAlertsCommand.ExpirationType.reservoir(let volume) = cfg.expirationType {
                 XCTAssertEqual(10, volume)
             }
-            XCTAssertEqual(.beepBeepBeepBeep, cfg.beepType)
+            XCTAssertEqual(.beepEvery1MinuteFor3MinutesAndRepeatEvery60Minutes, cfg.beepRepeat)
+            XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, cfg.beepType)
 
 
         } catch (let error) {

--- a/OmniKitTests/PodInfoTests.swift
+++ b/OmniKitTests/PodInfoTests.swift
@@ -273,11 +273,7 @@ class PodInfoTests: XCTestCase {
             XCTFail("message decoding threw error: \(error)")
         }
     }
-    
-    
-    
-    
-    
+
     func testPodInfoResetStatus() {
         //02 7c (omitted)// 4600791f00ee841f00ee84ff00ff00ffffffffffff0000ffffffffffffffffffffffff04060d10070000a62b0004e3db0000ffffffffffffff32cd50af0ff014eb01fe01fe06f9ff00ff0002fd649b14eb14eb07f83cc332cd05fa02fd58a700ffffffffffffffffffffffffffffffffffffffffffffffffffffff2d00658effffffffffffff2d0065
         do {


### PR DESCRIPTION
@bbassett who is working on the AndroidAPS implementation found a bug which is fixed with this PR:
_In the ConfigureAlerts command, the beep type and beep repeat are listed one way in the document and reversed in the swift code._ 
Fixed the above and also added these:
- Created enum for BeepRepeat to  know what setting you select.
- Fixed Tests to pass on enum values of BeepRepeat
- Removed whitespace from PodInfoTests