### PR TITLE
Pairingpod image clip fix

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "LoopKit/LoopKit" "0f12e7a973625be59ea617166fea7bd2e0f6d729"
+github "LoopKit/LoopKit" "864fc937bd7f30adc1ec3d918a6293987a85d6b1"

--- a/OmniKitUI/OmnipodPumpManager.storyboard
+++ b/OmniKitUI/OmnipodPumpManager.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="XLM-uO-pGZ">
-    <device id="retina3_5" orientation="portrait">
+    <device id="retina6_1" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -14,7 +14,7 @@
             <objects>
                 <navigationController id="XLM-uO-pGZ" customClass="OmnipodPumpManagerSetupViewController" customModule="OmniKitUI" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" largeTitles="YES" id="hv4-rC-Neh">
-                        <rect key="frame" x="0.0" y="20" width="320" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -30,7 +30,7 @@
             <objects>
                 <navigationController storyboardIdentifier="DevelopmentPumpSetup" id="EeD-Yo-EZn" customClass="OmnipodPumpManagerSetupViewController" customModule="OmniKitUI" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="QCx-Ao-paS">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -45,8 +45,8 @@
         <scene sceneID="IFR-Fz-Qw6">
             <objects>
                 <tableViewController id="iRh-at-Q3A" customClass="RileyLinkSetupTableViewController" customModule="RileyLinkKitUI" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" id="DeZ-9b-Mdg">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="358"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="DeZ-9b-Mdg">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <connections>
@@ -67,75 +67,89 @@
         <scene sceneID="okF-JR-4y4">
             <objects>
                 <tableViewController title="Pump Setup" id="91O-Un-vKc" userLabel="Pair Pod" customClass="PairPodSetupViewController" customModule="OmniKitUI" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" id="1wC-au-0ju">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="358"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" id="1wC-au-0ju">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <sections>
                             <tableViewSection id="T7j-wo-L8a" userLabel="Pod Image Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="124" id="qz2-NN-p0o">
-                                        <rect key="frame" x="0.0" y="35" width="320" height="124"/>
+                                        <rect key="frame" x="0.0" y="35" width="414" height="124"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qz2-NN-p0o" id="JqU-2C-uNE">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="124"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="124"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PodBottom" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-ab-vGQ">
-                                                    <rect key="frame" x="94.5" y="0.0" width="131" height="113"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <rect key="frame" x="141.5" y="0.0" width="131" height="113"/>
                                                 </imageView>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="fvP-ab-vGQ" firstAttribute="centerX" secondItem="JqU-2C-uNE" secondAttribute="centerX" id="6rH-IP-01J"/>
