### PR TITLE
Use submessages for confirmation beeps instead of a separate message

### DIFF
--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -270,7 +270,7 @@ public class PodCommsSession {
     public func prime() throws -> TimeInterval {
         let primeDuration = TimeInterval(seconds: 55)   // a bit longer than (Pod.primeUnits / Pod.primeDeliveryRate)
 
-        // Skip the fault config and alert setup commands if we've already done them before
+        // Must skip the fault config and alert setup commands if we've already done them before
         if podState.setupProgress != .startingPrime {
             // N.B. If the pod progress is not at least 3 (.pairingSuccess), the pod will not respond to the next two commands
 


### PR DESCRIPTION
Fix Play Test Beeps so that it can report failures
Report errors for confirmation beeps on Read Pulse Log
Don't change the confirmationBeeps variable on beepConfig error
Use new improved beep submessage cancel method when suspending
Add confirmation beeping back for Read Pod Status
Add confirmation beeping for acknowledge alerts
send() now has optional prefixMessage and appendMessage submessages
Improved comments for possible send() errors
Remove obsolete comment in prime() for old PDM action
Improved comments for prime() actions and pod state
beepConfig() now returns optional StatusResponse and can throw
Remove previous split cancel command workaround to handle suspend beeping