### PR TITLE
flush SGV data

### DIFF
--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -235,6 +235,7 @@ public class NightscoutUploader {
             direction: direction
         )
         entries.append(entry)
+        flushAll()
     }
     
     public func handleMeterMessage(_ msg: MeterMessage) {


### PR DESCRIPTION
Is there any reason why not to flush the data after calling `uploadSGV()`? `CGMManager`s with `shouldSyncToRemoteService == true` can't push data to NS without this line (unless some other function calls `flushAll()`, which cannot always be relied upon).