+                                                <constraint firstItem="fvP-ab-vGQ" firstAttribute="top" secondItem="JqU-2C-uNE" secondAttribute="top" id="8ru-dP-3bd"/>
+                                                <constraint firstItem="fvP-ab-vGQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="JqU-2C-uNE" secondAttribute="leadingMargin" id="DsF-fJ-MUn"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="fvP-ab-vGQ" secondAttribute="bottom" id="oBt-JK-gVq"/>
+                                                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="fvP-ab-vGQ" secondAttribute="trailing" id="uqF-AC-SOR"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Prepare Pod" footerTitle="NOTE: Do not remove needle cap at this time." id="EUt-xk-Rmp" userLabel="Instructions Section">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="68" id="zQ2-f5-GDP" userLabel="Instructions">
-                                        <rect key="frame" x="0.0" y="222" width="320" height="68"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="45" id="zQ2-f5-GDP" userLabel="Instructions">
+                                        <rect key="frame" x="0.0" y="222.5" width="414" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zQ2-f5-GDP" id="Ztd-hJ-cGm">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="68"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" fixedFrame="YES" text="Fill a new pod with insulin. After filling pod, listen for 2 beeps." lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dgf-Pl-Tgp">
-                                                    <rect key="frame" x="16" y="0.0" width="288" height="44"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" ambiguous="YES" text="Fill a new pod with insulin. After filling pod, listen for 2 beeps." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dgf-Pl-Tgp">
+                                                    <rect key="frame" x="16" y="2.8421709430404007e-14" width="382" height="45"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="dgf-Pl-Tgp" secondAttribute="trailing" constant="16" id="5UU-8n-xEi"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="dgf-Pl-Tgp" secondAttribute="trailing" constant="-16" id="cqS-ii-4Kb"/>
+                                                <constraint firstItem="dgf-Pl-Tgp" firstAttribute="leading" secondItem="Ztd-hJ-cGm" secondAttribute="leading" constant="16" id="fl1-S1-McC"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection id="FRI-q2-E4T" userLabel="Status Section">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="myB-Js-Bw0">
-                                        <rect key="frame" x="0.0" y="337.5" width="320" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="50" id="myB-Js-Bw0">
+                                        <rect key="frame" x="0.0" y="315" width="414" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="myB-Js-Bw0" id="vND-m3-QTC">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="50" placeholderIntrinsicHeight="50" translatesAutoresizingMaskIntoConstraints="NO" id="qG6-Ic-XqX" customClass="SetupIndicatorView" customModule="LoopKitUI">
-                                                    <rect key="frame" x="135" y="0.0" width="50" height="50"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <rect key="frame" x="182" y="0.0" width="50" height="50"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </view>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="qG6-Ic-XqX" firstAttribute="centerX" secondItem="vND-m3-QTC" secondAttribute="centerX" id="78Q-ip-Aix"/>
+                                                <constraint firstAttribute="bottom" secondItem="qG6-Ic-XqX" secondAttribute="bottom" id="pIc-EI-1Pr"/>
+                                                <constraint firstItem="qG6-Ic-XqX" firstAttribute="top" secondItem="vND-m3-QTC" secondAttribute="top" id="sS2-nP-7hf"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="PqY-xo-4Qg" rowHeight="0.0" style="IBUITableViewCellStyleDefault" id="PCK-0c-r8Z">
-                                        <rect key="frame" x="0.0" y="381.5" width="320" height="0.0"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="PqY-xo-4Qg" style="IBUITableViewCellStyleDefault" id="PCK-0c-r8Z">
+                                        <rect key="frame" x="0.0" y="365" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PCK-0c-r8Z" id="lFr-X8-3TV">
-                                            <rect key="frame" x="0.0" y="0" width="320" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="PqY-xo-4Qg">
-                                                    <rect key="frame" x="15" y="0.0" width="288" height="0.0"/>
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -167,22 +181,22 @@
         <scene sceneID="xNW-i2-fPX">
             <objects>
                 <tableViewController title="Pump Setup" id="k1Y-x4-m0a" userLabel="Insert Cannula" customClass="InsertCannulaSetupViewController" customModule="OmniKitUI" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" id="YEa-Yl-3uG">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="358"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" id="YEa-Yl-3uG">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <sections>
                             <tableViewSection id="A2Z-KG-OZa" userLabel="Pod Image Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="124" id="hsO-b9-n1S">
-                                        <rect key="frame" x="0.0" y="35" width="320" height="124"/>
+                                        <rect key="frame" x="0.0" y="35" width="414" height="124"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hsO-b9-n1S" id="MnS-FA-AjW">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="124"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="124"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PodLarge" translatesAutoresizingMaskIntoConstraints="NO" id="QH8-CP-KKu">
-                                                    <rect key="frame" x="91" y="0.0" width="138" height="113"/>
+                                                    <rect key="frame" x="138" y="0.0" width="138" height="113"/>
                                                 </imageView>
                                             </subviews>
                                             <constraints>
@@ -199,23 +213,24 @@
                             <tableViewSection headerTitle="Apply POD" footerTitle="NOTE: If cannula sticks out, press cancel." id="rcC-ke-lUP" userLabel="Instructions Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="68" id="Nsn-dD-nL6" userLabel="Instructions">
