### PR TITLE
Fix issue #617: OmniKitUI displays a single dot for certain setup errors

### DIFF
--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -64,8 +64,8 @@ extension PodCommsError: LocalizedError {
         case .podFault(let fault):
             let faultDescription = String(describing: fault.currentStatus)
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
-        case .commsError:
-            return nil
+        case .commsError(let error):
+            return error.localizedDescription
         }
     }
     

--- a/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
@@ -102,13 +102,17 @@ class InsertCannulaSetupViewController: SetupTableViewController {
             var errorText = lastError?.localizedDescription
             
             if let error = lastError as? LocalizedError {
-                let localizedText = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap({ $0 }).joined(separator: ". ") + "."
+                let localizedText = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap({ $0 }).joined(separator: ". ")
                 
                 if !localizedText.isEmpty {
-                    errorText = localizedText
+                    errorText = localizedText + "."
                 }
             }
             
+            // If we have an error but no error text, generate a string to describe the error
+            if let error = lastError, (errorText == nil || errorText!.isEmpty) {
+                errorText = String(describing: error)
+            }
             loadingText = errorText
             
             // If we have an error, update the continue state

--- a/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
@@ -126,6 +126,7 @@ class PairPodSetupViewController: SetupTableViewController {
             }
             
             var errorStrings: [String]
+            var errorText: String
             
             if let error = lastError as? LocalizedError {
                 errorStrings = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap { $0 }
@@ -140,8 +141,16 @@ class PairPodSetupViewController: SetupTableViewController {
                     previouslyEncounteredWeakComms = true
                 }
             }
+
+            errorText = errorStrings.joined(separator: ". ")
             
-            loadingText = errorStrings.joined(separator: ". ") + "."
+            if !errorText.isEmpty {
+                errorText += "."
+            } else if let error = lastError {
+                // We have an error but no error text, generate a string to describe the error
+                errorText = String(describing: error)
+            }
+            loadingText = errorText
             
             // If we have an error, update the continue state
             if let podCommsError = lastError as? PodCommsError,

--- a/OmniKitUI/ViewControllers/ReplacePodViewController.swift
+++ b/OmniKitUI/ViewControllers/ReplacePodViewController.swift
@@ -140,13 +140,18 @@ class ReplacePodViewController: SetupTableViewController {
             var errorText = lastError?.localizedDescription
             
             if let error = lastError as? LocalizedError {
-                let localizedText = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap({ $0 }).joined(separator: ". ") + "."
+                let localizedText = [error.errorDescription, error.failureReason, error.recoverySuggestion].compactMap({ $0 }).joined(separator: ". ")
                 
                 if !localizedText.isEmpty {
-                    errorText = localizedText
+                    errorText = localizedText + "."
                 }
             }
             
+            // If we have an error but no error text, generate a string to describe the error
+            if let error = lastError, (errorText == nil || errorText!.isEmpty) {
+                errorText = String(describing: error)
+            }
+
             tableView.beginUpdates()
             loadingLabel.text = errorText
             


### PR DESCRIPTION
* Return the underlying localized error string for PodCommError.commsError
* Improved lastError handling logic in PairPodSetupViewController,
InsertCannulaSetupViewController & ReplacePodViewController to never display a single
dot (".") for any error and to always display some message for any errors returned.