### PR TITLE
Upgrade Bolus Beeps to more general purpose Confirmation Beeps

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -13,6 +13,10 @@ import RileyLinkBLEKit
 import UserNotifications
 import os.log
 
+fileprivate let bolusConfirmationBeeps: Bool = true      // whether to emit bolus confirmation beeps
+fileprivate let basalConfirmationBeeps: Bool = true      // whether to emit basal confirmation beeps
+fileprivate let supplementaryBeeps: Bool = true          // whether to emit supplementary confirmation beeps
+fileprivate let tempBasalConfirmationBeeps: Bool = false // whether to emit temp basal confirmation beeps (for testing use)
 
 
 public enum ReservoirAlertState {
@@ -365,13 +369,13 @@ extension OmnipodPumpManager {
     }
 
     // Thread-safe
-    public var bolusBeeps: Bool {
+    public var confirmationBeeps: Bool {
         get {
-            return state.bolusBeeps
+            return state.confirmationBeeps
         }
         set {
             setState { (state) in
-                state.bolusBeeps = newValue
+                state.confirmationBeeps = newValue
             }
         }
     }
@@ -636,7 +640,16 @@ extension OmnipodPumpManager {
         #endif
     }
 
-    private func checkCannulaInsertionFinished() {
+    private func emitConfirmationBeep(session: PodCommsSession, beepConfigType: BeepConfigType) {
+        if self.confirmationBeeps && supplementaryBeeps {
+            let basalCompletionBeep = basalConfirmationBeeps
+            let tempBasalCompletionBeep = tempBasalConfirmationBeeps
+            let bolusCompletionBeep = bolusConfirmationBeeps
+            session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
+        }
+    }
+
+    public func checkCannulaInsertionFinished() {
         let deviceSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Check cannula insertion finished", using: deviceSelector) { (result) in
             switch result {
@@ -644,10 +657,10 @@ extension OmnipodPumpManager {
                 do {
                     try session.checkInsertionCompleted()
                 } catch let error {
-                    self.log.error("Failed to fetch pump status: %{public}@", String(describing: error))
+                    self.log.error("Failed to fetch pod status: %{public}@", String(describing: error))
                 }
             case .failure(let error):
-                self.log.error("Failed to fetch pump status: %{public}@", String(describing: error))
+                self.log.error("Failed to fetch pod status: %{public}@", String(describing: error))
             }
         }
     }
@@ -687,7 +700,7 @@ extension OmnipodPumpManager {
                 }
             } catch let error {
                 completion?(.failure(error))
-                self.log.error("Failed to fetch pump status: %{public}@", String(describing: error))
+                self.log.error("Failed to fetch pod status: %{public}@", String(describing: error))
             }
         }
     }
