### PR TITLE
Fix issue #618: Omnipod errors should display localized Strings

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "LoopKit/LoopKit" "8bc6e4b4ed4d8a7e98d8dcf539238b98c83ed3d1"
+github "LoopKit/LoopKit" "953b58e617379354b89ea33e0fd8f220ccc2d366"
 github "LoopKit/MKRingProgressView" "f548a5c64832be2d37d7c91b5800e284887a2a0a"

--- a/OmniKit/MessageTransport/MessageBlocks/CancelDeliveryCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/CancelDeliveryCommand.swift
@@ -36,7 +36,7 @@ public struct CancelDeliveryCommand : NonceResyncableMessageBlock {
     public struct DeliveryType: OptionSet, Equatable {
         public let rawValue: UInt8
         
-        public static let none          = DeliveryType(rawValue: 0)
+        public static let none          = DeliveryType()
         public static let basal         = DeliveryType(rawValue: 1 << 0)
         public static let tempBasal     = DeliveryType(rawValue: 1 << 1)
         public static let bolus         = DeliveryType(rawValue: 1 << 2)

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -973,10 +973,8 @@ extension OmnipodPumpManager {
                 case .failure(let error):
                     reportError(String(describing: error))
                 }
-            } catch let error as LocalizedError {
-                reportError(error.localizedDescription)
             } catch let error {
-                reportError(String(describing: error))
+                reportError(error.localizedDescription)
             }
         }
     }

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1035,24 +1035,14 @@ extension OmnipodPumpManager {
 
     public func readPulseLog(completion: @escaping (String) -> Void) {
 
-        let errString = { (error: Error) -> String in
-            if let localizedError = error as? LocalizedError {
-                return localizedError.localizedDescription
-            }
-            if let podCommsError = error as? PodCommsError, podCommsError.errorDescription != nil {
-                return podCommsError.errorDescription!
-            }
-            return (String(describing: error))
-        }
-
         // use hasSetupPod to be able to read the pulse log from a faulted Pod
         guard self.hasSetupPod else {
-            completion(errString(PodCommsError.noPodPaired))
+            completion(PodCommsError.noPodPaired.localizedDescription)
             return
         }
         if self.state.podState?.fault == nil && self.state.podState?.unfinalizedBolus?.isFinished == false {
             self.log.info("Skipping Read Pulse Log due to bolus still in progress.")
-            completion(errString(PodCommsError.unfinalizedBolus))
+            completion(PodCommsError.unfinalizedBolus.localizedDescription)
             return
         }
 
@@ -1078,10 +1068,10 @@ extension OmnipodPumpManager {
                     self.emitConfirmationBeep(session: session, beepConfigType: .beeeeeep)
                     completion(str)
                 } catch let error {
-                    completion(errString(error))
+                    completion(error.localizedDescription)
                 }
             case .failure(let error):
-                completion(errString(error))
+                completion(error.localizedDescription)
             }
         }
     }

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -64,8 +64,8 @@ extension PodCommsError: LocalizedError {
         case .podFault(let fault):
             let faultDescription = String(describing: fault.currentStatus)
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
-        case .commsError:
-            return nil
+        case .commsError(let error):
+            return error.localizedDescription
         }
     }
     

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -452,6 +452,42 @@ public class PodCommsSession {
             return DeliveryCommandResult.uncertainFailure(error: error as? PodCommsError ?? PodCommsError.commsError(error: error))
         }
     }
