### PR TITLE
Various error message fixes and improvements

### DIFF
--- a/OmniKit/PumpManager/PodComms.swift
+++ b/OmniKit/PumpManager/PodComms.swift
@@ -67,8 +67,9 @@ class PodComms: CustomDebugStringConvertible {
             throw PodCommsError.podFault(fault: fault)
         }
         
-        guard let config = response.messageBlocks[0] as? VersionResponse else
-        {
+        guard let config = response.messageBlocks[0] as? VersionResponse,
+            config.isAssignAddressVersionResponse == true
+        else {
             self.log.error("assignAddress unexpected response: %{public}@", String(describing: response))
             let responseType = response.messageBlocks[0].blockType
             throw PodCommsError.unexpectedResponse(response: responseType)
@@ -76,7 +77,7 @@ class PodComms: CustomDebugStringConvertible {
         
         guard config.address == address else {
             self.log.error("assignAddress response with incorrect address: %{public}@", String(describing: response))
-            throw PodCommsError.invalidAddress(address: response.address, expectedAddress: address)
+            throw PodCommsError.invalidAddress(address: config.address, expectedAddress: address)
         }
 
         self.log.default("Assigned address 0x%x to pod lot %u tid %u, signal strength %u", config.address, config.lot, config.tid, config.rssi ?? 0)

--- a/OmniKit/PumpManager/PodComms.swift
+++ b/OmniKit/PumpManager/PodComms.swift
@@ -67,9 +67,8 @@ class PodComms: CustomDebugStringConvertible {
             throw PodCommsError.podFault(fault: fault)
         }
         
-        guard let config = response.messageBlocks[0] as? VersionResponse,
-            config.isAssignAddressVersionResponse == true
-        else {
+        guard let config = response.messageBlocks[0] as? VersionResponse else
+        {
             self.log.error("assignAddress unexpected response: %{public}@", String(describing: response))
             let responseType = response.messageBlocks[0].blockType
             throw PodCommsError.unexpectedResponse(response: responseType)

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -49,6 +49,8 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Unexpected response from pod", comment: "Error message shown when empty response from pod was received")
         case .unknownResponseType:
             return nil
+        case .invalidAddress(address: let address, expectedAddress: let expectedAddress):
+            return String(format: LocalizedString("Invalid address 0x%x. Expected 0x%x", comment: "Error message for when unexpected address is received (1: received address) (2: expected address)"), address, expectedAddress)
         case .noRileyLinkAvailable:
             return LocalizedString("No RileyLink available", comment: "Error message shown when no response from pod was received")
         case .unfinalizedBolus:
@@ -64,8 +66,6 @@ extension PodCommsError: LocalizedError {
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
         case .commsError:
             return nil
-        case .invalidAddress(address: let address, expectedAddress: let expectedAddress):
-            return String(format: LocalizedString("Invalid address 0x%x. Expected 0x%x", comment: "Error message for when unexpected address is received (1: received address) (2: expected address)"), address, expectedAddress)
         }
     }
     
@@ -84,13 +84,15 @@ extension PodCommsError: LocalizedError {
         case .emptyResponse:
             return nil
         case .podAckedInsteadOfReturningResponse:
-            return LocalizedString("Try again.", comment: "Recovery suggestion when ack received instead of response.")
+            return LocalizedString("Try again", comment: "Recovery suggestion when ack received instead of response")
         case .unexpectedPacketType:
             return nil
         case .unexpectedResponse:
             return nil
         case .unknownResponseType:
             return nil
+        case .invalidAddress:
+            return LocalizedString("Crosstalk possible. Please move to a new location and try again", comment: "Recovery suggestion when unexpected address received")
         case .noRileyLinkAvailable:
             return LocalizedString("Make sure your RileyLink is nearby and powered on", comment: "Recovery suggestion when no RileyLink is available")
         case .unfinalizedBolus:
@@ -105,8 +107,6 @@ extension PodCommsError: LocalizedError {
             return nil
         case .commsError:
             return nil
-        case .invalidAddress:
-            return LocalizedString("Crosstalk possible. Please move to a new location and try again.", comment: "Recovery suggestion when unexpected address received.")
         }
     }
 }


### PR DESCRIPTION
* Use the correct invalid address argument for PodCommsError.invalidAddress error
* Remove unneeded periods in new PodCommsError recoverySuggestion strings to avoid double periods
* Have errorDescription and recoverySuggestion switches in same order as the PodCommsError enum
* Verify that the assignAddress version response is actually from an assignAddress command