-                                        <rect key="frame" x="0.0" y="222" width="320" height="68"/>
+                                        <rect key="frame" x="0.0" y="222.5" width="414" height="68"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Nsn-dD-nL6" id="Rjj-Oz-AlR">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="68"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="68"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" text="Prepare site. Remove pod's needle cap and adhesive backing. If pod is OK, apply to site." lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SGb-Zs-lF6">
-                                                    <rect key="frame" x="16" y="0.0" width="288" height="65"/>
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="68"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="SGb-Zs-lF6" firstAttribute="leading" secondItem="Rjj-Oz-AlR" secondAttribute="leadingMargin" id="3kB-hy-rV7"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="SGb-Zs-lF6" secondAttribute="bottom" constant="-8" id="a47-yS-qlB"/>
-                                                <constraint firstItem="SGb-Zs-lF6" firstAttribute="centerX" secondItem="Rjj-Oz-AlR" secondAttribute="centerX" id="lcH-Dy-PoJ"/>
-                                                <constraint firstItem="SGb-Zs-lF6" firstAttribute="top" secondItem="Rjj-Oz-AlR" secondAttribute="top" id="xeL-sX-nbI"/>
+                                                <constraint firstItem="SGb-Zs-lF6" firstAttribute="top" secondItem="Rjj-Oz-AlR" secondAttribute="top" id="Uv9-3Q-56t"/>
+                                                <constraint firstItem="SGb-Zs-lF6" firstAttribute="leading" secondItem="Rjj-Oz-AlR" secondAttribute="leadingMargin" id="e0E-h8-DOS"/>
+                                                <constraint firstItem="SGb-Zs-lF6" firstAttribute="leading" secondItem="Rjj-Oz-AlR" secondAttribute="leadingMargin" constant="16" id="gbA-Cb-Htf"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="SGb-Zs-lF6" secondAttribute="trailing" id="j1g-5L-fHN"/>
+                                                <constraint firstAttribute="bottom" secondItem="SGb-Zs-lF6" secondAttribute="bottom" id="sl1-nw-itb"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -223,30 +238,34 @@
                             </tableViewSection>
                             <tableViewSection id="VgK-az-0oS" userLabel="Status Section">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="1" id="V0c-ku-Ha8">
-                                        <rect key="frame" x="0.0" y="337.5" width="320" height="1"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="32" id="V0c-ku-Ha8">
+                                        <rect key="frame" x="0.0" y="338" width="414" height="32"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="V0c-ku-Ha8" id="ryO-Kg-4KE">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="1"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="32"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" fixedFrame="YES" placeholderIntrinsicWidth="50" placeholderIntrinsicHeight="50" translatesAutoresizingMaskIntoConstraints="NO" id="fNn-3N-mJd" customClass="SetupIndicatorView" customModule="LoopKitUI">
-                                                    <rect key="frame" x="135" y="-1" width="50" height="22"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <view contentMode="scaleToFill" placeholderIntrinsicWidth="50" placeholderIntrinsicHeight="50" translatesAutoresizingMaskIntoConstraints="NO" id="fNn-3N-mJd" customClass="SetupIndicatorView" customModule="LoopKitUI">
+                                                    <rect key="frame" x="182" y="0.0" width="50" height="32"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </view>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="fNn-3N-mJd" secondAttribute="bottom" id="EzP-zU-M6a"/>
+                                                <constraint firstItem="fNn-3N-mJd" firstAttribute="top" secondItem="ryO-Kg-4KE" secondAttribute="top" id="c8n-ga-OZk"/>
+                                                <constraint firstItem="fNn-3N-mJd" firstAttribute="centerX" secondItem="ryO-Kg-4KE" secondAttribute="centerX" id="vbL-I0-mjm"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="DkY-8R-pUP" rowHeight="20" style="IBUITableViewCellStyleDefault" id="bHr-BP-Q9x">
-                                        <rect key="frame" x="0.0" y="338.5" width="320" height="20"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="DkY-8R-pUP" style="IBUITableViewCellStyleDefault" id="bHr-BP-Q9x">
+                                        <rect key="frame" x="0.0" y="370" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bHr-BP-Q9x" id="MMX-hw-6gS">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="DkY-8R-pUP">
-                                                    <rect key="frame" x="16" y="0.0" width="288" height="20"/>
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -272,28 +291,28 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DmI-Gw-k1w" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1476" y="230"/>
+            <point key="canvasLocation" x="1476" y="230.54187192118226"/>
         </scene>
         <!--Setup Complete-->
         <scene sceneID="hkh-fg-zc5">
             <objects>
                 <tableViewController title="Pump Setup" id="aNg-mm-Uuy" userLabel="Setup Complete" customClass="PodSetupCompleteViewController" customModule="OmniKitUI" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" id="Mtx-27-ViY">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="358"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" id="Mtx-27-ViY">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <sections>
                             <tableViewSection id="PT0-CV-aJc" userLabel="Pod Image Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="192" id="wdM-LF-1g3">
