### PR TITLE
Dose identifiers

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -436,11 +436,16 @@ extension MinimedPumpManager {
         }
 
         // Reconcile temp basal
-        if let tempBasal = self.state.unfinalizedTempBasal, let index = reconcilableEvents.firstMatchingIndex(for: tempBasal, within: matchingTimeWindow), let dose = events[index].dose {
+        if let tempBasal = self.state.unfinalizedTempBasal, let index = reconcilableEvents.firstMatchingIndex(for: tempBasal, within: matchingTimeWindow) {
             let matchedTempBasal = reconcilableEvents[index]
             self.log.debug("Matched unfinalized temp basal %@ to history record %@", String(describing: tempBasal), String(describing: matchedTempBasal))
+            
             // Update unfinalizedTempBasal to match entry in history, and mark as reconciled
-            self.state.unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: dose.unitsPerHour, startTime: dose.startDate, duration: dose.endDate.timeIntervalSince(dose.startDate), isReconciledWithHistory: true)
+            //self.state.unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: dose.unitsPerHour, startTime: tempBasal.startDate, duration: dose.endDate.timeIntervalSince(dose.startDate), isReconciledWithHistory: true)
+            
+            // Temporary: Keeping original command time here, instead of pump time, for NS natural key restriction
+            self.state.unfinalizedTempBasal?.isReconciledWithHistory = true
+            
             markReconciled(startTime: tempBasal.startTime, uuid: tempBasal.uniqueId, eventRaw: matchedTempBasal.raw, index: index)
         }
 

--- a/MinimedKit/PumpManager/UnfinalizedDose.swift
+++ b/MinimedKit/PumpManager/UnfinalizedDose.swift
@@ -227,7 +227,8 @@ extension DoseEntry {
         case .unitsPerHour:
             value = unitsPerHour
         }
-        return DoseEntry(type: type, startDate: newStartDate, endDate: endDate, value: value, unit: unit, deliveredUnits: deliveredUnits, description: description, syncIdentifier: syncIdentifier)
+        let newEndDate = max(newStartDate, endDate)
+        return DoseEntry(type: type, startDate: newStartDate, endDate: newEndDate, value: value, unit: unit, deliveredUnits: deliveredUnits, description: description, syncIdentifier: syncIdentifier)
     }
 }
 

--- a/MinimedKit/PumpManager/UnfinalizedDose.swift
+++ b/MinimedKit/PumpManager/UnfinalizedDose.swift
@@ -19,20 +19,14 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         case resume
     }
 
-    private static let dateFormatter = ISO8601DateFormatter()
-
-    fileprivate var uniqueKey: Data {
-        return "\(doseType) \(scheduledUnits ?? units) \(UnfinalizedDose.dateFormatter.string(from: startTime))".data(using: .utf8)!
-    }
-
     let doseType: DoseType
     public var units: Double
-    var scheduledUnits: Double?     // Set when finalized; tracks original scheduled units
-    var scheduledTempRate: Double?  // Set when finalized; tracks the original temp rate
+    var programmedUnits: Double?     // Set when finalized; tracks programmed units
+    var programmedTempRate: Double?  // Set when finalized; tracks programmed temp rate
     let startTime: Date
     var duration: TimeInterval
     var isReconciledWithHistory: Bool
