### PR TITLE
Updated VersionResponse definition and added additional verifications

### DIFF
--- a/OmniKit/MessageTransport/MessageBlocks/VersionResponse.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/VersionResponse.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+fileprivate let assignAddressVersionLength: UInt8 = 0x15
+fileprivate let setupPodVersionLength: UInt8 = 0x1B
+
 public struct VersionResponse : MessageBlock {
     
     public struct FirmwareVersion : CustomStringConvertible {
@@ -28,83 +31,85 @@ public struct VersionResponse : MessageBlock {
     
     public let blockType: MessageBlockType = .versionResponse
 
-    public let lot: UInt32
-    public let tid: UInt32
-    public let address: UInt32?
-    public let setupState: SetupState
     public let pmVersion: FirmwareVersion
     public let piVersion: FirmwareVersion
+    public let setupState: SetupState
+    public let lot: UInt32
+    public let tid: UInt32
+    public let gain: UInt8? // Only in the shorter assignAddress response
+    public let rssi: UInt8? // Only in the shorter assignAddress response
+    public let address: UInt32
     
     public let data: Data
     
     public init(encodedData: Data) throws {
-        
-        let length = encodedData[1] + 2
-        data = encodedData.subdata(in: 0..<Int(length))
+        let responseLength = encodedData[1]
+        data = encodedData.subdata(in: 0..<Int(responseLength + 2))
 
-        switch length {
-        case 0x17:
-            // This is the response to the address assignment command
-            //01 15 020700 020700 02 02 0000a640 00097c27 9c 1f08ced2
-            //01 15 020700 020700 02 02 0000a377 0003ab37 9f 1f00ee87
-            //0  1  2      5      8  9  10       14       18 19
-            //AA BB CC     DD     EE FF GG       HH       II JJ
-            
-            // AA = mtype (01)
-            // BB = length (21)
-            // CC = PM
-            // DD = PI
-            // EE = ?
-            // FF = pairing state
-            // GG = lot id
-            // HH = tid
-            // II = RLG/RSSI?
-            // JJ = address
-            
-            if let setupState = SetupState(rawValue: encodedData[9]) {
-                self.setupState = setupState
-            } else {
-                throw MessageBlockError.parseError
-            }
-            
+        switch responseLength {
+        case assignAddressVersionLength:
+            // This is the shorter 0x15 response to the 07 AssignAddress command
+            // 01 15 020700 020700 02 02 0000a377 0003ab37 9f 1f00ee87
+            // 0  1  2      5      8  9  10       14       18 19
+            // 01 LL MXMYMZ IXIYIZ 02 0J LLLLLLLL TTTTTTTT GS IIIIIIII
+            // LL = 0x15 (assignAddressVersionLength)
+            // PM = MX.MY.MZ
+            // PI = IX.IY.IZ
+            // 0J = Pod progress state (typically 02, could be 01)
+            // LLLLLLLL = Lot
+            // TTTTTTTT = Tid
+            // GS = ggssssss (Gain/RSSI)
+            // IIIIIIII = address
+
             pmVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 2..<5))
             piVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 5..<8))
-            lot = encodedData[10...].toBigEndian(UInt32.self)
-            tid = encodedData[14...].toBigEndian(UInt32.self)
-            address = encodedData[19...].toBigEndian(UInt32.self)
-            
-        case 0x1d:
-            // This is the response to the set time command
-            //01 1b 13881008340a50 020700 020700 02 03 0000a62b 00044794 1f00ee87
-            //0  1  2              9      12     15 16 17       21       25
-            //AA BB CC             DD     EE     FF GG HH       II       JJ
-            
-            // AA = mtype (01)
-            // BB = length (27)
-            // CC = ?
-            // DD = PM
-            // EE = PI
-            // FF = ?
-            // GG = pairing state
-            // HH = lot id
-            // II = tid
-            // JJ = address
-            
-            if let pairingState = SetupState(rawValue: encodedData[16]) {
-                self.setupState = pairingState
+            if let podProgress = SetupState(rawValue: encodedData[9]) {
+                self.setupState = podProgress
             } else {
                 throw MessageBlockError.parseError
             }
+            lot = encodedData[10...].toBigEndian(UInt32.self)
+            tid = encodedData[14...].toBigEndian(UInt32.self)
+            gain = (encodedData[18] & 0xc0) >> 6
+            rssi = encodedData[18] & 0x3f
+            address = encodedData[19...].toBigEndian(UInt32.self)
             
+        case setupPodVersionLength:
+            // This is the longer 0x1B response to the 03 SetupPod command
+            // 01 1b 13881008340a50 020700 020700 02 03 0000a62b 00044794 1f00ee87
+            // 0  1  2              9      12        16 17       21       25
+            // 01 LL 13881008340A50 MXMYMZ IXIYIZ 02 0J LLLLLLLL TTTTTTTT IIIIIIII
+            // LL = 0x1B (setupPodVersionMessageLength)
+            // PM = MX.MY.MZ
+            // PI = IX.IY.IZ
+            // 0J = Pod progress state (should always be 03)
+            // LLLLLLLL = Lot
+            // TTTTTTTT = Tid
+            // IIIIIIII = address
+
             pmVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 9..<12))
             piVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 12..<15))
