### PR TITLE
Added spinner to Status Header on Settings Page.

### DIFF
--- a/OmniKitUI/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/OmnipodSettingsViewController.swift
@@ -179,9 +179,15 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
     
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         switch Section(rawValue: section)! {
+        case .status:
+            if podStatus == nil {
+                return super.tableView(tableView, viewForHeaderInSection: section)
+            } else {
+                return nil
+            }
         case .rileyLinks:
             return super.tableView(tableView, viewForHeaderInSection: section)
-        case .info, .configuration, .status, .deactivate:
+        case .info, .configuration, .deactivate:
             return nil
         }
     }


### PR DESCRIPTION
Added the spinner, but it only shows now when the podStatus is empty, not on every update request.
If I want to let it show on every update request, what part should I evaluate? 

I was looking at options to do it on one of these, but I do not know how grab these to evaluate them:
- updateStatus()
- viewDidLoad()
- viewWillAppear
- self.tableView.reloadSections