### PR TITLE
Add .canada PumpRegion

### DIFF
--- a/MinimedKit/Models/PumpRegion.swift
+++ b/MinimedKit/Models/PumpRegion.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum PumpRegion: Int, CustomStringConvertible  {
     case northAmerica = 0
     case worldWide
+    case canada
     
     public var description: String {
         switch self {
@@ -18,6 +19,8 @@ public enum PumpRegion: Int, CustomStringConvertible  {
             return LocalizedString("World-Wide", comment: "Describing the worldwide pump region")
         case .northAmerica:
             return LocalizedString("North America", comment: "Describing the North America pump region")
+        case .canada:
+            return LocalizedString("Canada", comment: "Describing the Canada pump region ")
         }
     }
 }

--- a/MinimedKitUI/Setup/MinimedPumpIDSetupViewController.swift
+++ b/MinimedKitUI/Setup/MinimedPumpIDSetupViewController.swift
@@ -23,8 +23,10 @@ class MinimedPumpIDSetupViewController: SetupTableViewController {
 
         var region: PumpRegion {
             switch self {
-            case .northAmerica, .canada:
+            case .northAmerica:
                 return .northAmerica
+            case .canada:
+                return .canada
             case .worldWide:
                 return .worldWide
             }

--- a/RileyLinkKit/PumpOpsSession.swift
+++ b/RileyLinkKit/PumpOpsSession.swift
@@ -788,7 +788,7 @@ private extension PumpRegion {
         switch self {
         case .worldWide:
             scanFrequencies = [868.25, 868.30, 868.35, 868.40, 868.45, 868.50, 868.55, 868.60, 868.65]
-        case .northAmerica:
+        case .northAmerica, .canada:
             scanFrequencies = [916.45, 916.50, 916.55, 916.60, 916.65, 916.70, 916.75, 916.80]
         }
 


### PR DESCRIPTION
Adding .canada (CA) PumpRegion to differentiate from .northAmerica (NA).
At the moment,  during Medtronic pump setup, selecting CA pump region returns NA, creating confusion.