### PR TITLE
Fix incomplete pod age title in HUD (FR)

### DIFF
--- a/OmniKitUI/fr.lproj/Localizable.strings
+++ b/OmniKitUI/fr.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "PM Version" = "Version PM";
 
 /* Label describing pod age view */
-"Pod Age" = " ge du pod";
+"Pod Age" = " âge pod";
 
 /* Title of the pod settings view controller */
 "Pod Settings" = "Réglages du pod";


### PR DESCRIPTION
In current HUD, the pod's age is denoted in French as "ge du pod", rather than "âge du pod". Submitting "âge pod" as translation to keep things concise in the HUD ("age of the pod" vs "pod age").