-                                        <rect key="frame" x="0.0" y="35" width="320" height="192"/>
+                                        <rect key="frame" x="0.0" y="35" width="414" height="192"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wdM-LF-1g3" id="bEL-i5-hDF">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="192"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="192"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PodLarge" translatesAutoresizingMaskIntoConstraints="NO" id="dvx-vd-E9Z">
-                                                    <rect key="frame" x="91" y="0.0" width="138" height="181"/>
+                                                    <rect key="frame" x="138" y="0.0" width="138" height="181"/>
                                                 </imageView>
                                             </subviews>
                                             <constraints>
@@ -306,14 +325,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="55" id="AYb-HI-Jne">
-                                        <rect key="frame" x="0.0" y="227" width="320" height="55"/>
+                                        <rect key="frame" x="0.0" y="227" width="414" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AYb-HI-Jne" id="FML-id-Mp1">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="55"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" fixedFrame="YES" text="Your Pod is ready for use." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bJ5-iH-fnF">
-                                                    <rect key="frame" x="16" y="0.0" width="288" height="24"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" fixedFrame="YES" text="Your Pod is ready for use." lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bJ5-iH-fnF">
+                                                    <rect key="frame" x="16" y="11" width="343" height="45"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="highlightedColor"/>
@@ -333,26 +352,26 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="b4d-Ps-yhl" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2287.5" y="230"/>
+            <point key="canvasLocation" x="2288.8000000000002" y="231.2807881773399"/>
         </scene>
         <!--Pod Settings-->
         <scene sceneID="qel-YT-3JK">
             <objects>
                 <tableViewController title="Pod Settings" id="6vo-Ov-UpE" userLabel="Pod Settings" customClass="PodSettingsSetupViewController" customModule="OmniKitUI" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ysS-MS-L3N">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="364"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="DescriptionCell" textLabel="kLL-SQ-K0a" rowHeight="103" style="IBUITableViewCellStyleDefault" id="cmX-ay-VFH">
-                                <rect key="frame" x="0.0" y="55.5" width="320" height="103"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="DescriptionCell" textLabel="kLL-SQ-K0a" rowHeight="111" style="IBUITableViewCellStyleDefault" id="cmX-ay-VFH">
+                                <rect key="frame" x="0.0" y="55.5" width="414" height="111"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cmX-ay-VFH" id="RlG-Pl-jPJ">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="111"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="kLL-SQ-K0a">
-                                            <rect key="frame" x="16" y="0.0" width="288" height="103"/>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="kLL-SQ-K0a">
+                                            <rect key="frame" x="20" y="0.0" width="374" height="111"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <string key="text">Review your settings below. They will be programmed into the pod during pairing. You can change these settings at any time in Loopʼs Settings screen.</string>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -375,7 +394,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xBZ-Ak-dDF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-219" y="230"/>
+            <point key="canvasLocation" x="-219.375" y="230"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
I accidentally removed the constraints on all items on the pairing screen during my edits in the previous commit. That resulted in the image clipping.

So to be sure nothing else was removed, I redid the  fix applying the margins to the static text' on the previous working storyboard. I've tested this on my iPhone 6 and it looks ok again!