+
+    @discardableResult
+    private func handleCancelDosing(deliveryType: CancelDeliveryCommand.DeliveryType, bolusNotDelivered: Double) -> UnfinalizedDose? {
+        var canceledDose: UnfinalizedDose? = nil
+        let now = Date()
+
+        if deliveryType.contains(.basal) {
+            podState.unfinalizedSuspend = UnfinalizedDose(suspendStartTime: now, scheduledCertainty: .certain)
+            podState.suspendState = .suspended(now)
+        }
+
+        if let unfinalizedTempBasal = podState.unfinalizedTempBasal,
+            let finishTime = unfinalizedTempBasal.finishTime,
+            deliveryType.contains(.tempBasal),
+            finishTime > now
+        {
+            podState.unfinalizedTempBasal?.cancel(at: now)
+            if !deliveryType.contains(.basal) {
+                podState.suspendState = .resumed(now)
+            }
+            canceledDose = podState.unfinalizedTempBasal
+            log.info("Interrupted temp basal: %@", String(describing: canceledDose))
+        }
+
+        if let unfinalizedBolus = podState.unfinalizedBolus,
+            let finishTime = unfinalizedBolus.finishTime,
+            deliveryType.contains(.bolus),
+            finishTime > now
+        {
+            podState.unfinalizedBolus?.cancel(at: now, withRemaining: bolusNotDelivered)
+            canceledDose = podState.unfinalizedBolus
+            log.info("Interrupted bolus: %@", String(describing: canceledDose))
+        }
+
+        return canceledDose
+    }
     
     // cancelDelivery() implements a smart interface to the Pod's cancel delivery command
     public func cancelDelivery(deliveryType: CancelDeliveryCommand.DeliveryType, beepType: BeepType) -> CancelDeliveryResult {
@@ -468,36 +504,8 @@ public class PodCommsSession {
         }
         do {
             let status: StatusResponse = try send(message)
-            let now = Date()
-            if deliveryType.contains(.basal) {
-                podState.unfinalizedSuspend = UnfinalizedDose(suspendStartTime: now, scheduledCertainty: .certain)
-                podState.suspendState = .suspended(now)
-            }
 
-            var canceledDose: UnfinalizedDose? = nil
-
-            if let unfinalizedTempBasal = podState.unfinalizedTempBasal,
-                let finishTime = unfinalizedTempBasal.finishTime,
-                deliveryType.contains(.tempBasal),
-                finishTime > now
-            {
-                podState.unfinalizedTempBasal?.cancel(at: now)
-                if !deliveryType.contains(.basal) {
-                    podState.suspendState = .resumed(now)
-                }
-                canceledDose = podState.unfinalizedTempBasal
-                log.info("Interrupted temp basal: %@", String(describing: canceledDose))
-            }
-
-            if let unfinalizedBolus = podState.unfinalizedBolus,
-                let finishTime = unfinalizedBolus.finishTime,
-                deliveryType.contains(.bolus),
-                finishTime > now
-            {
-                podState.unfinalizedBolus?.cancel(at: now, withRemaining: status.insulinNotDelivered)
-                canceledDose = podState.unfinalizedBolus
-                log.info("Interrupted bolus: %@", String(describing: canceledDose))
-            }
+            let canceledDose = handleCancelDosing(deliveryType: deliveryType, bolusNotDelivered: status.insulinNotDelivered)
 
             podState.updateFromStatusResponse(status)
 
@@ -617,6 +625,19 @@ public class PodCommsSession {
                 throw error
             default:
                 break
+            }
+        }
+
+        if let fault = podState.fault {
+            // Be sure to clean up the dosing info in case cancelDelivery() wasn't called
+            // (or if it was called and it had a fault return) & then read the pulse log.
+            handleCancelDosing(deliveryType: .all, bolusNotDelivered: fault.insulinNotDelivered)
+            do {
+                // read the most recent pulse log entries for later analysis, but don't throw on error
+                let podInfoCommand = GetStatusCommand(podInfoType: .pulseLogRecent)
+                let _: PodInfoResponse = try send([podInfoCommand])
+            } catch let error {
+                log.error("Read pulse log failed: %@", String(describing: error))
             }
         }
 

--- a/OmniKitUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniKitUI/ViewControllers/CommandResponseViewController.swift
@@ -27,10 +27,16 @@ extension CommandResponseViewController {
                     }).joined(separator: "\n")
 
                     if messageWithRecovery.isEmpty {
-                        response = String(describing: error)
+                        if error.localizedDescription.isEmpty {
+                            response = String(describing: error)
+                        } else {
+                            response = error.localizedDescription
+                        }
                     } else {
                         response = messageWithRecovery
                     }