-    var uniqueId: String
+    var uniqueId: UUID
 
     var finishTime: Date {
         get {
@@ -73,9 +67,9 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.units = bolusAmount
         self.startTime = startTime
         self.duration = duration
-        self.scheduledUnits = nil
+        self.programmedUnits = nil
         self.isReconciledWithHistory = isReconciledWithHistory
-        self.uniqueId = UUID().uuidString
+        self.uniqueId = UUID()
     }
 
     init(tempBasalRate: Double, startTime: Date, duration: TimeInterval, isReconciledWithHistory: Bool = false) {
@@ -83,9 +77,9 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.units = tempBasalRate * duration.hours
         self.startTime = startTime
         self.duration = duration
-        self.scheduledUnits = nil
+        self.programmedUnits = nil
         self.isReconciledWithHistory = isReconciledWithHistory
-        self.uniqueId = UUID().uuidString
+        self.uniqueId = UUID()
     }
 
     init(suspendStartTime: Date, isReconciledWithHistory: Bool = false) {
@@ -94,7 +88,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.startTime = suspendStartTime
         self.duration = 0
         self.isReconciledWithHistory = isReconciledWithHistory
-        self.uniqueId = UUID().uuidString
+        self.uniqueId = UUID()
     }
 
     init(resumeStartTime: Date, isReconciledWithHistory: Bool = false) {
@@ -103,7 +97,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.startTime = resumeStartTime
         self.duration = 0
         self.isReconciledWithHistory = isReconciledWithHistory
-        self.uniqueId = UUID().uuidString
+        self.uniqueId = UUID()
     }
 
     public mutating func cancel(at date: Date) {
@@ -111,14 +105,14 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
             return
         }
 
-        scheduledUnits = units
+        programmedUnits = units
         let newDuration = date.timeIntervalSince(startTime)
 
         switch doseType {
         case .bolus:
             units = rate * newDuration.hours
         case .tempBasal:
-            scheduledTempRate = rate
+            programmedTempRate = rate
             units = floor(rate * newDuration.hours * 20) / 20
         default:
             break
@@ -129,9 +123,9 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
     public var description: String {
         switch doseType {
         case .bolus:
-            return "Bolus units:\(scheduledUnits ?? units) \(startTime)"
+            return "Bolus units:\(programmedUnits ?? units) \(startTime)"
         case .tempBasal:
-            return "TempBasal rate:\(scheduledTempRate ?? rate) \(startTime) duration:\(String(describing: duration))"
+            return "TempBasal rate:\(programmedTempRate ?? rate) \(startTime) duration:\(String(describing: duration))"
         default:
             return "\(String(describing: doseType).capitalized) \(startTime)"
         }
@@ -155,17 +149,21 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.duration = duration
 
         if let scheduledUnits = rawValue["scheduledUnits"] as? Double {
-            self.scheduledUnits = scheduledUnits
+            self.programmedUnits = scheduledUnits
         }
 
         if let scheduledTempRate = rawValue["scheduledTempRate"] as? Double {
-            self.scheduledTempRate = scheduledTempRate
+            self.programmedTempRate = scheduledTempRate
         }
         
-        if let uniqueId = rawValue["uniqueId"] as? String {
-            self.uniqueId = uniqueId
+        if let uuidString = rawValue["uniqueId"] as? String {
+            if let uuid = UUID(uuidString: uuidString) {
+                self.uniqueId = uuid
+            } else {
+                return nil
+            }
         } else {
-            self.uniqueId = UUID().uuidString
+            self.uniqueId = UUID()
         }
 
         self.isReconciledWithHistory = rawValue["isReconciledWithHistory"] as? Bool ?? false
@@ -178,14 +176,14 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
             "startTime": startTime,
             "duration": duration,
             "isReconciledWithHistory": isReconciledWithHistory,
-            "uniqueId": uniqueId,
+            "uniqueId": uniqueId.uuidString,
         ]
 
-        if let scheduledUnits = scheduledUnits {
+        if let scheduledUnits = programmedUnits {
             rawValue["scheduledUnits"] = scheduledUnits
         }
 
-        if let scheduledTempRate = scheduledTempRate {
+        if let scheduledTempRate = programmedTempRate {
             rawValue["scheduledTempRate"] = scheduledTempRate
         }
 
@@ -197,11 +195,13 @@ extension NewPumpEvent {
     init(_ dose: UnfinalizedDose) {
         let title = String(describing: dose)
         let entry = DoseEntry(dose)
-        self.init(date: dose.startTime, dose: entry, isMutable: true, raw: dose.uniqueKey, title: title)
+        let raw = dose.uniqueId.asRaw
+        self.init(date: dose.startTime, dose: entry, isMutable: true, raw: raw, title: title)
     }
     
-    func replacingDose(_ newDose: DoseEntry?) -> NewPumpEvent {
-        return NewPumpEvent(date: date, dose: newDose, isMutable: isMutable, raw: raw, title: title, type: type)
+    func replacingRawAndDate(newRaw: Data, newDate: Date) -> NewPumpEvent {
+        let newDose = dose?.replacingStartDate(newDate)
+        return NewPumpEvent(date: newDate, dose: newDose, isMutable: isMutable, raw: newRaw, title: title, type: type)
     }
 }
 
@@ -209,9 +209,9 @@ extension DoseEntry {
     init (_ dose: UnfinalizedDose) {
         switch dose.doseType {
         case .bolus:
-            self = DoseEntry(type: .bolus, startDate: dose.startTime, endDate: dose.finishTime, value: dose.scheduledUnits ?? dose.units, unit: .units, deliveredUnits: dose.finalizedUnits)
+            self = DoseEntry(type: .bolus, startDate: dose.startTime, endDate: dose.finishTime, value: dose.programmedUnits ?? dose.units, unit: .units, deliveredUnits: dose.finalizedUnits)
         case .tempBasal:
-            self = DoseEntry(type: .tempBasal, startDate: dose.startTime, endDate: dose.finishTime, value: dose.scheduledTempRate ?? dose.rate, unit: .unitsPerHour, deliveredUnits: dose.finalizedUnits)
+            self = DoseEntry(type: .tempBasal, startDate: dose.startTime, endDate: dose.finishTime, value: dose.programmedTempRate ?? dose.rate, unit: .unitsPerHour, deliveredUnits: dose.finalizedUnits)
         case .suspend:
             self = DoseEntry(suspendDate: dose.startTime)
         case .resume:
@@ -219,7 +219,7 @@ extension DoseEntry {
         }
     }
     
-    func replacingSyncIdentifier(_ newSyncIdentifier: String?) -> DoseEntry {
+    func replacingStartDate(_ newStartDate: Date) -> DoseEntry {
         let value: Double
         switch unit {
         case .units:
@@ -227,7 +227,7 @@ extension DoseEntry {
         case .unitsPerHour:
             value = unitsPerHour
         }
-        return DoseEntry(type: type, startDate: startDate, endDate: endDate, value: value, unit: unit, deliveredUnits: deliveredUnits, description: description, syncIdentifier: newSyncIdentifier)
+        return DoseEntry(type: type, startDate: newStartDate, endDate: endDate, value: value, unit: unit, deliveredUnits: deliveredUnits, description: description, syncIdentifier: syncIdentifier)
     }
 }
 
@@ -241,14 +241,22 @@ extension Collection where Element == NewPumpEvent {
 
             switch dose.doseType {
             case .bolus:
-                return type == .bolus && eventDose.programmedUnits == dose.scheduledUnits ?? dose.units
+                return type == .bolus && eventDose.programmedUnits == dose.programmedUnits ?? dose.units
             case .tempBasal:
-                return type == .tempBasal && eventDose.unitsPerHour == dose.scheduledTempRate ?? dose.rate
+                return type == .tempBasal && eventDose.unitsPerHour == dose.programmedTempRate ?? dose.rate
             case .suspend:
                 return type == .suspend
             case .resume:
                 return type == .resume
             }
         })
+    }
+}
+
+extension UUID {
+    var asRaw: Data {
+        return withUnsafePointer(to: self) {
+            Data(bytes: $0, count: MemoryLayout.size(ofValue: self))
+        }
     }
 }

--- a/NightscoutUploadKit/Treatments/BolusNightscoutTreatment.swift
+++ b/NightscoutUploadKit/Treatments/BolusNightscoutTreatment.swift
@@ -32,7 +32,8 @@ public class BolusNightscoutTreatment: NightscoutTreatment {
         self.duration = duration
         self.carbs = carbs
         self.ratio = ratio
-        super.init(timestamp: timestamp, enteredBy: enteredBy, notes: notes, id: id,
+        // Commenting out usage of surrogate ID until Nightscout supports it.
+        super.init(timestamp: timestamp, enteredBy: enteredBy, notes: notes, /* id: id, */
                    eventType: (carbs > 0) ? "Meal Bolus" : "Correction Bolus")
 
     }

--- a/NightscoutUploadKit/Treatments/BolusNightscoutTreatment.swift
+++ b/NightscoutUploadKit/Treatments/BolusNightscoutTreatment.swift
@@ -24,7 +24,7 @@ public class BolusNightscoutTreatment: NightscoutTreatment {
     let carbs: Int
     let ratio: Double
 
-    public init(timestamp: Date, enteredBy: String, bolusType: BolusType, amount: Double, programmed: Double, unabsorbed: Double, duration: TimeInterval, carbs: Int, ratio: Double, notes: String? = nil) {
+    public init(timestamp: Date, enteredBy: String, bolusType: BolusType, amount: Double, programmed: Double, unabsorbed: Double, duration: TimeInterval, carbs: Int, ratio: Double, notes: String? = nil, id: String?) {
         self.bolusType = bolusType
         self.amount = amount
         self.programmed = programmed
@@ -32,7 +32,7 @@ public class BolusNightscoutTreatment: NightscoutTreatment {
         self.duration = duration
         self.carbs = carbs
         self.ratio = ratio
-        super.init(timestamp: timestamp, enteredBy: enteredBy, notes: notes,
+        super.init(timestamp: timestamp, enteredBy: enteredBy, notes: notes, id: id,
                    eventType: (carbs > 0) ? "Meal Bolus" : "Correction Bolus")
 
     }

--- a/NightscoutUploadKit/Treatments/TempBasalNightscoutTreatment.swift
+++ b/NightscoutUploadKit/Treatments/TempBasalNightscoutTreatment.swift
@@ -21,13 +21,13 @@ public class TempBasalNightscoutTreatment: NightscoutTreatment {
     let temp: RateType
     let duration: Int
     
-    public init(timestamp: Date, enteredBy: String, temp: RateType, rate: Double, absolute: Double?, duration: Int) {
+    public init(timestamp: Date, enteredBy: String, temp: RateType, rate: Double, absolute: Double?, duration: Int, id: String? = nil) {
         self.rate = rate
         self.absolute = absolute
         self.temp = temp
         self.duration = duration
         
-        super.init(timestamp: timestamp, enteredBy: enteredBy, eventType: "Temp Basal")
+        super.init(timestamp: timestamp, enteredBy: enteredBy, id: id, eventType: "Temp Basal")
     }
     
     override public var dictionaryRepresentation: [String: Any] {

--- a/NightscoutUploadKit/Treatments/TempBasalNightscoutTreatment.swift
+++ b/NightscoutUploadKit/Treatments/TempBasalNightscoutTreatment.swift
@@ -27,7 +27,8 @@ public class TempBasalNightscoutTreatment: NightscoutTreatment {
         self.temp = temp
         self.duration = duration
         
-        super.init(timestamp: timestamp, enteredBy: enteredBy, id: id, eventType: "Temp Basal")
+        // Commenting out usage of surrogate ID until supported by Nightscout
+        super.init(timestamp: timestamp, enteredBy: enteredBy, /*id: id,*/ eventType: "Temp Basal")
     }
     
     override public var dictionaryRepresentation: [String: Any] {


### PR DESCRIPTION
Update identifiers on doses so that we keep consistent ids before and after reconciliation to pump history events.  This is necessary for remote synchronization where dates are updated.

Unfortunately, Nightscout currently enforces a natural key of timestamp and datatype, which means that changes to timestamp are not allowed.  Hoping we can eventually remove this limitation, and allow us to use surrogate keys for synchronizing Loop data to NS. In the meantime, we're hacking pump event values to the time of command issuance, based on the phone clock. 