### PR TITLE
Rework cancelDelivery to provide reasonable beep semantics

### DIFF
--- a/OmniKit/MessageTransport/MessageBlocks/CancelDeliveryCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/CancelDeliveryCommand.swift
@@ -41,6 +41,7 @@ public struct CancelDeliveryCommand : NonceResyncableMessageBlock {
         public static let tempBasal     = DeliveryType(rawValue: 1 << 1)
         public static let bolus         = DeliveryType(rawValue: 1 << 2)
         
+        public static let allButBasal: DeliveryType = [.tempBasal, .bolus]
         public static let all: DeliveryType = [.none, .basal, .tempBasal, .bolus]
         
         public init(rawValue: UInt8) {


### PR DESCRIPTION
* Use two cancel commands in a single message to implement an integrated single
suspend confirmation beep instead of having to use a separate beepConfig message
* Various confirmation beep related cleanup items