### PR TITLE
Calculate insertion wait time from Pod cannulaInsertionUnits constant

### DIFF
--- a/OmniKit/MessageTransport/MessageBlocks/BolusExtraCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/BolusExtraCommand.swift
@@ -64,7 +64,7 @@ public struct BolusExtraCommand : MessageBlock {
         squareWaveDuration = timeBetweenExtendedPulses * Double(pulseCountX10) / 10
     }
     
-    public init(units: Double, timeBetweenPulses: TimeInterval = 2, squareWaveUnits: Double = 0.0, squareWaveDuration: TimeInterval = 0, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) {
+    public init(units: Double, timeBetweenPulses: TimeInterval = Pod.secondsPerBolusPulse, squareWaveUnits: Double = 0.0, squareWaveDuration: TimeInterval = 0, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) {
         self.acknowledgementBeep = acknowledgementBeep
         self.completionBeep = completionBeep
         self.programReminderInterval = programReminderInterval

--- a/OmniKit/Model/Pod.swift
+++ b/OmniKit/Model/Pod.swift
@@ -13,10 +13,19 @@ public struct Pod {
     public static let pulseSize: Double = 0.05
 
     // Number of pulses required to deliver one unit of insulin
-    public static let pulsesPerUnit: Double = 20
+    public static let pulsesPerUnit: Double = 1 / Pod.pulseSize
 
-    // Units per second
-    public static let bolusDeliveryRate: Double = 0.025
+    // Seconds per pulse for boluses
+    public static let secondsPerBolusPulse: Double = 2
+
+    // Units per second for boluses
+    public static let bolusDeliveryRate: Double = Pod.pulseSize / Pod.secondsPerBolusPulse
+
+    // Seconds per pulse for priming/cannula insertion
+    public static let secondsPerPrimePulse: Double = 1
+
+    // Units per second for priming/cannula insertion
+    public static let primeDeliveryRate: Double = Pod.pulseSize / Pod.secondsPerPrimePulse
 
     // User configured time before expiration advisory (PDM allows 1-24 hours)
     public static let expirationAlertWindow = TimeInterval(hours: 2)

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -336,7 +336,7 @@ public class PodCommsSession {
     }
 
     public func insertCannula() throws -> TimeInterval {
-        let insertionWait: TimeInterval = .seconds(10)
+        let insertionWait: TimeInterval = .seconds(Pod.cannulaInsertionUnits/Pod.pulseSize)
 
         guard let activatedAt = podState.activatedAt else {
             throw PodCommsError.noPodPaired

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -256,7 +256,7 @@ public class PodCommsSession {
     public func prime() throws -> TimeInterval {
         //4c00 00c8 0102
 
-        let primeDuration = TimeInterval(seconds: 55)
+        let primeDuration = TimeInterval(seconds: 55)   // a bit more than (Pod.primeUnits / Pod.primeDeliveryRate)
         
         // Skip following alerts if we've already done them before
         if podState.setupProgress != .startingPrime {
@@ -281,7 +281,7 @@ public class PodCommsSession {
         podState.primeFinishTime = primeFinishTime
         podState.setupProgress = .startingPrime
 
-        let timeBetweenPulses = TimeInterval(seconds: 1)
+        let timeBetweenPulses = TimeInterval(seconds: Pod.secondsPerPrimePulse)
         let bolusSchedule = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: Pod.primeUnits, timeBetweenPulses: timeBetweenPulses)
         let scheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, deliverySchedule: bolusSchedule)
         let bolusExtraCommand = BolusExtraCommand(units: Pod.primeUnits, timeBetweenPulses: timeBetweenPulses)
@@ -336,7 +336,7 @@ public class PodCommsSession {
     }
 
     public func insertCannula() throws -> TimeInterval {
-        let insertionWait: TimeInterval = .seconds(Pod.cannulaInsertionUnits/Pod.pulseSize)
+        let insertionWait: TimeInterval = .seconds(Pod.cannulaInsertionUnits / Pod.primeDeliveryRate)
 
         guard let activatedAt = podState.activatedAt else {
             throw PodCommsError.noPodPaired
@@ -366,7 +366,7 @@ public class PodCommsSession {
         
         // Mark 0.5U delivery with 1 second between pulses for cannula insertion
 
-        let timeBetweenPulses = TimeInterval(seconds: 1)
+        let timeBetweenPulses = TimeInterval(seconds: Pod.secondsPerPrimePulse)
         let bolusSchedule = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: Pod.cannulaInsertionUnits, timeBetweenPulses: timeBetweenPulses)
         let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, deliverySchedule: bolusSchedule)
         
@@ -405,7 +405,7 @@ public class PodCommsSession {
     
     public func bolus(units: Double, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) -> DeliveryCommandResult {
         
-        let timeBetweenPulses = TimeInterval(seconds: 2)
+        let timeBetweenPulses = TimeInterval(seconds: Pod.secondsPerBolusPulse)
         let bolusSchedule = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: units, timeBetweenPulses: timeBetweenPulses)
         let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, deliverySchedule: bolusSchedule)
         
@@ -416,7 +416,7 @@ public class PodCommsSession {
         // Between bluetooth and the radio and firmware, about 1.2s on average passes before we start tracking
         let commsOffset = TimeInterval(seconds: -1.5)
         
-        let bolusExtraCommand = BolusExtraCommand(units: units, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep)
+        let bolusExtraCommand = BolusExtraCommand(units: units, timeBetweenPulses: timeBetweenPulses, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep)
         do {
             let statusResponse: StatusResponse = try send([bolusScheduleCommand, bolusExtraCommand])
             podState.unfinalizedBolus = UnfinalizedDose(bolusAmount: units, startTime: Date().addingTimeInterval(commsOffset), scheduledCertainty: .certain)


### PR DESCRIPTION
Instead of have a fixed 10 second value for insertionWait constant,
calculate this value as (Pod.cannulaInsertionUnits/Pod.pulseSize)
(i.e., 0.5/0.05 = 10 with default cannulaInsertionUnits) so
that the insertion wait time will scale with cannulaInsertionUnits