@@ -744,7 +757,7 @@ extension OmnipodPumpManager {
             switch result {
             case .success(let session):
                 do {
-                    let beep = false
+                    let beep = self.confirmationBeeps && basalConfirmationBeeps
                     let _ = try session.setTime(timeZone: timeZone, basalSchedule: self.state.basalSchedule, date: Date(), acknowledgementBeep: beep, completionBeep: beep)
                     self.setState { (state) in
                         state.timeZone = timeZone
@@ -801,7 +814,7 @@ extension OmnipodPumpManager {
                     case .success:
                         break
                     }
-                    let beep = false
+                    let beep = self.confirmationBeeps && basalConfirmationBeeps
                     let _ = try session.setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
 
                     self.setState { (state) in
@@ -874,7 +887,7 @@ extension OmnipodPumpManager {
     }
 
     public func testingCommands(completion: @escaping (Error?) -> Void) {
-        // use hasSetupPod so that the user can see any fault info
+        // use hasSetupPod so the user can see any fault info and post fault commands can be attempted
         guard self.hasSetupPod else {
             completion(OmnipodPumpManagerError.noPodPaired)
             return
@@ -886,6 +899,7 @@ extension OmnipodPumpManager {
             case .success(let session):
                 do {
                     try session.testingCommands()
+                    self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
                     completion(nil)
                 } catch let error {
                     completion(error)
@@ -911,7 +925,10 @@ extension OmnipodPumpManager {
         self.podComms.runSession(withName: "Play Test Beeps", using: rileyLinkSelector) { (result) in
             switch result {
             case .success(let session):
-                session.beepConfig(beepConfigType: .bipBeepBipBeepBipBeepBipBeep, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: self.bolusBeeps)
+                let basalCompletionBeep = self.confirmationBeeps && basalConfirmationBeeps
+                let tempBasalCompletionBeep = self.confirmationBeeps && tempBasalConfirmationBeeps
+                let bolusCompletionBeep = self.confirmationBeeps && bolusConfirmationBeeps
+                session.beepConfig(beepConfigType: .bipBeepBipBeepBipBeepBipBeep, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
                 // Don't bother emitting another beep sequence to approximate the PDM "Check alarms" function as the Pod beeping is
                 // asynchronous to the UI which will have already printed Succeeded before the first beep sequence is done playing
                 completion(nil)
@@ -939,11 +956,14 @@ extension OmnipodPumpManager {
             case .success(let session):
                 do {
                     // read up to the most recent 50 entries from flash log
+                    self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
                     try session.readFlashLogsRequest(podInfoResponseSubType: .flashLogRecent)
 
                     // read up to the previous 50 entries from flash log
+                    self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
                     try session.readFlashLogsRequest(podInfoResponseSubType: .dumpOlderFlashlog)
 
+                    self.emitConfirmationBeep(session: session, beepConfigType: .beeeeeep)
                     completion(nil)
                 } catch let error {
                     completion(error)
@@ -954,23 +974,23 @@ extension OmnipodPumpManager {
         }
     }
 
-    public func setBolusBeeps(enabled: Bool, completion: @escaping (Error?) -> Void) {
-        self.bolusBeeps = enabled // set here to allow changes on a faulted Pod
-        self.log.default("Set Bolus Beeps to %s", String(describing: enabled))
+    public func setConfirmationBeeps(enabled: Bool, completion: @escaping (Error?) -> Void) {
+        self.confirmationBeeps = enabled // set here to allow changes on a faulted Pod
+        self.log.default("Set Confirmation Beeps to %s", String(describing: enabled))
         guard self.hasActivePod else {
             completion(nil)
             return
         }
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
-        let name: String = enabled ? "Enable Bolus Beeps" : "Disable Bolus Beeps"
+        let name: String = enabled ? "Enable Confirmation Beeps" : "Disable Confirmation Beeps"
         self.podComms.runSession(withName: name, using: rileyLinkSelector) { (result) in
             switch result {
             case .success(let session):
                 let beepConfigType: BeepConfigType = enabled ? .bipBip : .noBeep
-                let basalCompletionBeep = false
-                let tempBasalCompletionBeep = false
-                let bolusCompletionBeep = enabled
+                let basalCompletionBeep = enabled && basalConfirmationBeeps
+                let tempBasalCompletionBeep = enabled && tempBasalConfirmationBeeps
+                let bolusCompletionBeep = enabled && bolusConfirmationBeeps
 
                 // enable/disable Pod completion beeps for any in-progress insulin delivery
                 session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
@@ -1092,7 +1112,7 @@ extension OmnipodPumpManager: PumpManager {
                 state.suspendEngageState = .engaging
             })
 
-            // N.B. with a deliveryType of .all and a beepType other then .noBeep, the Pod will emit 3 beeps!
+            // N.B. with a deliveryType of .all and a beepType other then .noBeep, the Pod will emit 3 beeps! Use .noBeep here & do beeping at end.
             let result = session.cancelDelivery(deliveryType: .all, beepType: .noBeep)
             switch result {
             case .certainFailure(let error):
@@ -1100,6 +1120,10 @@ extension OmnipodPumpManager: PumpManager {
             case .uncertainFailure(let error):
                 completion(error)
             case .success:
+                // Do a separate single confirmation beep if appropriate. There are no in-progress deliveries to worry about after the cancel all.
+                if self.confirmationBeeps && basalConfirmationBeeps {
+                    session.beepConfig(beepConfigType: .beeeeeep, basalCompletionBeep: false, tempBasalCompletionBeep: false, bolusCompletionBeep: false)
+                }
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)
                 }
@@ -1137,7 +1161,7 @@ extension OmnipodPumpManager: PumpManager {
 
             do {
                 let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
-                let beep = false
+                let beep = self.confirmationBeeps && basalConfirmationBeeps
                 let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)
@@ -1240,7 +1264,7 @@ extension OmnipodPumpManager: PumpManager {
             if podStatus.deliveryStatus == .suspended {
                 do {
                     let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
-                    let beep = false
+                    let beep = self.confirmationBeeps && basalConfirmationBeeps
                     podStatus = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
                 } catch let error {
                     completion(.failure(SetBolusError.certain(error as? PodCommsError ?? PodCommsError.commsError(error: error))))
@@ -1258,7 +1282,7 @@ extension OmnipodPumpManager: PumpManager {
             let dose = DoseEntry(type: .bolus, startDate: date, endDate: endDate, value: enactUnits, unit: .units)
             willRequest(dose)
 
-            let beep = self.bolusBeeps
+            let beep = self.confirmationBeeps && bolusConfirmationBeeps
             let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep)
             session.dosesForStorage() { (doses) -> Bool in
                 return self.store(doses: doses, in: session)
@@ -1304,7 +1328,7 @@ extension OmnipodPumpManager: PumpManager {
                 })
 
                 // when cancelling a bolus give a type 6 beeeeeep to match PDM if doing bolus confirmation beeps
-                let beeptype: BeepType = self.bolusBeeps ? .beeeeeep : .noBeep
+                let beeptype: BeepType = self.confirmationBeeps && bolusConfirmationBeeps ? .beeeeeep : .noBeep
                 let result = session.cancelDelivery(deliveryType: .bolus, beepType: beeptype)
                 switch result {
                 case .certainFailure(let error):
@@ -1410,7 +1434,7 @@ extension OmnipodPumpManager: PumpManager {
                         state.tempBasalEngageState = .engaging
                     })
 
-                    let beep = false
+                    let beep = self.confirmationBeeps && tempBasalConfirmationBeeps
                     let result = session.setTempBasal(rate: rate, duration: duration, acknowledgementBeep: beep, completionBeep: beep)
                     let basalStart = Date()
                     let dose = DoseEntry(type: .tempBasal, startDate: basalStart, endDate: basalStart.addingTimeInterval(duration), value: rate, unit: .unitsPerHour)

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1389,7 +1389,9 @@ extension OmnipodPumpManager: PumpManager {
                 let status: StatusResponse
                 let canceledDose: UnfinalizedDose?
 
-                let result = session.cancelDelivery(deliveryType: .tempBasal, beepType: .noBeep)
+                // if resuming a normal basal as denoted by a 0 duration temp basal, use a confirmation beep if appropriate
+                let beep: BeepType = duration < .ulpOfOne && self.confirmationBeeps && tempBasalConfirmationBeeps ? .beep : .noBeep
+                let result = session.cancelDelivery(deliveryType: .tempBasal, beepType: beep)
                 switch result {
                 case .certainFailure(let error):
                     throw error

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -642,10 +642,7 @@ extension OmnipodPumpManager {
 
     private func emitConfirmationBeep(session: PodCommsSession, beepConfigType: BeepConfigType) {
         if self.confirmationBeeps && supplementaryBeeps {
-            let basalCompletionBeep = basalConfirmationBeeps
-            let tempBasalCompletionBeep = tempBasalConfirmationBeeps
-            let bolusCompletionBeep = bolusConfirmationBeeps
-            session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
+            session.beepConfig(beepConfigType: beepConfigType, basalCompletionBeep: basalConfirmationBeeps, tempBasalCompletionBeep: tempBasalConfirmationBeeps, bolusCompletionBeep: bolusConfirmationBeeps)
         }
     }
 

--- a/OmniKit/PumpManager/OmnipodPumpManagerState.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManagerState.swift
@@ -30,7 +30,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
 
     public var expirationReminderDate: Date?
 
-    public var bolusBeeps: Bool
+    public var confirmationBeeps: Bool
 
     // Temporal state not persisted
 
@@ -56,7 +56,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
         self.basalSchedule = basalSchedule
         self.rileyLinkConnectionManagerState = rileyLinkConnectionManagerState
         self.unstoredDoses = []
-        self.bolusBeeps = false
+        self.confirmationBeeps = false
     }
     
     public init?(rawValue: RawValue) {
@@ -131,7 +131,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
             self.unstoredDoses = []
         }
 
-        self.bolusBeeps = rawValue["bolusBeeps"] as? Bool ?? false
+        self.confirmationBeeps = rawValue["confirmationBeeps"] as? Bool ?? rawValue["bolusBeeps"] as? Bool ?? false
     }
     
     public var rawValue: RawValue {
@@ -141,7 +141,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
             "basalSchedule": basalSchedule.rawValue,
             "messageLog": messageLog.rawValue,
             "unstoredDoses": unstoredDoses.map { $0.rawValue },
-            "bolusBeeps": bolusBeeps,
+            "confirmationBeeps": confirmationBeeps,
         ]
         
         if let podState = podState {
@@ -190,7 +190,7 @@ extension OmnipodPumpManagerState: CustomDebugStringConvertible {
             "* tempBasalEngageState: \(String(describing: tempBasalEngageState))",
             "* lastPumpDataReportDate: \(String(describing: lastPumpDataReportDate))",
             "* isPumpDataStale: \(String(describing: isPumpDataStale))",
-            "* bolusBeeps: \(String(describing: bolusBeeps))",
+            "* confirmationBeeps: \(String(describing: confirmationBeeps))",
             String(reflecting: podState),
             String(reflecting: rileyLinkConnectionManagerState),
             String(reflecting: messageLog),

--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -16,9 +16,9 @@ public class ConfirmationBeepsTableViewCell: TextButtonTableViewCell {
 
     public func updateTextLabel(enabled: Bool) {
         if enabled {
-            self.textLabel?.text = LocalizedString("Disable Bolus Beeps", comment: "Title text for button to disable bolus beeps")
+            self.textLabel?.text = LocalizedString("Disable Confirmation Beeps", comment: "Title text for button to disable confirmation beeps")
         } else {
-            self.textLabel?.text = LocalizedString("Enable Bolus Beeps", comment: "Title text for button to enable bolus beeps")
+            self.textLabel?.text = LocalizedString("Enable Confirmation Beeps", comment: "Title text for button to enable confirmation beeps")
         }
     }
     
@@ -68,7 +68,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
 
     lazy var confirmationBeepsTableViewCell: ConfirmationBeepsTableViewCell = {
         let cell = ConfirmationBeepsTableViewCell(style: .default, reuseIdentifier: nil)
-        cell.updateTextLabel(enabled: pumpManager.bolusBeeps)
+        cell.updateTextLabel(enabled: pumpManager.confirmationBeeps)
         return cell
     }()
 
@@ -594,12 +594,12 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
     }
 
     private func confirmationBeepsTapped() {
-        let confirmationBeeps: Bool = pumpManager.bolusBeeps
+        let confirmationBeeps: Bool = pumpManager.confirmationBeeps
         
         func done() {
             DispatchQueue.main.async { [weak self] in
                 if let self = self {
-                    self.confirmationBeepsTableViewCell.updateTextLabel(enabled: self.pumpManager.bolusBeeps)
+                    self.confirmationBeepsTableViewCell.updateTextLabel(enabled: self.pumpManager.confirmationBeeps)
                     self.confirmationBeepsTableViewCell.isLoading = false
                 }
             }
@@ -607,20 +607,20 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
 
         confirmationBeepsTableViewCell.isLoading = true
         if confirmationBeeps {
-            pumpManager.setBolusBeeps(enabled: false, completion: { (error) in
+            pumpManager.setConfirmationBeeps(enabled: false, completion: { (error) in
                 if let error = error {
                     DispatchQueue.main.async {
-                        let title = LocalizedString("Error disabling bolus beeps", comment: "The alert title for disable bolus beeps error")
+                        let title = LocalizedString("Error disabling confirmation beeps", comment: "The alert title for disable confirmation beeps error")
                         self.present(UIAlertController(with: error, title: title), animated: true)
                     }
                 }
                 done()
             })
         } else {
-            pumpManager.setBolusBeeps(enabled: true, completion: { (error) in
+            pumpManager.setConfirmationBeeps(enabled: true, completion: { (error) in
                 if let error = error {
                     DispatchQueue.main.async {
-                        let title = LocalizedString("Error enabling bolus beeps", comment: "The alert title for enable bolus beeps error")
+                        let title = LocalizedString("Error enabling confirmation beeps", comment: "The alert title for enable confirmation beeps error")
                         self.present(UIAlertController(with: error, title: title), animated: true)
                     }
                 }

--- a/OmniKitUI/ViewControllers/PodSetupCompleteViewController.swift
+++ b/OmniKitUI/ViewControllers/PodSetupCompleteViewController.swift
@@ -45,6 +45,16 @@ class PodSetupCompleteViewController: SetupTableViewController {
         if let replaceVC = navigationController as? PodReplacementNavigationController {
             replaceVC.completeSetup()
         }
+        if pumpManager.confirmationBeeps {
+            pumpManager.setConfirmationBeeps(enabled: true, completion: { (error) in
+                if let error = error {
+                    DispatchQueue.main.async {
+                        let title = LocalizedString("Error emitting completion confirmation beep", comment: "The alert title for emitting completion beep error")
+                        self.present(UIAlertController(with: error, title: title), animated: true)
+                    }
+                }
+            })
+        }
     }
 
     override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {


### PR DESCRIPTION
which are Loop's version of the PDM's Confidence Reminders functionality
that when enabled adds confirmation beeps for user initiated Pod activity when doing
Suspend/Resume Delivery, Change Time Zone, Change Basal Rate, Test Command &
upon completion of Pod Setup.