### PR TITLE
Add a HUDTapAction link to Minimed Pump Settings

### DIFF
--- a/MinimedKitUI/MinimedHUDProvider.swift
+++ b/MinimedKitUI/MinimedHUDProvider.swift
@@ -84,7 +84,7 @@ class MinimedHUDProvider: HUDProvider {
     }
 
     public func didTapOnHUDView(_ view: BaseHUDView) -> HUDTapAction? {
-        return nil
+        return HUDTapAction.presentViewController(pumpManager.settingsViewController())
     }
 
     public var hudViewsRawState: HUDProvider.HUDViewsRawState {


### PR DESCRIPTION
This adds a shortcut link to Minimed Pump Settings view, when tapping either reservoir or battery icon in the main HUD section (similar to Omnipod HUD).