### PR TITLE
More pairing fixes  https://github.com/LoopKit/Loop/issues/1338

### DIFF
--- a/OmniKit/MessageTransport/MessageTransport.swift
+++ b/OmniKit/MessageTransport/MessageTransport.swift
@@ -209,7 +209,12 @@ class PodMessageTransport: MessageTransport {
     /// - Returns: The received message response
     /// - Throws:
     ///     - PodCommsError.noResponse
+    ///     - PodCommsError.podAckedInsteadOfReturningResponse
+    ///     - PodCommsError.unexpectedPacketType
+    ///     - PodCommsError.emptyResponse
     ///     - MessageError.invalidCrc
+    ///     - MessageError.invalidSequence
+    ///     - MessageError.invalidAddress
     ///     - RileyLinkDeviceError
     func sendMessage(_ message: Message) throws -> Message {
         

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1043,7 +1043,7 @@ extension OmnipodPumpManager {
         }
         if self.state.podState?.isFaulted == false && self.state.podState?.unfinalizedBolus?.isFinished == false {
             self.log.info("Skipping Read Pulse Log due to bolus still in progress.")
-            completion(String(describing: PodCommsError.unfinalizedBolus))
+            completion(PodCommsError.unfinalizedBolus.localizedDescription)
             return
         }
 

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1041,19 +1041,11 @@ extension OmnipodPumpManager {
             completion(PodCommsError.noPodPaired.localizedDescription)
             return
         }
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-        if self.state.podState?.fault == nil && self.state.podState?.unfinalizedBolus?.isFinished == false {
-            self.log.info("Skipping Read Pulse Log due to bolus still in progress.")
-            completion(PodCommsError.unfinalizedBolus.localizedDescription)
-            return
-        }
-#else
         if self.state.podState?.isFaulted == false && self.state.podState?.unfinalizedBolus?.isFinished == false {
             self.log.info("Skipping Read Pulse Log due to bolus still in progress.")
             completion(String(describing: PodCommsError.unfinalizedBolus))
             return
         }
-#endif
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Read Pulse Log", using: rileyLinkSelector) { (result) in

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1038,11 +1038,19 @@ extension OmnipodPumpManager {
             completion(String(describing: OmnipodPumpManagerError.noPodPaired))
             return
         }
+#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
         if self.state.podState?.fault == nil && self.state.podState?.unfinalizedBolus?.isFinished == false {
             self.log.info("Skipping Read Pulse Log due to bolus still in progress.")
             completion(String(describing: PodCommsError.unfinalizedBolus))
             return
         }
+#else
+        if self.state.podState?.isFaulted == false && self.state.podState?.unfinalizedBolus?.isFinished == false {
+            self.log.info("Skipping Read Pulse Log due to bolus still in progress.")
+            completion(String(describing: PodCommsError.unfinalizedBolus))
+            return
+        }
+#endif
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Read Pulse Log", using: rileyLinkSelector) { (result) in

--- a/OmniKit/PumpManager/PodComms.swift
+++ b/OmniKit/PumpManager/PodComms.swift
@@ -11,6 +11,14 @@ import RileyLinkBLEKit
 import LoopKit
 import os.log
 
+#if !SKIP_RSSI_CHECKS
+fileprivate let enforceRssiLimits = true    // whether to enforce RSSI limit checking
+fileprivate let maxRssiAllowed = 59         // maximum RSSI limit allowed when RSSI limit checking is enabled
+fileprivate let minRssiAllowed = 30         // minimum RSSI limit allowed when RSSI limit checking is enabled
+fileprivate let numRssiRetries = 2          // number of automatic retries if received RSSI value is out of range
+fileprivate let rssiTesting = false         // whether to display message with RSSI value for testing without pairing
+#endif
+
 protocol PodCommsDelegate: class {
     func podComms(_ podComms: PodComms, didChange podState: PodState)
 }
@@ -24,6 +32,8 @@ class PodComms: CustomDebugStringConvertible {
     weak var messageLogger: MessageLogger?
 
     public let log = OSLog(category: "PodComms")
+
+    private var startingPacketNumber = 0
 
     // Only valid to access on the session serial queue
     private var podState: PodState? {
@@ -41,52 +51,161 @@ class PodComms: CustomDebugStringConvertible {
         self.messageLogger = nil
     }
     
-    private func assignAddress(address: UInt32, commandSession: CommandSession) throws -> PodState {
-        commandSession.assertOnSessionQueue()
-        
-        self.log.debug("Attempting pairing with address %{public}@", String(format: "%04X", address))
+    // Handles all the common work to send and verify the version response for the two pairing commands, AssignAddress and SetupPod
+    private func sendPairMessage(address: UInt32, transport: PodMessageTransport, message: Message) throws -> VersionResponse {
 
-        let messageTransportState = MessageTransportState(packetNumber: 0, messageNumber: 0)
-        
+        defer {
+            log.debug("sendPairMessage saving current transport packet #%d", transport.packetNumber)
+            if self.podState != nil {
+                self.podState!.messageTransportState = MessageTransportState(packetNumber: transport.packetNumber, messageNumber: transport.messageNumber)
+            } else {
+                self.startingPacketNumber = transport.packetNumber
+            }
+        }
+
+#if !SKIP_AUTO_PACKET_RETRY
+        var didRetry = false
+#endif
+#if !SKIP_RSSI_CHECKS
+        var rssiRetries = numRssiRetries
+#endif
+        while true {
+#if SKIP_AUTO_PACKET_RETRY
+            let response = try transport.sendMessage(message)
+#else
+            let response: Message
+            do {
+                response = try transport.sendMessage(message)
+            } catch let error {
+                if let podCommsError = error as? PodCommsError {
+                    switch podCommsError {
+                    // These errors can happen some times when the responses are not seen for a long
+                    // enough time. Automatically retrying using the already incremented packet # can
+                    // clear this condition without requiring any user interaction for a pairing failure.
+                    case .podAckedInsteadOfReturningResponse, .noResponse:
+                        if didRetry == false {
+                            didRetry = true
+                            log.debug("sendPairMessage to retry using updated packet #%d", transport.packetNumber)
+                            continue // the transport packet # is already advanced for the retry
+                        }
+                    default:
+                        break
+                    }
+                }
+                throw error
+            }
+#endif
+
+            if let fault = response.fault {
+                log.error("Pod Fault: %{public}@", String(describing: fault))
+                if let podState = self.podState, podState.fault == nil {
+                    self.podState!.fault = fault
+                }
+                throw PodCommsError.podFault(fault: fault)
+            }
+
+            guard let config = response.messageBlocks[0] as? VersionResponse else {
+                log.error("sendPairMessage unexpected response: %{public}@", String(describing: response))
+                let responseType = response.messageBlocks[0].blockType
+                throw PodCommsError.unexpectedResponse(response: responseType)
+            }
+
+            guard config.address == address else {
+                log.error("sendPairMessage unexpected address return of %{public}@ instead of expected %{public}@",
+                  String(format: "04X", config.address), String(format: "%04X", address))
+                throw PodCommsError.invalidAddress(address: config.address, expectedAddress: address)
+            }
+
+#if !SKIP_POD_VERIFICATION
+            // If we previously had podState, verify that we are still dealing with the same pod
+            if let podState = self.podState, (podState.lot != config.lot || podState.tid != config.tid) {
+                // Have a new pod, could be a pod change w/o deactivation (or we're picking up some other pairing pod!)
+                log.error("Received pod response for [lot %u tid %u], expected [lot %u tid %u]", config.lot, config.tid, podState.lot, podState.tid)
+                throw PodCommsError.podChange
+            }
+#endif
+
+            if let rssi = config.rssi, let gain = config.gain {
+                let rssiStr = String(format: "Receiver Low Gain: %d.\nReceived Signal Strength Indicator: %d", gain, rssi)
+                log.default("%s", rssiStr)
+#if !SKIP_RSSI_CHECKS
+                if rssiTesting {
+                    throw PodCommsError.debugFault(str: rssiStr)
+                }
+                if enforceRssiLimits {
+                    rssiRetries -= 1
+                    if rssi < minRssiAllowed {
+                        log.default("RSSI value %d is less than minimum allowed value of %d, %d retries left", rssi, minRssiAllowed, rssiRetries)
+                        if rssiRetries > 0 {
+                            continue
+                        }
+                        throw PodCommsError.rssiTooLow
+                    }
+                    if rssi > maxRssiAllowed {
+                        log.default("RSSI value %d is more than maximum allowed value of %d, %d retries left", rssi, maxRssiAllowed, rssiRetries)
+                        if rssiRetries > 0 {
+                            continue
+                        }
+                        throw PodCommsError.rssiTooHigh
+                    }
+                }
+#endif
+            }
+
+            if self.podState == nil {
+                log.default("Creating PodState for address %{public}@ [lot %u tid %u], packet #%d, message #%d", String(format: "%04X", config.address), config.lot, config.tid, transport.packetNumber, transport.messageNumber)
+                self.podState = PodState(
+                    address: config.address,
+                    piVersion: String(describing: config.piVersion),
+                    pmVersion: String(describing: config.pmVersion),
+                    lot: config.lot,
+                    tid: config.tid,
+                    packetNumber: transport.packetNumber,
+                    messageNumber: transport.messageNumber
+                )
+                // podState setupProgress state should be addressAssigned
+            }
+
+#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
+            // Now that we have podState, check for an activation timeout condition that can be noted in setupProgress
+            guard config.podProgressStatus != .activationTimeExceeded else {
+                // The 2 hour window for the initial pairing has expired
+                self.podState?.setupProgress = .activationTimeout
+                throw PodCommsError.activationTimeExceeded
+            }
+
+#endif
+            if config.podProgressStatus == .pairingCompleted {
+                log.info("Version Response %{public}@ indicates pairing is complete, moving pod to configured state", String(describing: config))
+                self.podState?.setupProgress = .podConfigured
+            }
+
+            return config
+        }
+    }
+
+    private func assignAddress(address: UInt32, commandSession: CommandSession) throws {
+        commandSession.assertOnSessionQueue()
+
+        let packetNumber, messageNumber: Int
+        if let podState = self.podState {
+            packetNumber = podState.messageTransportState.packetNumber
+            messageNumber = podState.messageTransportState.messageNumber
+        } else {
+            packetNumber = self.startingPacketNumber
+            messageNumber = 0
+        }
+
+        log.debug("Attempting pairing with address %{public}@ using packet #%d", String(format: "%04X", address), packetNumber)
+        let messageTransportState = MessageTransportState(packetNumber: packetNumber, messageNumber: messageNumber)
         let transport = PodMessageTransport(session: commandSession, address: 0xffffffff, ackAddress: address, state: messageTransportState)
         transport.messageLogger = messageLogger
         
-        // Assign Address
+        // Create the Assign Address command message
         let assignAddress = AssignAddressCommand(address: address)
-        
         let message = Message(address: 0xffffffff, messageBlocks: [assignAddress], sequenceNum: transport.messageNumber)
-        
-        let response = try transport.sendMessage(message)
 
-        if let fault = response.fault {
-            self.log.error("Pod Fault: %{public}@", String(describing: fault))
-            throw PodCommsError.podFault(fault: fault)
-        }
-        
-        guard let config = response.messageBlocks[0] as? VersionResponse else
-        {
-            self.log.error("assignAddress unexpected response: %{public}@", String(describing: response))
-            let responseType = response.messageBlocks[0].blockType
-            throw PodCommsError.unexpectedResponse(response: responseType)
-        }
-        
-        guard config.address == address else {
-            self.log.error("assignAddress response with incorrect address: %{public}@", String(describing: response))
-            throw PodCommsError.invalidAddress(address: config.address, expectedAddress: address)
-        }
-
-        self.log.default("Assigned address 0x%x to pod lot %u tid %u, signal strength %u", config.address, config.lot, config.tid, config.rssi ?? 0)
-        
-        // Pairing state should be addressAssigned
-        return PodState(
-            address: address,
-            piVersion: String(describing: config.piVersion),
-            pmVersion: String(describing: config.pmVersion),
-            lot: config.lot,
-            tid: config.tid,
-            packetNumber: transport.packetNumber,
-            messageNumber: transport.messageNumber
-        )
+        _ = try sendPairMessage(address: address, transport: transport, message: message)
     }
     
     private func setupPod(podState: PodState, timeZone: TimeZone, commandSession: CommandSession) throws {
@@ -100,46 +219,23 @@ class PodComms: CustomDebugStringConvertible {
         
         let message = Message(address: 0xffffffff, messageBlocks: [setupPod], sequenceNum: transport.messageNumber)
         
-        defer {
-            self.podState?.messageTransportState = MessageTransportState(packetNumber: transport.packetNumber, messageNumber: transport.messageNumber)
-        }
-
-        let response: Message
+        let versionResponse: VersionResponse
         do {
-            response = try transport.sendMessage(message)
+            versionResponse = try sendPairMessage(address: podState.address, transport: transport, message: message)
         } catch let error {
             if case PodCommsError.podAckedInsteadOfReturningResponse = error {
-                self.log.default("Pod acked instead of returning response. Moving pod to configured state.")
+                log.default("SetupPod acked instead of returning response. Moving pod to configured state.")
                 self.podState?.setupProgress = .podConfigured
                 return
             }
+            log.error("SetupPod returns error %{public}@", String(describing: error))
             throw error
         }
 
-        if let fault = response.fault {
-            self.log.error("Pod Fault: %{public}@", String(describing: fault))
-            throw PodCommsError.podFault(fault: fault)
-        }
-
-        guard let config = response.messageBlocks[0] as? VersionResponse,
-            config.isSetupPodVersionResponse == true
-        else {
-            self.log.error("setupPod unexpected response: %{public}@", String(describing: response))
-            let responseType = response.messageBlocks[0].blockType
-            throw PodCommsError.unexpectedResponse(response: responseType)
-        }
-        
-        guard config.podProgressStatus == .pairingCompleted else {
-            self.log.error("setupPod unexpected pod progress value of %{public}@", String(describing: config.podProgressStatus))
+        guard versionResponse.isSetupPodVersionResponse else {
+            log.error("SetupPod unexpected VersionResponse type: %{public}@", String(describing: versionResponse))
             throw PodCommsError.invalidData
         }
-
-        guard config.address == podState.address else {
-            self.log.error("SetupPod response with incorrect address: %{public}@", String(describing: response))
-            throw PodCommsError.invalidAddress(address: config.address, expectedAddress: podState.address)
-        }
-        
-        self.podState?.setupProgress = .podConfigured
     }
     
     func assignAddressAndSetupPod(address: UInt32, using deviceSelector: @escaping (_ completion: @escaping (_ device: RileyLinkDevice?) -> Void) -> Void, timeZone: TimeZone, messageLogger: MessageLogger?, _ block: @escaping (_ result: SessionRunResult) -> Void)
@@ -155,7 +251,7 @@ class PodComms: CustomDebugStringConvertible {
                     self.configureDevice(device, with: commandSession)
                     
                     if self.podState == nil {
-                        self.podState = try self.assignAddress(address: address, commandSession: commandSession)
+                        try self.assignAddress(address: address, commandSession: commandSession)
                     }
                     
                     guard self.podState != nil else {
@@ -163,7 +259,15 @@ class PodComms: CustomDebugStringConvertible {
                         return
                     }
 
-                    try self.setupPod(podState: self.podState!, timeZone: timeZone, commandSession: commandSession)
+                    if self.podState!.setupProgress != .podConfigured {
+                        try self.setupPod(podState: self.podState!, timeZone: timeZone, commandSession: commandSession)
+                    }
+
+                    guard self.podState!.setupProgress == .podConfigured else {
+                        self.log.error("Unexpected podStatus setupProgress value of %{public}@", String(describing: self.podState!.setupProgress))
+                        throw PodCommsError.invalidData
+                    }
+                    self.startingPacketNumber = 0
 
                     // Run a session now for any post-pairing commands
                     let transport = PodMessageTransport(session: commandSession, address: self.podState!.address, state: self.podState!.messageTransportState)

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -28,17 +28,11 @@ public enum PodCommsError: Error {
     case podSuspended
     case podFault(fault: PodInfoFaultEvent)
     case commsError(error: Error)
-#if !SKIP_POD_VERIFICATION
     case podChange
-#endif
-#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
     case activationTimeExceeded
-#endif
-#if !SKIP_RSSI_CHECKS
     case rssiTooLow
     case rssiTooHigh
     case debugFault(str: String)
-#endif
 }
 
 extension PodCommsError: LocalizedError {
@@ -75,24 +69,18 @@ extension PodCommsError: LocalizedError {
         case .podFault(let fault):
             let faultDescription = String(describing: fault.currentStatus)
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
-        case .commsError(let: error):
+        case .commsError(let error):
             return error.localizedDescription
-#if !SKIP_POD_VERIFICATION
         case .podChange:
             return LocalizedString("Unexpected pod change", comment: "Format string for unexpected pod change")
-#endif
-#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
         case .activationTimeExceeded:
             return LocalizedString("Activation time exceeded", comment: "Format string for activation time exceeded")
-#endif
-#if !SKIP_RSSI_CHECKS
         case .rssiTooLow: // occurs when RileyLink is too far from pod for reliable pairing, but can sometimes occur at other distances & positions
             return LocalizedString("Poor signal strength", comment: "Format string for poor pod signal strength")
         case .rssiTooHigh: // only occurs when RileyLink is too close to the pod for reliable pairing
             return LocalizedString("Signal strength too high", comment: "Format string for pod signal strength too high")
         case .debugFault(let str):
             return str
-#endif
         }
     }
     
@@ -134,22 +122,16 @@ extension PodCommsError: LocalizedError {
             return nil
         case .commsError:
             return nil
-#if !SKIP_POD_VERIFICATION
         case .podChange:
             return LocalizedString("Please bring only original pod in range or deactivate original pod", comment: "Recovery suggestion on unexpected pod change")
-#endif
-#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
         case .activationTimeExceeded:
             return nil
-#endif
-#if !SKIP_RSSI_CHECKS
         case .rssiTooLow:
             return LocalizedString("Please reposition the RileyLink relative to the pod", comment: "Recovery suggestion when pairing signal strength is too low")
         case .rssiTooHigh:
             return LocalizedString("Please reposition the RileyLink further from the pod", comment: "Recovery suggestion when pairing signal strength is too high")
         case .debugFault:
             return nil
-#endif
         }
     }
 }
@@ -180,19 +162,6 @@ public class PodCommsSession {
         self.transport.delegate = self
     }
 
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-    private func handlePodFault(fault: PodInfoFaultEvent) {
-        if self.podState.fault == nil {
-            self.podState.fault = fault // save the first fault returned
-        }
-        log.error("Pod Fault: %@", String(describing: fault))
-        if fault.deliveryStatus == .suspended {
-            let now = Date()
-            podState.unfinalizedTempBasal?.cancel(at: now)
-            podState.unfinalizedBolus?.cancel(at: now, withRemaining: fault.insulinNotDelivered)
-        }
-    }
-#else
     // Will throw either PodCommsError.podFault or PodCommsError.activationTimeExceeded
     private func throwPodFault(fault: PodInfoFaultEvent) throws {
         if self.podState.fault == nil {
@@ -210,7 +179,6 @@ public class PodCommsSession {
         }
         throw PodCommsError.podFault(fault: fault)
     }
-#endif
 
     /// Performs a message exchange, handling nonce resync, pod faults
     ///
@@ -280,12 +248,7 @@ public class PodCommsSession {
                     })
                     podState.advanceToNextNonce()
                 } else if let fault = response.fault {
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-                    handlePodFault(fault: fault)
-                    throw PodCommsError.podFault(fault: fault)
-#else
                     try throwPodFault(fault: fault) // always throws
-#endif
                 } else {
                     log.error("Unexpected response: %@", String(describing: response.messageBlocks[0]))
                     throw PodCommsError.unexpectedResponse(response: responseType)
@@ -366,17 +329,10 @@ public class PodCommsSession {
 
     // emits the specified beep type and sets the completion beep flags, doesn't throw
     public func beepConfig(beepConfigType: BeepConfigType, basalCompletionBeep: Bool, tempBasalCompletionBeep: Bool, bolusCompletionBeep: Bool) {
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-        guard self.podState.fault == nil else {
-            log.info("Skip beep config with faulted pod")
-            return
-        }
-#else
         guard self.podState.isFaulted == false else {
             log.info("Skip beep config with faulted pod")
             return
         }
-#endif
         
         let beepConfigCommand = BeepConfigCommand(beepConfigType: beepConfigType, basalCompletionBeep: basalCompletionBeep, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
         do {
@@ -670,12 +626,7 @@ public class PodCommsSession {
             log.default("Pod pulse log: %@", String(describing: podInfoResponseMessageBlock))
             return podInfoResponseMessageBlock
         } else if let fault = messageResponse.fault {
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-            handlePodFault(fault: fault)
-            throw PodCommsError.podFault(fault: fault)
-#else
             try throwPodFault(fault: fault) // always throws
-#endif
         }
         log.error("Unexpected Pod pulse log response: %@", String(describing: messageResponse.messageBlocks[0]))
         throw PodCommsError.unexpectedResponse(response: messageResponse.messageBlocks[0].blockType)

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -32,7 +32,6 @@ public enum PodCommsError: Error {
     case activationTimeExceeded
     case rssiTooLow
     case rssiTooHigh
-    case debugFault(str: String)
 }
 
 extension PodCommsError: LocalizedError {
@@ -79,8 +78,6 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Poor signal strength", comment: "Format string for poor pod signal strength")
         case .rssiTooHigh: // only occurs when RileyLink is too close to the pod for reliable pairing
             return LocalizedString("Signal strength too high", comment: "Format string for pod signal strength too high")
-        case .debugFault(let str):
-            return str
         }
     }
     
@@ -130,8 +127,6 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Please reposition the RileyLink relative to the pod", comment: "Recovery suggestion when pairing signal strength is too low")
         case .rssiTooHigh:
             return LocalizedString("Please reposition the RileyLink further from the pod", comment: "Recovery suggestion when pairing signal strength is too high")
-        case .debugFault:
-            return nil
         }
     }
 }

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -18,9 +18,7 @@ public enum SetupProgress: Int {
     case startingInsertCannula
     case cannulaInserting
     case completed
-#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
     case activationTimeout
-#endif
     
     public var primingNeeded: Bool {
         return self.rawValue < SetupProgress.priming.rawValue
@@ -131,12 +129,10 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     public var isSetupComplete: Bool {
         return setupProgress == .completed
     }
-#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
 
     public var isFaulted: Bool {
         return fault != nil || setupProgress == .activationTimeout
     }
-#endif
 
     public mutating func advanceToNextNonce() {
         nonceState.advanceToNextNonce()

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -18,6 +18,9 @@ public enum SetupProgress: Int {
     case startingInsertCannula
     case cannulaInserting
     case completed
+#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
+    case activationTimeout
+#endif
     
     public var primingNeeded: Bool {
         return self.rawValue < SetupProgress.priming.rawValue
@@ -128,6 +131,12 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     public var isSetupComplete: Bool {
         return setupProgress == .completed
     }
+#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
+
+    public var isFaulted: Bool {
+        return fault != nil || setupProgress == .activationTimeout
+    }
+#endif
 
     public mutating func advanceToNextNonce() {
         nonceState.advanceToNextNonce()

--- a/OmniKitUI/PumpManager/OmnipodHUDProvider.swift
+++ b/OmniKitUI/PumpManager/OmnipodHUDProvider.swift
@@ -30,15 +30,9 @@ internal class OmnipodHUDProvider: NSObject, HUDProvider, PodStateObserver {
                 updateReservoirView()
             }
             
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-            if oldValue?.fault != podState?.fault {
-                updateFaultDisplay()
-            }
-#else
             if oldValue?.isFaulted != podState?.isFaulted {
                 updateFaultDisplay()
             }
-#endif
             
             if oldValue != nil && podState == nil {
                 updateReservoirView()
@@ -95,19 +89,11 @@ internal class OmnipodHUDProvider: NSObject, HUDProvider, PodStateObserver {
     
     private func updateFaultDisplay() {
         if let podLifeView = podLifeView {
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-            if podState?.fault != nil {
-                podLifeView.alertState = .fault
-            } else {
-                podLifeView.alertState = .none
-            }
-#else
             if let podState = self.podState, podState.isFaulted {
                 podLifeView.alertState = .fault
             } else {
                 podLifeView.alertState = .none
             }
-#endif
         }
     }
     
@@ -138,19 +124,11 @@ internal class OmnipodHUDProvider: NSObject, HUDProvider, PodStateObserver {
     }
     
     public func didTapOnHUDView(_ view: BaseHUDView) -> HUDTapAction? {
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-        if podState?.fault != nil {
-            return HUDTapAction.presentViewController(PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager))
-        } else {
-            return HUDTapAction.presentViewController(pumpManager.settingsViewController())
-        }
-#else
         if let podState = self.podState, podState.isFaulted {
             return HUDTapAction.presentViewController(PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager))
         } else {
             return HUDTapAction.presentViewController(pumpManager.settingsViewController())
         }
-#endif
     }
     
     func hudDidAppear() {

--- a/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
@@ -112,6 +112,7 @@ class InsertCannulaSetupViewController: SetupTableViewController {
             loadingText = errorText
             
             // If we have an error, update the continue state
+#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
             if let podCommsError = lastError as? PodCommsError,
                 case PodCommsError.podFault = podCommsError
             {
@@ -119,6 +120,18 @@ class InsertCannulaSetupViewController: SetupTableViewController {
             } else if lastError != nil {
                 continueState = .initial
             }
+#else
+            if let podCommsError = lastError as? PodCommsError {
+                switch podCommsError {
+                case .podFault, .activationTimeExceeded:
+                    continueState = .fault
+                default:
+                    continueState = .initial
+                }
+            } else if lastError != nil {
+                continueState = .initial
+            }
+#endif
         }
     }
 

--- a/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
@@ -116,15 +116,6 @@ class InsertCannulaSetupViewController: SetupTableViewController {
             loadingText = errorText
             
             // If we have an error, update the continue state
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-            if let podCommsError = lastError as? PodCommsError,
-                case PodCommsError.podFault = podCommsError
-            {
-                continueState = .fault
-            } else if lastError != nil {
-                continueState = .initial
-            }
-#else
             if let podCommsError = lastError as? PodCommsError {
                 switch podCommsError {
                 case .podFault, .activationTimeExceeded:
@@ -135,7 +126,6 @@ class InsertCannulaSetupViewController: SetupTableViewController {
             } else if lastError != nil {
                 continueState = .initial
             }
-#endif
         }
     }
 

--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -334,7 +334,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                 return cell
             case .replacePod:
                 let cell = tableView.dequeueReusableCell(withIdentifier: TextButtonTableViewCell.className, for: indexPath) as! TextButtonTableViewCell
-                
+#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
                 if podState == nil {
                     cell.textLabel?.text = LocalizedString("Pair New Pod", comment: "The title of the command to pair new pod")
                 } else if podState?.fault != nil {
@@ -345,6 +345,18 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                     cell.textLabel?.text = LocalizedString("Replace Pod", comment: "The title of the command to replace pod")
                     cell.tintColor = .deleteColor
                 }
+#else
+                if podState == nil {
+                    cell.textLabel?.text = LocalizedString("Pair New Pod", comment: "The title of the command to pair new pod")
+                } else if let podState = podState, podState.isFaulted {
+                    cell.textLabel?.text = LocalizedString("Replace Pod Now", comment: "The title of the command to replace pod when there is a pod fault")
+                } else if let podState = podState, podState.unfinishedPairing {
+                    cell.textLabel?.text = LocalizedString("Finish pod setup", comment: "The title of the command to finish pod setup")
+                } else {
+                    cell.textLabel?.text = LocalizedString("Replace Pod", comment: "The title of the command to replace pod")
+                    cell.tintColor = .deleteColor
+                }
+#endif
 
                 cell.isEnabled = true
                 return cell
@@ -494,6 +506,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                 show(vc, sender: indexPath)
             case .replacePod:
                 let vc: UIViewController
+#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
                 if podState == nil || podState!.setupProgress.primingNeeded {
                     vc = PodReplacementNavigationController.instantiateNewPodFlow(pumpManager)
                 } else if podState?.fault != nil {
@@ -503,6 +516,17 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                 } else {
                     vc = PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager)
                 }
+#else
+                if podState == nil || podState!.setupProgress.primingNeeded {
+                    vc = PodReplacementNavigationController.instantiateNewPodFlow(pumpManager)
+                } else if let podState = podState, podState.isFaulted {
+                    vc = PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager)
+                } else if let podState = podState, podState.unfinishedPairing {
+                    vc = PodReplacementNavigationController.instantiateInsertCannulaFlow(pumpManager)
+                } else {
+                    vc = PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager)
+                }
+#endif
                 if var completionNotifying = vc as? CompletionNotifying {
                     completionNotifying.completionDelegate = self
                 }

--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -334,18 +334,6 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                 return cell
             case .replacePod:
                 let cell = tableView.dequeueReusableCell(withIdentifier: TextButtonTableViewCell.className, for: indexPath) as! TextButtonTableViewCell
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-                if podState == nil {
-                    cell.textLabel?.text = LocalizedString("Pair New Pod", comment: "The title of the command to pair new pod")
-                } else if podState?.fault != nil {
-                    cell.textLabel?.text = LocalizedString("Replace Pod Now", comment: "The title of the command to replace pod when there is a pod fault")
-                } else if let podState = podState, podState.unfinishedPairing {
-                    cell.textLabel?.text = LocalizedString("Finish pod setup", comment: "The title of the command to finish pod setup")
-                } else {
-                    cell.textLabel?.text = LocalizedString("Replace Pod", comment: "The title of the command to replace pod")
-                    cell.tintColor = .deleteColor
-                }
-#else
                 if podState == nil {
                     cell.textLabel?.text = LocalizedString("Pair New Pod", comment: "The title of the command to pair new pod")
                 } else if let podState = podState, podState.isFaulted {
@@ -356,7 +344,6 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                     cell.textLabel?.text = LocalizedString("Replace Pod", comment: "The title of the command to replace pod")
                     cell.tintColor = .deleteColor
                 }
-#endif
 
                 cell.isEnabled = true
                 return cell
@@ -506,17 +493,6 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                 show(vc, sender: indexPath)
             case .replacePod:
                 let vc: UIViewController
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-                if podState == nil || podState!.setupProgress.primingNeeded {
-                    vc = PodReplacementNavigationController.instantiateNewPodFlow(pumpManager)
-                } else if podState?.fault != nil {
-                    vc = PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager)
-                } else if let podState = podState, podState.unfinishedPairing {
-                    vc = PodReplacementNavigationController.instantiateInsertCannulaFlow(pumpManager)
-                } else {
-                    vc = PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager)
-                }
-#else
                 if podState == nil || podState!.setupProgress.primingNeeded {
                     vc = PodReplacementNavigationController.instantiateNewPodFlow(pumpManager)
                 } else if let podState = podState, podState.isFaulted {
@@ -526,7 +502,6 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                 } else {
                     vc = PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager)
                 }
-#endif
                 if var completionNotifying = vc as? CompletionNotifying {
                     completionNotifying.completionDelegate = self
                 }

--- a/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
@@ -153,15 +153,6 @@ class PairPodSetupViewController: SetupTableViewController {
             loadingText = errorText
             
             // If we have an error, update the continue state
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-            if let podCommsError = lastError as? PodCommsError,
-                case PodCommsError.podFault = podCommsError
-            {
-                continueState = .fault
-            } else if lastError != nil {
-                continueState = .initial
-            }
-#else
             if let podCommsError = lastError as? PodCommsError {
                 switch podCommsError {
                 case .podFault, .activationTimeExceeded:
@@ -172,7 +163,6 @@ class PairPodSetupViewController: SetupTableViewController {
             } else if lastError != nil {
                 continueState = .initial
             }
-#endif
         }
     }
     
@@ -240,13 +230,8 @@ class PairPodSetupViewController: SetupTableViewController {
 private extension PodCommsError {
     var possibleWeakCommsCause: Bool {
         switch self {
-#if SKIP_RSSI_CHECKS
-        case .invalidData, .noResponse:
-            return true
-#else
         case .invalidData, .noResponse, .invalidAddress, .rssiTooLow, .rssiTooHigh, .unexpectedPacketType:
             return true
-#endif
         default:
             return false
         }

--- a/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
@@ -144,6 +144,7 @@ class PairPodSetupViewController: SetupTableViewController {
             loadingText = errorStrings.joined(separator: ". ") + "."
             
             // If we have an error, update the continue state
+#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
             if let podCommsError = lastError as? PodCommsError,
                 case PodCommsError.podFault = podCommsError
             {
@@ -151,6 +152,18 @@ class PairPodSetupViewController: SetupTableViewController {
             } else if lastError != nil {
                 continueState = .initial
             }
+#else
+            if let podCommsError = lastError as? PodCommsError {
+                switch podCommsError {
+                case .podFault, .activationTimeExceeded:
+                    continueState = .fault
+                default:
+                    continueState = .initial
+                }
+            } else if lastError != nil {
+                continueState = .initial
+            }
+#endif
         }
     }
     
@@ -218,8 +231,13 @@ class PairPodSetupViewController: SetupTableViewController {
 private extension PodCommsError {
     var possibleWeakCommsCause: Bool {
         switch self {
+#if SKIP_RSSI_CHECKS
         case .invalidData, .noResponse:
             return true
+#else
+        case .invalidData, .noResponse, .invalidAddress, .rssiTooLow, .rssiTooHigh, .unexpectedPacketType:
+            return true
+#endif
         default:
             return false
         }

--- a/OmniKitUI/ViewControllers/ReplacePodViewController.swift
+++ b/OmniKitUI/ViewControllers/ReplacePodViewController.swift
@@ -50,15 +50,11 @@ class ReplacePodViewController: SetupTableViewController {
             let podState = pumpManager.state.podState
 
             if let podFault = podState?.fault {
-#if SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
-                self.replacementReason = .fault(podFault.currentStatus)
-#else
                 if podFault.podProgressStatus == .activationTimeExceeded {
                     self.replacementReason = .activationTimeout
                 } else {
                     self.replacementReason = .fault(podFault.currentStatus)
                 }
-#endif
             } else if podState?.setupProgress.primingNeeded == true {
                 self.replacementReason = .canceledPairingBeforeApplication
             } else if podState?.setupProgress.needsCannulaInsertion == true {

--- a/OmniKitUI/ViewControllers/ReplacePodViewController.swift
+++ b/OmniKitUI/ViewControllers/ReplacePodViewController.swift
@@ -15,9 +15,7 @@ class ReplacePodViewController: SetupTableViewController {
 
     enum PodReplacementReason {
         case normal
-#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
         case activationTimeout
-#endif
         case fault(_ faultCode: FaultEventCode)
         case canceledPairingBeforeApplication
         case canceledPairing
@@ -29,10 +27,8 @@ class ReplacePodViewController: SetupTableViewController {
             switch replacementReason {
             case .normal:
                 break // Text set in interface builder
-#if !SKIP_ACTIVATION_TIME_EXCEEDED_CHECKING
             case .activationTimeout:
                 instructionsLabel.text = LocalizedString("Activation time exceeded. The pod must be deactivated before pairing with a new one. Please deactivate and discard pod.", comment: "Instructions when deactivating pod that didn't complete activation in time.")
-#endif
             case .fault(let faultCode):
                 instructionsLabel.text = String(format: LocalizedString("%1$@. Insulin delivery has stopped. Please deactivate and remove pod.", comment: "Format string providing instructions for replacing pod due to a fault. (1: The fault description)"), faultCode.localizedDescription)
             case .canceledPairingBeforeApplication:


### PR DESCRIPTION
* Use an increasing packet # on pairing retries to prevent constant 07 acks
* Automatic retry with new packet # in some cases to prevent a user retry
* Correctly handle pod activation time exceeded faults
* Verify in range RSSI to prevent pods running with malformed pod_addr_1
* Check pod #'s to prevent weird errors with 2 pods pairing
