### PR TITLE
Various internal improvements for better Omnipod support

### DIFF
--- a/OmniKit/Model/AlertSlot.swift
+++ b/OmniKit/Model/AlertSlot.swift
@@ -74,22 +74,27 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
     case autoOffAlarm(active: Bool, countdownDuration: TimeInterval)
 
     public var description: String {
+        var alertName: String
         switch self {
         case .waitingForPairingReminder:
             return LocalizedString("Waiting for pairing reminder", comment: "Description waiting for pairing reminder")
         case .finishSetupReminder:
             return LocalizedString("Finish setup ", comment: "Description for finish setup")
         case .expirationAlert:
-            return LocalizedString("Expiration alert", comment: "Description for expiration alert")
+            alertName = LocalizedString("Expiration alert", comment: "Description for expiration alert")
         case .expirationAdvisoryAlarm:
-            return LocalizedString("Pod expiration advisory alarm", comment: "Description for expiration advisory alarm")
+            alertName = LocalizedString("Pod expiration advisory alarm", comment: "Description for expiration advisory alarm")
         case .shutdownImminentAlarm:
-            return LocalizedString("Shutdown imminent alarm", comment: "Description for shutdown imminent alarm")
+            alertName = LocalizedString("Shutdown imminent alarm", comment: "Description for shutdown imminent alarm")
         case .lowReservoirAlarm:
-            return LocalizedString("Low reservoir advisory alarm", comment: "Description for low reservoir alarm")
+            alertName = LocalizedString("Low reservoir advisory alarm", comment: "Description for low reservoir alarm")
         case .autoOffAlarm:
-            return LocalizedString("Auto-off alarm", comment: "Description for auto-off alarm")
+            alertName = LocalizedString("Auto-off alarm", comment: "Description for auto-off alarm")
         }
+        if self.configuration.active == false {
+            alertName += LocalizedString(" (inactive)", comment: "Description for an inactive alert modifier")
+        }
+        return alertName
     }
 
     public var configuration: AlertConfiguration {

--- a/OmniKit/Model/BeepType.swift
+++ b/OmniKit/Model/BeepType.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 // BeepType is used for the $19 Configure Alerts and $1F Cancel Commands
+// Values 1 thru 8 are exactly the same as in BeepConfigType below
+// N.B. for BeepType, noBeep is 0x0, while for BeepConfigType it is 0xF
 public enum BeepType: UInt8 {
     case noBeep = 0x0
     case beepBeepBeepBeep = 0x1
@@ -19,12 +21,14 @@ public enum BeepType: UInt8 {
     case beeeeeep = 0x6
     case bipBipBipbipBipBip = 0x7
     case beeepBeeep = 0x8
+    // values greater than 0x8 for $19 and $1F commands can fault pod!
 }
 
-// BeepConfigType is used only for the $1E Beep Config Command.
-// Values 1 thru 8 are exactly the same as in BeepType
+// BeepConfigType is used for the $1E Beep Config Command.
+// Values 1 thru 8 are exactly the same as in BeepType above
+// N.B. for BeepConfigType, noBeep is 0xF, while for BeepType it is 0x0
 public enum BeepConfigType: UInt8 {
-     // 0x0 always returns an error response for Beep Config (use 0xF for no beep)
+     // 0 always returns an error response for Beep Config
     case beepBeepBeepBeep = 0x1
     case bipBeepBipBeepBipBeepBipBeep = 0x2
     case bipBip = 0x3
@@ -37,6 +41,6 @@ public enum BeepConfigType: UInt8 {
     case beepBeep = 0xB
     case beeep = 0xC
     case bipBeeeeep = 0xD
-    case fiveSecondBeep = 0xE    // can only be used if Pod is currently suspended
+    case fiveSecondBeep = 0xE // can only be used if Pod is currently suspended!
     case noBeep = 0xF
 }

--- a/OmniKit/Model/Pod.swift
+++ b/OmniKit/Model/Pod.swift
@@ -30,6 +30,9 @@ public struct Pod {
     // Total pod service time. A fault is triggered if this time is reached before pod deactivation.
     public static let serviceDuration = TimeInterval(hours: 80)
 
+    // Nomimal pod life (72 hours)
+    public static let nominalPodLife = Pod.serviceDuration - Pod.endOfServiceImminentWindow - Pod.expirationAdvisoryWindow
+
     // Maximum reservoir level reading
     public static let maximumReservoirReading: Double = 50
 
@@ -45,8 +48,11 @@ public struct Pod {
     // Minimum duration of a single basal schedule entry
     public static let minimumBasalScheduleEntryDuration = TimeInterval.minutes(30)
 
-    // Amount of insulin delivered for priming
+    // Amount of insulin delivered with 1 second between pulses for priming
     public static let primeUnits = 2.6
+
+    // Amount of insulin delivered with 1 second between pulses for cannula insertion
+    public static let cannulaInsertionUnits = 0.5
 
     // Default and limits for expiration reminder alerts
     public static let expirationReminderAlertDefaultTimeBeforeExpiration = TimeInterval.hours(2)

--- a/OmniKit/PumpManager/MessageLog.swift
+++ b/OmniKit/PumpManager/MessageLog.swift
@@ -57,10 +57,11 @@ public struct MessageLog: CustomStringConvertible, Equatable {
     var entries = [MessageLogEntry]()
 
     public var description: String {
-        var lines = ["### MessageLog"]
+        var lines = ["\n### MessageLog"]
         for entry in entries {
             lines.append("* " + entry.description)
         }
+        lines.append("")
         return lines.joined(separator: "\n")
     }
 

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -13,6 +13,9 @@ import RileyLinkBLEKit
 import UserNotifications
 import os.log
 
+fileprivate let defaultPodLowReservoirLevel: Double = 10 // default pod low reservior alert level (1..50)
+
+
 public enum ReservoirAlertState {
     case ok
     case lowReservoir
@@ -345,8 +348,8 @@ extension OmnipodPumpManager {
     }
 
     // Thread-safe
-    public var hasSetupCompletePod: Bool {
-        return state.hasSetupCompletePod
+    public var hasSetupPod: Bool {
+        return state.hasSetupPod
     }
 
     // Thread-safe
@@ -634,6 +637,13 @@ extension OmnipodPumpManager {
         #endif
     }
 
+    private func emitConfirmationBeep(session: PodCommsSession, beepConfigType: BeepConfigType) {
+        let basalCompletionBeep = false
+        let tempBasalCompletionBeep = false
+        let bolusCompletionBeep = self.bolusBeeps
+        session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
+    }
+
     private func checkCannulaInsertionFinished() {
         let deviceSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Check cannula insertion finished", using: deviceSelector) { (result) in
@@ -742,7 +752,8 @@ extension OmnipodPumpManager {
             switch result {
             case .success(let session):
                 do {
-                    let _ = try session.setTime(timeZone: timeZone, basalSchedule: self.state.basalSchedule, date: Date())
+                    let beep = false
+                    let _ = try session.setTime(timeZone: timeZone, basalSchedule: self.state.basalSchedule, date: Date(), acknowledgementBeep: beep, completionBeep: beep)
                     self.setState { (state) in
                         state.timeZone = timeZone
                     }
@@ -798,7 +809,8 @@ extension OmnipodPumpManager {
                     case .success:
                         break
                     }
-                    let _ = try session.setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset)
+                    let beep = false
+                    let _ = try session.setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
 
                     self.setState { (state) in
                         state.basalSchedule = schedule
@@ -870,8 +882,8 @@ extension OmnipodPumpManager {
     }
 
     public func testingCommands(completion: @escaping (Error?) -> Void) {
-        // use hasSetupCompletePod instead of hasActivePod so we don't fail on a faulted Pod
-        guard self.hasSetupCompletePod else {
+        // use hasSetupPod so that the user can see any fault info
+        guard self.hasSetupPod else {
             completion(OmnipodPumpManagerError.noPodPaired)
             return
         }
@@ -897,20 +909,74 @@ extension OmnipodPumpManager {
             completion(OmnipodPumpManagerError.noPodPaired)
             return
         }
+        guard self.state.podState?.unfinalizedBolus?.isFinished != false else {
+            self.log.info("Skipping Play Test Beeps due to bolus still in progress.")
+            completion(PodCommsError.unfinalizedBolus)
+            return
+        }
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Play Test Beeps", using: rileyLinkSelector) { (result) in
             switch result {
             case .success(let session):
+                session.beepConfig(beepConfigType: .bipBeepBipBeepBipBeepBipBeep, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: self.bolusBeeps)
+                // Don't bother emitting another beep sequence to approximate the PDM "Check alarms" function as the Pod beeping is
+                // asynchronous to the UI which will have already printed Succeeded before the first beep sequence is done playing
+                completion(nil)
+            case .failure(let error):
+                completion(error)
+            }
+        }
+    }
+
+    public func readPodStatus(completion: @escaping (Error?) -> Void) {
+        // use hasSetupPod so that the user can see any fault info
+        guard self.hasSetupPod else {
+            completion(OmnipodPumpManagerError.noPodPaired)
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        self.podComms.runSession(withName: "Read Pod Status", using: rileyLinkSelector) { (result) in switch result {
+            case .success(let session):
                 do {
-                    guard self.state.podState?.unfinalizedBolus?.isFinished != false else {
-                        self.log.info("Unfinalized bolus, skipping play test beeps")
-                        throw PodCommsError.unfinalizedBolus
-                    }
-                    
-                    try session.beepConfig(beepConfigType: .bipBeepBipBeepBipBeepBipBeep, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: self.bolusBeeps)
-                    // .fiveSecondBeep could be used for a PDM style "Check alarms", but this only works if the pod is suspended!
-                    try session.beepConfig(beepConfigType: .beeeeeep, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: self.bolusBeeps)
+                    try session.getStatus()
+                    completion(nil)
+                } catch let error {
+                    completion(error)
+                }
+            case .failure(let error):
+                completion(error)
+            }
+        }
+    }
+
+    public func readFlashLog(completion: @escaping (Error?) -> Void) {
+        // use hasSetupPod to be able to read the flash log from a faulted Pod
+        guard self.hasSetupPod else {
+            completion(OmnipodPumpManagerError.noPodPaired)
+            return
+        }
+        if self.state.podState?.fault == nil && self.state.podState?.unfinalizedBolus?.isFinished == false {
+            self.log.info("Skipping Read Flash Log due to bolus still in progress.")
+            completion(PodCommsError.unfinalizedBolus)
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        self.podComms.runSession(withName: "Read Flash Log", using: rileyLinkSelector) { (result) in
+            switch result {
+            case .success(let session):
+                do {
+                    // read up to the most recent 50 entries from flash log
+                    self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
+                    try session.readFlashLogsRequest(podInfoResponseSubType: .flashLogRecent)
+
+                    // read up to the previous 50 entries from flash log
+                    self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
+                    try session.readFlashLogsRequest(podInfoResponseSubType: .dumpOlderFlashlog)
+
+                    self.emitConfirmationBeep(session: session, beepConfigType: .beeeeeep)
                     completion(nil)
                 } catch let error {
                     completion(error)
@@ -922,26 +988,26 @@ extension OmnipodPumpManager {
     }
 
     public func setBolusBeeps(enabled: Bool, completion: @escaping (Error?) -> Void) {
-        self.log.info("Set Bolus Beeps to %s", enabled ? "true" : "false")
-
+        self.bolusBeeps = enabled // set here to allow changes on a faulted Pod
+        self.log.default("Set Bolus Beeps to %s", String(describing: enabled))
         guard self.hasActivePod else {
             completion(nil)
             return
         }
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
-        let name: String = enabled ? "Enable Confirmation Beeps" : "Disable Confirmation Beeps"
+        let name: String = enabled ? "Enable Bolus Beeps" : "Disable Bolus Beeps"
         self.podComms.runSession(withName: name, using: rileyLinkSelector) { (result) in
             switch result {
             case .success(let session):
-                do {
-                    let beepConfigType: BeepConfigType = enabled ? .bipBip : .noBeep
-                    try session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: enabled)
-                    self.bolusBeeps = enabled
-                    completion(nil)
-                } catch let error {
-                    completion(error)
-                }
+                let beepConfigType: BeepConfigType = enabled ? .bipBip : .noBeep
+                let basalCompletionBeep = false
+                let tempBasalCompletionBeep = false
+                let bolusCompletionBeep = enabled
+
+                // enable/disable Pod completion beeps for any in-progress insulin delivery
+                session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
+                completion(nil)
             case .failure(let error):
                 completion(error)
             }
@@ -1104,7 +1170,8 @@ extension OmnipodPumpManager: PumpManager {
 
             do {
                 let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
-                let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset)
+                let beep = false
+                let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)
                 }
@@ -1206,7 +1273,8 @@ extension OmnipodPumpManager: PumpManager {
             if podStatus.deliveryStatus == .suspended {
                 do {
                     let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
-                    podStatus = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset)
+                    let beep = false
+                    podStatus = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
                 } catch let error {
                     completion(.failure(SetBolusError.certain(error as? PodCommsError ?? PodCommsError.commsError(error: error))))
                     return
@@ -1223,7 +1291,8 @@ extension OmnipodPumpManager: PumpManager {
             let dose = DoseEntry(type: .bolus, startDate: date, endDate: endDate, value: enactUnits, unit: .units)
             willRequest(dose)
 
-            let result = session.bolus(units: enactUnits, acknowledgementBeep: self.bolusBeeps, completionBeep: self.bolusBeeps)
+            let beep = self.bolusBeeps
+            let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep)
             session.dosesForStorage() { (doses) -> Bool in
                 return self.store(doses: doses, in: session)
             }
@@ -1374,7 +1443,8 @@ extension OmnipodPumpManager: PumpManager {
                         state.tempBasalEngageState = .engaging
                     })
 
-                    let result = session.setTempBasal(rate: rate, duration: duration)
+                    let beep = false
+                    let result = session.setTempBasal(rate: rate, duration: duration, acknowledgementBeep: beep, completionBeep: beep)
                     let basalStart = Date()
                     let dose = DoseEntry(type: .tempBasal, startDate: basalStart, endDate: basalStart.addingTimeInterval(duration), value: rate, unit: .unitsPerHour)
                     session.dosesForStorage() { (doses) -> Bool in

--- a/OmniKit/PumpManager/OmnipodPumpManagerState.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManagerState.swift
@@ -165,7 +165,7 @@ extension OmnipodPumpManagerState {
         return podState?.isActive == true
     }
 
-    var hasSetupCompletePod: Bool {
+    var hasSetupPod: Bool {
         return podState?.isSetupComplete == true
     }
 

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -652,36 +652,6 @@ public class PodCommsSession {
     public func assertOnSessionQueue() {
         transport.assertOnSessionQueue()
     }
-
-    public func setPodLowReserviorAlert(level: Double) throws {
-        // consider verifying that the level is above the current reservior value?
-        log.default("Setting pod alert for low reservior level %s units", String(describing: level))
-        guard level > 0 && level <= Pod.maximumReservoirReading else {
-            throw PodCommsError.invalidData
-        }
-        let lowReservoirAlarm = PodAlert.lowReservoirAlarm(level)
-        try configureAlerts([lowReservoirAlarm])
-    }
-
-    public func setPodExpirationAlert(expirationReminderDate: Date?) throws {
-        guard let expiryAlert = expirationReminderDate else {
-            return
-        }
-        let timeUntilExpirationAlert = expiryAlert.timeIntervalSinceNow
-        guard timeUntilExpirationAlert > 0 else {
-            log.default("Pod expiration reminder alert for %s already past %s ago, ignoring", String(describing: expiryAlert), TimeInterval(seconds: -timeUntilExpirationAlert).stringValue)
-            return // past the expiration reminder alert time
-        }
-        log.default("Setting pod expiration reminder alert for %s in %s", String(describing: expiryAlert), TimeInterval(seconds: timeUntilExpirationAlert).stringValue)
-        let expirationAlert = PodAlert.expirationAlert(timeUntilExpirationAlert)
-        try configureAlerts([expirationAlert])
-    }
-
-    public func clearOptionalPodAlarms() throws {
-        let lowReservoirAlarm = PodAlert.lowReservoirAlarm(0)
-        let expirationAlert = PodAlert.expirationAlert(TimeInterval(hours: 0))
-        try configureAlerts([lowReservoirAlarm, expirationAlert])
-    }
 }
 
 extension PodCommsSession: MessageTransportDelegate {

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -147,7 +147,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         if activatedAt == nil {
             self.activatedAt = activatedAtComputed
         }
-        let expiresAtComputed = activatedAtComputed + (Pod.serviceDuration - Pod.endOfServiceImminentWindow - Pod.expirationAdvisoryWindow)
+        let expiresAtComputed = activatedAtComputed + Pod.nominalPodLife
         if expiresAt == nil {
             self.expiresAt = expiresAtComputed
         } else if expiresAtComputed < self.expiresAt! || expiresAtComputed > (self.expiresAt! + TimeInterval(minutes: 1)) {
@@ -258,7 +258,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             if let expiresAt = rawValue["expiresAt"] as? Date {
                 self.expiresAt = expiresAt
             } else {
-                self.expiresAt = activatedAt + (Pod.serviceDuration - Pod.endOfServiceImminentWindow - Pod.expirationAdvisoryWindow)
+                self.expiresAt = activatedAt + Pod.nominalPodLife
             }
         }
 


### PR DESCRIPTION
+ Change Play Test Beeps to not emit a second beep type (it plays well after the UI has reported Succeeded)
+ Change the PodAlert enum description string to add “ (inactive)” for inactive configured alerts
+ Add a new Pod.cannulaInsertionUnits constant of 0.5
+ Add a new Pod.nominalPodLife constant (i.e., 72 hours)
+ Updated comments for the BeepType & BeepConfigType enums
+ Update the MessageLog description string to include a blank line before and after
+ Rename the OmnipodPumpManager hasSetupCompletePod var to hasSetupPod
+ Move readFlashLog() from PodCommsSession to OmnipodPumpManager
+ Call the setTime(), setBasalSchedule(), resumeBasal(), setTempBasal() functions with all parameters from OmnipodPumpManager
+ Mark the PodCommsSession’s configureAlerts() and cancelNone() functions with @discardableResult
+ Change beepConfig() to catch errors and never throw
+ Don't do the unneeded configuration for the autoOffAlarm alert
+ Updated PodCommsSession functions to be able to set individual optional alerts values
+ Only save the first fault status returned in podState
+ Change defaultPodLowReservoirLevel constant to 10
+ Updated and improved comments and Xcode logging