+                } else if let localizedError = error as? LocalizedError, !localizedError.localizedDescription.isEmpty {
+                    response = localizedError.localizedDescription
                 } else if let error = error {
                     response = String(describing: error)
                 } else {
@@ -46,13 +52,7 @@ extension CommandResponseViewController {
 
     static func readPodStatus(pumpManager: OmnipodPumpManager) -> T {
         return T { (completionHandler) -> String in
-            pumpManager.readPodStatus() { (error) in
-                let response: String
-                if let error = error {
-                    response = String(describing: error)
-                } else {
-                    response = self.successText
-                }
+            pumpManager.readPodStatus() { (response) in
                 DispatchQueue.main.async {
                     completionHandler(response)
                 }
@@ -65,7 +65,9 @@ extension CommandResponseViewController {
         return T { (completionHandler) -> String in
             pumpManager.testingCommands() { (error) in
                 let response: String
-                if let error = error {
+                if let localizedError = error as? LocalizedError, !localizedError.localizedDescription.isEmpty {
+                    response = localizedError.localizedDescription
+                } else if error != nil {
                     response = String(describing: error)
                 } else {
                     response = self.successText
@@ -82,7 +84,9 @@ extension CommandResponseViewController {
         return T { (completionHandler) -> String in
             pumpManager.playTestBeeps() { (error) in
                 let response: String
-                if let error = error {
+                if let localizedError = error as? LocalizedError, !localizedError.localizedDescription.isEmpty {
+                    response = localizedError.localizedDescription
+                } else if error != nil {
                     response = String(describing: error)
                 } else {
                     response = self.successText
@@ -97,13 +101,7 @@ extension CommandResponseViewController {
 
     static func readPulseLog(pumpManager: OmnipodPumpManager) -> T {
         return T { (completionHandler) -> String in
-            pumpManager.readPulseLog() { (error) in
-                let response: String
-                if let error = error {
-                    response = String(describing: error)
-                } else {
-                    response = self.successText
-                }
+            pumpManager.readPulseLog() { (response) in
                 DispatchQueue.main.async {
                     completionHandler(response)
                 }

--- a/OmniKitUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniKitUI/ViewControllers/CommandResponseViewController.swift
@@ -58,14 +58,8 @@ extension CommandResponseViewController {
     static func testingCommands(pumpManager: OmnipodPumpManager) -> T {
         return T { (completionHandler) -> String in
             pumpManager.testingCommands() { (error) in
-                let response: String
-                if let error = error {
-                    response = error.localizedDescription
-                } else {
-                    response = self.successText
-                }
                 DispatchQueue.main.async {
-                    completionHandler(response)
+                    completionHandler(error?.localizedDescription ?? self.successText)
                 }
             }
             return LocalizedString("Testing Commands…", comment: "Progress message for testing commands.")
@@ -75,14 +69,8 @@ extension CommandResponseViewController {
     static func playTestBeeps(pumpManager: OmnipodPumpManager) -> T {
         return T { (completionHandler) -> String in
             pumpManager.playTestBeeps() { (error) in
-                let response: String
-                if let error = error {
-                    response = error.localizedDescription
-                } else {
-                    response = self.successText
-                }
                 DispatchQueue.main.async {
-                    completionHandler(response)
+                    completionHandler(error?.localizedDescription ?? self.successText)
                 }
             }
             return LocalizedString("Play Test Beeps…", comment: "Progress message for play test beeps.")

--- a/OmniKitUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniKitUI/ViewControllers/CommandResponseViewController.swift
@@ -27,15 +27,11 @@ extension CommandResponseViewController {
                     }).joined(separator: "\n")
 
                     if messageWithRecovery.isEmpty {
-                        if error.localizedDescription.isEmpty {
-                            response = String(describing: error)
-                        } else {
-                            response = error.localizedDescription
-                        }
+                        response = error.localizedDescription
                     } else {
                         response = messageWithRecovery
                     }
-                } else if let localizedError = error as? LocalizedError, !localizedError.localizedDescription.isEmpty {
+                } else if let localizedError = error as? LocalizedError {
                     response = localizedError.localizedDescription
                 } else if let error = error {
                     response = String(describing: error)
@@ -65,7 +61,7 @@ extension CommandResponseViewController {
         return T { (completionHandler) -> String in
             pumpManager.testingCommands() { (error) in
                 let response: String
-                if let localizedError = error as? LocalizedError, !localizedError.localizedDescription.isEmpty {
+                if let localizedError = error as? LocalizedError {
                     response = localizedError.localizedDescription
                 } else if error != nil {
                     response = String(describing: error)
@@ -84,7 +80,7 @@ extension CommandResponseViewController {
         return T { (completionHandler) -> String in
             pumpManager.playTestBeeps() { (error) in
                 let response: String
-                if let localizedError = error as? LocalizedError, !localizedError.localizedDescription.isEmpty {
+                if let localizedError = error as? LocalizedError {
                     response = localizedError.localizedDescription
                 } else if error != nil {
                     response = String(describing: error)

--- a/OmniKitUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniKitUI/ViewControllers/CommandResponseViewController.swift
@@ -59,10 +59,8 @@ extension CommandResponseViewController {
         return T { (completionHandler) -> String in
             pumpManager.testingCommands() { (error) in
                 let response: String
-                if let localizedError = error as? LocalizedError {
-                    response = localizedError.localizedDescription
-                } else if error != nil {
-                    response = String(describing: error)
+                if let error = error {
+                    response = error.localizedDescription
                 } else {
                     response = self.successText
                 }
@@ -78,10 +76,8 @@ extension CommandResponseViewController {
         return T { (completionHandler) -> String in
             pumpManager.playTestBeeps() { (error) in
                 let response: String
-                if let localizedError = error as? LocalizedError {
-                    response = localizedError.localizedDescription
-                } else if error != nil {
-                    response = String(describing: error)
+                if let error = error {
+                    response = error.localizedDescription
                 } else {
                     response = self.successText
                 }
@@ -104,3 +100,4 @@ extension CommandResponseViewController {
         }
     }
 }
+

--- a/OmniKitUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniKitUI/ViewControllers/CommandResponseViewController.swift
@@ -31,10 +31,8 @@ extension CommandResponseViewController {
                     } else {
                         response = messageWithRecovery
                     }
-                } else if let localizedError = error as? LocalizedError {
-                    response = localizedError.localizedDescription
                 } else if let error = error {
-                    response = String(describing: error)
+                    response = error.localizedDescription
                 } else {
                     response = self.successText
                 }

--- a/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
@@ -102,13 +102,17 @@ class InsertCannulaSetupViewController: SetupTableViewController {
             var errorText = lastError?.localizedDescription
             
             if let error = lastError as? LocalizedError {
-                let localizedText = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap({ $0 }).joined(separator: ". ") + "."
+                let localizedText = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap({ $0 }).joined(separator: ". ")
                 
                 if !localizedText.isEmpty {
-                    errorText = localizedText
+                    errorText = localizedText + "."
                 }
             }
             
+            // If we have an error but no error text, generate a string to describe the error
+            if let error = lastError, (errorText == nil || errorText!.isEmpty) {
+                errorText = String(describing: error)
+            }
             loadingText = errorText
             
             // If we have an error, update the continue state

--- a/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
@@ -126,6 +126,7 @@ class PairPodSetupViewController: SetupTableViewController {
             }
             
             var errorStrings: [String]
+            var errorText: String
             
             if let error = lastError as? LocalizedError {
                 errorStrings = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap { $0 }
@@ -140,8 +141,16 @@ class PairPodSetupViewController: SetupTableViewController {
                     previouslyEncounteredWeakComms = true
                 }
             }
+
+            errorText = errorStrings.joined(separator: ". ")
             
-            loadingText = errorStrings.joined(separator: ". ") + "."
+            if !errorText.isEmpty {
+                errorText += "."
+            } else if let error = lastError {
+                // We have an error but no error text, generate a string to describe the error
+                errorText = String(describing: error)
+            }
+            loadingText = errorText
             
             // If we have an error, update the continue state
             if let podCommsError = lastError as? PodCommsError,

--- a/OmniKitUI/ViewControllers/ReplacePodViewController.swift
+++ b/OmniKitUI/ViewControllers/ReplacePodViewController.swift
@@ -140,13 +140,18 @@ class ReplacePodViewController: SetupTableViewController {
             var errorText = lastError?.localizedDescription
             
             if let error = lastError as? LocalizedError {
-                let localizedText = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap({ $0 }).joined(separator: ". ") + "."
+                let localizedText = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap({ $0 }).joined(separator: ". ")
                 
                 if !localizedText.isEmpty {
-                    errorText = localizedText
+                    errorText = localizedText + "."
                 }
             }
             
+            // If we have an error but no error text, generate a string to describe the error
+            if let error = lastError, (errorText == nil || errorText!.isEmpty) {
+                errorText = String(describing: error)
+            }
+
             tableView.beginUpdates()
             loadingLabel.text = errorText
             


### PR DESCRIPTION
* Return the underlying localized error string for PodCommError.commsError
* Have all OmnipodPumpManager commands return a localized error
* Fix coding errors in CommandResponseViewController for Read Pulse Log
and Read Pulse Log which return a String and not an error