### PR TITLE
Allow port in NightScout URL

### DIFF
--- a/NightscoutUploadKit/NightscoutUploader.swift
+++ b/NightscoutUploadKit/NightscoutUploader.swift
@@ -54,6 +54,7 @@ public class NightscoutUploader {
         var components = URLComponents()
         components.scheme = siteURL.scheme
         components.host = siteURL.host
+        components.port = siteURL.port
         components.queryItems = queryItems
         components.path = path
         return components.url


### PR DESCRIPTION
There was a change made in the past year that no longer allowed specifying the port on the Nightscout URL.  This allows it to work.  Tested on my device.