### PR TITLE
In-progress boluses and temp-basals should be marked as canceled during deactivation.

### DIFF
--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -504,11 +504,6 @@ public class PodCommsSession {
         }
         do {
             let status: StatusResponse = try send(message)
-            let now = Date()
-            if deliveryType.contains(.basal) {
-                podState.unfinalizedSuspend = UnfinalizedDose(suspendStartTime: now, scheduledCertainty: .certain)
-                podState.suspendState = .suspended(now)
-            }
 
             let canceledDose = handleCancelDosing(deliveryType: deliveryType, bolusNotDelivered: status.insulinNotDelivered)
 


### PR DESCRIPTION
* During deactivation, make sure any in-progress boluses or temp basals are recorded as canceled at the time of deactivation. For faulted pods, or if the cancel program failed, this wasn't happening.
* Do automatic read pulse log as pod messages now persist across pods