### PR TITLE
generalize Bolus Beeps to Confirmation Beeps

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -13,6 +13,10 @@ import RileyLinkBLEKit
 import UserNotifications
 import os.log
 
+fileprivate let bolusConfirmationBeeps: Bool = true      // bolus confirmation beeps
+fileprivate let basalConfirmationBeeps: Bool = true      // basal confirmation beeps
+fileprivate let tempBasalConfirmationBeeps: Bool = false // temp Basal confirmation beeps (debug only)
+
 public enum ReservoirAlertState {
     case ok
     case lowReservoir
@@ -363,13 +367,13 @@ extension OmnipodPumpManager {
     }
 
     // Thread-safe
-    public var bolusBeeps: Bool {
+    public var confirmationBeeps: Bool {
         get {
-            return state.bolusBeeps
+            return state.confirmationBeeps
         }
         set {
             setState { (state) in
-                state.bolusBeeps = newValue
+                state.confirmationBeeps = newValue
             }
         }
     }
@@ -633,6 +637,15 @@ extension OmnipodPumpManager {
         #endif
     }
 
+    private func emitConfirmationBeep(session: PodCommsSession, beepConfigType: BeepConfigType) {
+        if self.confirmationBeeps {
+            let basalCompletionBeep = basalConfirmationBeeps
+            let tempBasalCompletionBeep = tempBasalConfirmationBeeps
+            let bolusCompletionBeep = bolusConfirmationBeeps
+            session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
+        }
+    }
+
     private func checkCannulaInsertionFinished() {
         let deviceSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Check cannula insertion finished", using: deviceSelector) { (result) in
@@ -640,6 +653,9 @@ extension OmnipodPumpManager {
             case .success(let session):
                 do {
                     try session.checkInsertionCompleted()
+                    if self.hasSetupCompletePod {
+                        self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
+                    }
                 } catch let error {
                     self.log.error("Failed to fetch pump status: %{public}@", String(describing: error))
                 }
@@ -741,7 +757,8 @@ extension OmnipodPumpManager {
             switch result {
             case .success(let session):
                 do {
-                    let _ = try session.setTime(timeZone: timeZone, basalSchedule: self.state.basalSchedule, date: Date())
+                    let beep = self.confirmationBeeps && basalConfirmationBeeps
+                    let _ = try session.setTime(timeZone: timeZone, basalSchedule: self.state.basalSchedule, date: Date(), acknowledgementBeep: beep, completionBeep: beep)
                     self.setState { (state) in
                         state.timeZone = timeZone
                     }
@@ -797,7 +814,8 @@ extension OmnipodPumpManager {
                     case .success:
                         break
                     }
-                    let _ = try session.setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset)
+                    let beep = self.confirmationBeeps && basalConfirmationBeeps
+                    let _ = try session.setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
 
                     self.setState { (state) in
                         state.basalSchedule = schedule
@@ -869,8 +887,7 @@ extension OmnipodPumpManager {
     }
 
     public func testingCommands(completion: @escaping (Error?) -> Void) {
-        // use hasSetupCompletePod instead of hasActivePod so we don't fail on a faulted Pod
-        guard self.hasSetupCompletePod else {
+        guard self.hasActivePod else {
             completion(OmnipodPumpManagerError.noPodPaired)
             return
         }
@@ -896,20 +913,54 @@ extension OmnipodPumpManager {
             completion(OmnipodPumpManagerError.noPodPaired)
             return
         }
+        guard self.state.podState?.unfinalizedBolus?.isFinished != false else {
+            self.log.info("Skipping Play Test Beeps due to bolus still in progress.")
+            completion(PodCommsError.unfinalizedBolus)
+            return
+        }
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Play Test Beeps", using: rileyLinkSelector) { (result) in
             switch result {
             case .success(let session):
+                let basalCompletionBeep = self.confirmationBeeps && basalConfirmationBeeps
+                let tempBasalCompletionBeep = self.confirmationBeeps && tempBasalConfirmationBeeps
+                let bolusCompletionBeep = self.confirmationBeeps && bolusConfirmationBeeps
+                session.beepConfig(beepConfigType: .bipBeepBipBeepBipBeepBipBeep, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
+                // a .fiveSecondBeep could be added to implement a PDM "Check alarms", but this only works if the pod is suspended!
+                completion(nil)
+            case .failure(let error):
+                completion(error)
+            }
+        }
+    }
+
+    public func readFlashLogs(completion: @escaping (Error?) -> Void) {
+        // use hasSetupCompletePod instead of hasActivePod here so we don't fail on a faulted Pod
+        guard self.hasSetupCompletePod else {
+            completion(OmnipodPumpManagerError.noPodPaired)
+            return
+        }
+        if self.state.podState?.fault == nil && self.state.podState?.unfinalizedBolus?.isFinished == false {
+            self.log.info("Skipping Read Flash Logs due to bolus still in progress.")
+            completion(PodCommsError.unfinalizedBolus)
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        self.podComms.runSession(withName: "Read Flash Logs", using: rileyLinkSelector) { (result) in
+            switch result {
+            case .success(let session):
                 do {
-                    guard self.state.podState?.unfinalizedBolus?.isFinished != false else {
-                        self.log.info("Unfinalized bolus, skipping play test beeps")
-                        throw PodCommsError.unfinalizedBolus
-                    }
-                    
-                    try session.beepConfig(beepConfigType: .bipBeepBipBeepBipBeepBipBeep, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: self.bolusBeeps)
-                    // .fiveSecondBeep could be used for a PDM style "Check alarms", but this only works if the pod is suspended!
-                    try session.beepConfig(beepConfigType: .beeeeeep, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: self.bolusBeeps)
+                    // read up to the most recent 50 entries from flash log
+                    self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
+                    try session.readFlashLogsRequest(podInfoResponseSubType: .flashLogRecent)
+
+                    // read up to the previous 50 entries from flash log
+                    self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
+                    try session.readFlashLogsRequest(podInfoResponseSubType: .dumpOlderFlashlog)
+
+                    self.emitConfirmationBeep(session: session, beepConfigType: .beeeeeep)
                     completion(nil)
                 } catch let error {
                     completion(error)
@@ -920,9 +971,9 @@ extension OmnipodPumpManager {
         }
     }
 
-    public func setBolusBeeps(enabled: Bool, completion: @escaping (Error?) -> Void) {
-        self.log.info("Set Bolus Beeps to %s", enabled ? "true" : "false")
-
+    public func setConfirmationBeeps(enabled: Bool, completion: @escaping (Error?) -> Void) {
+        self.confirmationBeeps = enabled // set here to allow changes on a faulted Pod
+        self.log.default("Set Confirmation Beeps to %s", String(describing: enabled))
         guard self.hasActivePod else {
             completion(nil)
             return
@@ -933,14 +984,14 @@ extension OmnipodPumpManager {
         self.podComms.runSession(withName: name, using: rileyLinkSelector) { (result) in
             switch result {
             case .success(let session):
-                do {
-                    let beepConfigType: BeepConfigType = enabled ? .bipBip : .noBeep
-                    try session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: enabled)
-                    self.bolusBeeps = enabled
-                    completion(nil)
-                } catch let error {
-                    completion(error)
-                }
+                let beepConfigType: BeepConfigType = enabled ? .bipBip : .noBeep
+                let basalCompletionBeep = enabled && basalConfirmationBeeps
+                let tempBasalCompletionBeep = enabled && tempBasalConfirmationBeeps
+                let bolusCompletionBeep = enabled && bolusConfirmationBeeps
+
+                // enable/disable Pod completion beeps for any in-progress insulin delivery
+                session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
+                completion(nil)
             case .failure(let error):
                 completion(error)
             }
@@ -1069,6 +1120,7 @@ extension OmnipodPumpManager: PumpManager {
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)
                 }
+                self.emitConfirmationBeep(session: session, beepConfigType: .beeeeeep)
                 completion(nil)
             }
         }
@@ -1103,7 +1155,8 @@ extension OmnipodPumpManager: PumpManager {
 
             do {
                 let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
-                let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset)
+                let beep = self.confirmationBeeps && basalConfirmationBeeps
+                let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)
                 }
@@ -1205,7 +1258,7 @@ extension OmnipodPumpManager: PumpManager {
             if podStatus.deliveryStatus == .suspended {
                 do {
                     let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
-                    podStatus = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset)
+                    podStatus = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: false, completionBeep: false)
                 } catch let error {
                     completion(.failure(SetBolusError.certain(error as? PodCommsError ?? PodCommsError.commsError(error: error))))
                     return
@@ -1222,7 +1275,8 @@ extension OmnipodPumpManager: PumpManager {
             let dose = DoseEntry(type: .bolus, startDate: date, endDate: endDate, value: enactUnits, unit: .units)
             willRequest(dose)
 
-            let result = session.bolus(units: enactUnits, acknowledgementBeep: self.bolusBeeps, completionBeep: self.bolusBeeps)
+            let beep = self.confirmationBeeps && bolusConfirmationBeeps
+            let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep)
             session.dosesForStorage() { (doses) -> Bool in
                 return self.store(doses: doses, in: session)
             }
@@ -1267,7 +1321,7 @@ extension OmnipodPumpManager: PumpManager {
                 })
 
                 // when cancelling a bolus give a type 6 beeeeeep to match PDM if doing bolus confirmation beeps
-                let beeptype: BeepType = self.bolusBeeps ? .beeeeeep : .noBeep
+                let beeptype: BeepType = self.confirmationBeeps && bolusConfirmationBeeps ? .beeeeeep : .noBeep
                 let result = session.cancelDelivery(deliveryType: .bolus, beepType: beeptype)
                 switch result {
                 case .certainFailure(let error):
@@ -1373,7 +1427,8 @@ extension OmnipodPumpManager: PumpManager {
                         state.tempBasalEngageState = .engaging
                     })
 
-                    let result = session.setTempBasal(rate: rate, duration: duration)
+                    let beep = self.confirmationBeeps && tempBasalConfirmationBeeps
+                    let result = session.setTempBasal(rate: rate, duration: duration, acknowledgementBeep: beep, completionBeep: beep)
                     let basalStart = Date()
                     let dose = DoseEntry(type: .tempBasal, startDate: basalStart, endDate: basalStart.addingTimeInterval(duration), value: rate, unit: .unitsPerHour)
                     session.dosesForStorage() { (doses) -> Bool in

--- a/OmniKit/PumpManager/OmnipodPumpManagerState.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManagerState.swift
@@ -30,7 +30,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
 
     public var expirationReminderDate: Date?
 
-    public var bolusBeeps: Bool
+    public var confirmationBeeps: Bool
 
     // Temporal state not persisted
 
@@ -56,7 +56,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
         self.basalSchedule = basalSchedule
         self.rileyLinkConnectionManagerState = rileyLinkConnectionManagerState
         self.unstoredDoses = []
-        self.bolusBeeps = false
+        self.confirmationBeeps = false
     }
     
     public init?(rawValue: RawValue) {
@@ -131,7 +131,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
             self.unstoredDoses = []
         }
 
-        self.bolusBeeps = rawValue["bolusBeeps"] as? Bool ?? false
+        self.confirmationBeeps = rawValue["confirmationBeeps"] as? Bool ?? rawValue["bolusBeeps"] as? Bool ?? false
     }
     
     public var rawValue: RawValue {
@@ -141,7 +141,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
             "basalSchedule": basalSchedule.rawValue,
             "messageLog": messageLog.rawValue,
             "unstoredDoses": unstoredDoses.map { $0.rawValue },
-            "bolusBeeps": bolusBeeps,
+            "confirmationBeeps": confirmationBeeps,
         ]
         
         if let podState = podState {
@@ -190,7 +190,7 @@ extension OmnipodPumpManagerState: CustomDebugStringConvertible {
             "* tempBasalEngageState: \(String(describing: tempBasalEngageState))",
             "* lastPumpDataReportDate: \(String(describing: lastPumpDataReportDate))",
             "* isPumpDataStale: \(String(describing: isPumpDataStale))",
-            "* bolusBeeps: \(String(describing: bolusBeeps))",
+            "* confirmationBeeps: \(String(describing: confirmationBeeps))",
             String(reflecting: podState),
             String(reflecting: rileyLinkConnectionManagerState),
             String(reflecting: messageLog),

--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -16,9 +16,9 @@ public class ConfirmationBeepsTableViewCell: TextButtonTableViewCell {
 
     public func updateTextLabel(enabled: Bool) {
         if enabled {
-            self.textLabel?.text = LocalizedString("Disable Bolus Beeps", comment: "Title text for button to disable bolus beeps")
+            self.textLabel?.text = LocalizedString("Disable Confirmation Beeps", comment: "Title text for button to disable confirmation beeps")
         } else {
-            self.textLabel?.text = LocalizedString("Enable Bolus Beeps", comment: "Title text for button to enable bolus beeps")
+            self.textLabel?.text = LocalizedString("Enable Confirmation Beeps", comment: "Title text for button to enable confirmation beeps")
         }
     }
     
@@ -68,7 +68,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
 
     lazy var confirmationBeepsTableViewCell: ConfirmationBeepsTableViewCell = {
         let cell = ConfirmationBeepsTableViewCell(style: .default, reuseIdentifier: nil)
-        cell.updateTextLabel(enabled: pumpManager.bolusBeeps)
+        cell.updateTextLabel(enabled: pumpManager.confirmationBeeps)
         return cell
     }()
 
@@ -590,12 +590,12 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
     }
 
     private func confirmationBeepsTapped() {
-        let confirmationBeeps: Bool = pumpManager.bolusBeeps
+        let confirmationBeeps: Bool = pumpManager.confirmationBeeps
         
         func done() {
             DispatchQueue.main.async { [weak self] in
                 if let self = self {
-                    self.confirmationBeepsTableViewCell.updateTextLabel(enabled: self.pumpManager.bolusBeeps)
+                    self.confirmationBeepsTableViewCell.updateTextLabel(enabled: self.pumpManager.confirmationBeeps)
                     self.confirmationBeepsTableViewCell.isLoading = false
                 }
             }
@@ -603,20 +603,20 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
 
         confirmationBeepsTableViewCell.isLoading = true
         if confirmationBeeps {
-            pumpManager.setBolusBeeps(enabled: false, completion: { (error) in
+            pumpManager.setConfirmationBeeps(enabled: false, completion: { (error) in
                 if let error = error {
                     DispatchQueue.main.async {
-                        let title = LocalizedString("Error disabling bolus beeps", comment: "The alert title for disable bolus beeps error")
+                        let title = LocalizedString("Error disabling confirmation beeps", comment: "The alert title for disable confirmation beeps error")
                         self.present(UIAlertController(with: error, title: title), animated: true)
                     }
                 }
                 done()
             })
         } else {
-            pumpManager.setBolusBeeps(enabled: true, completion: { (error) in
+            pumpManager.setConfirmationBeeps(enabled: true, completion: { (error) in
                 if let error = error {
                     DispatchQueue.main.async {
-                        let title = LocalizedString("Error enabling bolus beeps", comment: "The alert title for enable bolus beeps error")
+                        let title = LocalizedString("Error enabling confirmation beeps", comment: "The alert title for enable confirmation beeps error")
                         self.present(UIAlertController(with: error, title: title), animated: true)
                     }
                 }


### PR DESCRIPTION
adjust Play Test Beeps to only emit one beep sequence
tweaks to better accomodate some actions on faulted pods
updated and improved logging
move readFlashLogs() to better integrate with confirmation beeps