+            if let podProgress = SetupState(rawValue: encodedData[16]) {
+                self.setupState = podProgress
+            } else {
+                throw MessageBlockError.parseError
+            }
             lot = encodedData[17...].toBigEndian(UInt32.self)
             tid = encodedData[21...].toBigEndian(UInt32.self)
+            gain = nil // No GS byte in the longer SetupPod response
+            rssi = nil // No GS byte in the longer SetupPod response
             address = encodedData[25...].toBigEndian(UInt32.self)
 
         default:
             throw MessageBlockError.parseError
-
         }
+    }
+
+    public var isAssignAddressVersionResponse: Bool {
+        return self.data.count == assignAddressVersionLength + 2
+    }
+
+    public var isSetupPodVersionResponse: Bool {
+        return self.data.count == setupPodVersionLength + 2
     }
 }

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -20,6 +20,7 @@ public enum PodCommsError: Error {
     case unexpectedPacketType(packetType: PacketType)
     case unexpectedResponse(response: MessageBlockType)
     case unknownResponseType(rawType: UInt8)
+    case invalidAddress(address: UInt32, expectedAddress: UInt32)
     case noRileyLinkAvailable
     case unfinalizedBolus
     case unfinalizedTempBasal
@@ -63,43 +64,14 @@ extension PodCommsError: LocalizedError {
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
         case .commsError:
             return nil
+        case .invalidAddress(address: let address, expectedAddress: let expectedAddress):
+            return String(format: LocalizedString("Invalid address 0x%x. Expected 0x%x", comment: "Error message for when unexpected address is received (1: received address) (2: expected address)"), address, expectedAddress)
         }
     }
     
-    public var failureReason: String? {
-        switch self {
-        case .noPodPaired:
-            return nil
-        case .invalidData:
-            return nil
-        case .noResponse:
-            return nil
-        case .emptyResponse:
-            return nil
-        case .podAckedInsteadOfReturningResponse:
-            return nil
-        case .unexpectedPacketType:
-            return nil
-        case .unexpectedResponse:
-            return nil
-        case .unknownResponseType:
-            return nil
-        case .noRileyLinkAvailable:
-            return nil
-        case .unfinalizedBolus:
-            return nil
-        case .unfinalizedTempBasal:
-            return nil
-        case .nonceResyncFailed:
-            return nil
-        case .podSuspended:
-            return nil
-        case .podFault:
-            return nil
-        case .commsError:
-            return nil
-        }
-    }
+//    public var failureReason: String? {
+//        return nil
+//    }
     
     public var recoverySuggestion: String? {
         switch self {
@@ -112,7 +84,7 @@ extension PodCommsError: LocalizedError {
         case .emptyResponse:
             return nil
         case .podAckedInsteadOfReturningResponse:
-            return nil
+            return LocalizedString("Try again.", comment: "Recovery suggestion when ack received instead of response.")
         case .unexpectedPacketType:
             return nil
         case .unexpectedResponse:
@@ -133,6 +105,8 @@ extension PodCommsError: LocalizedError {
             return nil
         case .commsError:
             return nil
+        case .invalidAddress:
+            return LocalizedString("Crosstalk possible. Please move to a new location and try again.", comment: "Recovery suggestion when unexpected address received.")
         }
     }
 }


### PR DESCRIPTION
Updated VersionResponse field names, ordering, and offsets to batter match wiki
VersionResponse address is never optional
VersionResponse has new optional gain and rssi for the shorter response
Added new isAssignAddressVersionResponse & isAssignAddressVersionResponse vars
Added additional verifications of returned VersionResponse during pairing
Added log.default message for pod info including signal strength during pairing
Added %{public} for all log.error sub-strings in PodComms
Updated commenting in both VersionResponse and PodComms