### PR TITLE
Move suspend/resume button to Pump Settings page

### DIFF
--- a/OmniKitUI/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/OmnipodSettingsViewController.swift
@@ -47,7 +47,8 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
         tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.className)
         tableView.register(TextButtonTableViewCell.self, forCellReuseIdentifier: TextButtonTableViewCell.className)
         tableView.register(AlarmsTableViewCell.self, forCellReuseIdentifier: AlarmsTableViewCell.className)
-        
+        tableView.register(SuspendResumeTableViewCell.self, forCellReuseIdentifier: SuspendResumeTableViewCell.className)
+
         let imageView = UIImageView(image: podImage)
         imageView.contentMode = .center
         imageView.frame.size.height += 18  // feels right


### PR DESCRIPTION
Moved the suspend/resume button to each of the specific pump settings page of Medtronic and Omnipod. It is now separated from Loop and more logically part of the pump managers.

I thought of moving the different parts to common folder into one suspend/resume file and reference elements from there. But then the function does get a bit more obscured that way so I did not do this.

Suspend/resume could also become part of the configuration, but because it is such a specific failsafe/shower button, a separate item feels more suited then a config list item.