### PR TITLE
Updated Read Pod Status command now reports RSSI and Low Gain

### DIFF
--- a/OmniKit/MessageTransport/MessageBlocks/StatusResponse.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/StatusResponse.swift
@@ -9,42 +9,6 @@
 import Foundation
 
 public struct StatusResponse : MessageBlock {
-    
-    public enum DeliveryStatus: UInt8, CustomStringConvertible {
-        case suspended = 0
-        case normal = 1
-        case tempBasalRunning = 2
-        case priming = 4
-        case bolusInProgress = 5
-        case bolusAndTempBasal = 6
-        
-        public var bolusing: Bool {
-            return self == .bolusInProgress || self == .bolusAndTempBasal
-        }
-        
-        public var tempBasalRunning: Bool {
-            return self == .tempBasalRunning || self == .bolusAndTempBasal
-        }
-
-        
-        public var description: String {
-            switch self {
-            case .suspended:
-                return LocalizedString("Suspended", comment: "Delivery status when insulin delivery is suspended")
-            case .normal:
-                return LocalizedString("Scheduled Basal", comment: "Delivery status when basal is running")
-            case .tempBasalRunning:
-                return LocalizedString("Temp basal running", comment: "Delivery status when temp basal is running")
-            case .priming:
-                return LocalizedString("Priming", comment: "Delivery status when pod is priming")
-            case .bolusInProgress:
-                return LocalizedString("Bolusing", comment: "Delivery status when bolusing")
-            case .bolusAndTempBasal:
-                return LocalizedString("Bolusing with temp basal", comment: "Delivery status when bolusing and temp basal is running")
-            }
-        }
-    }
-        
     public let blockType: MessageBlockType = .statusResponse
     public let length: UInt8 = 10
     public let deliveryStatus: DeliveryStatus

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -596,21 +596,10 @@ public class PodCommsSession {
     }
 
     @discardableResult
-    public func readPulseLogsRequest(podInfoResponseSubType: PodInfoResponseSubType) throws -> PodInfoResponse {
-        let blocksToSend = [GetStatusCommand(podInfoType: podInfoResponseSubType)]
-        let message = Message(address: podState.address, messageBlocks: blocksToSend, sequenceNum: transport.messageNumber)
-        let messageResponse = try transport.sendMessage(message)
-
-        if let podInfoResponseMessageBlock = messageResponse.messageBlocks[0] as? PodInfoResponse {
-            log.default("Pod pulse log: %@", String(describing: podInfoResponseMessageBlock))
-            return podInfoResponseMessageBlock
-        } else if let fault = messageResponse.fault {
-            handlePodFault(fault: fault)
-            throw PodCommsError.podFault(fault: fault)
-        } else {
-            log.error("Unexpected Pod pulse log response: %@", String(describing: messageResponse.messageBlocks[0]))
-            throw PodCommsError.unexpectedResponse(response: messageResponse.messageBlocks[0].blockType)
-        }
+    public func readPodInfo(podInfoResponseSubType: PodInfoResponseSubType) throws -> PodInfoResponse {
+        let podInfoCommand = GetStatusCommand(podInfoType: podInfoResponseSubType)
+        let podInfoResponseMessageBlock: PodInfoResponse = try send([podInfoCommand])
+        return podInfoResponseMessageBlock
     }
 
     public func deactivatePod() throws {

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -598,8 +598,11 @@ public class PodCommsSession {
     @discardableResult
     public func readPodInfo(podInfoResponseSubType: PodInfoResponseSubType) throws -> PodInfoResponse {
         let podInfoCommand = GetStatusCommand(podInfoType: podInfoResponseSubType)
-        let podInfoResponseMessageBlock: PodInfoResponse = try send([podInfoCommand])
-        return podInfoResponseMessageBlock
+        let podInfoResponse: PodInfoResponse = try send([podInfoCommand])
+        if let podInfoType2 = podInfoResponse.podInfo as? PodInfoFaultEvent {
+            podState.updateFromStatusResponse(podInfoType2)
+        }
+        return podInfoResponse
     }
 
     public func deactivatePod() throws {

--- a/OmniKit/PumpManager/PodInsulinMeasurements.swift
+++ b/OmniKit/PumpManager/PodInsulinMeasurements.swift
@@ -15,16 +15,16 @@ public struct PodInsulinMeasurements: RawRepresentable, Equatable {
     public let delivered: Double
     public let reservoirVolume: Double?
     
-    public init(statusResponse: StatusResponse, validTime: Date, setupUnitsDelivered: Double?) {
+    public init(insulinDelivered: Double, reservoirLevel: Double?, setupUnitsDelivered: Double?, validTime: Date) {
         self.validTime = validTime
-        self.reservoirVolume = statusResponse.reservoirLevel
+        self.reservoirVolume = reservoirLevel
         if let setupUnitsDelivered = setupUnitsDelivered {
-            self.delivered = statusResponse.insulin - setupUnitsDelivered
+            self.delivered = insulinDelivered - setupUnitsDelivered
         } else {
             // subtract off the fixed setup command values as we don't have an actual value (yet)
-            self.delivered = max(statusResponse.insulin - Pod.primeUnits - Pod.cannulaInsertionUnits, 0)
+            self.delivered = max(insulinDelivered - Pod.primeUnits - Pod.cannulaInsertionUnits, 0)
         }
-  }
+    }
     
     // RawRepresentable
     public init?(rawValue: RawValue) {

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -143,9 +143,9 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         nonceState = NonceState(lot: lot, tid: tid, seed: seed)
     }
     
-    public mutating func updateFromStatusResponse(_ response: StatusResponse) {
+    private mutating func updatePodTimes(timeActive: TimeInterval) -> Date {
         let now = Date()
-        let activatedAtComputed = now - response.timeActive
+        let activatedAtComputed = now - timeActive
         if activatedAt == nil {
             self.activatedAt = activatedAtComputed
         }
@@ -158,9 +158,21 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             // The more than a minute later test prevents oscillation of expiresAt based on the timing of the responses.
             self.expiresAt = expiresAtComputed
         }
+        return now
+    }
+
+    public mutating func updateFromStatusResponse(_ response: StatusResponse) {
+        let now = updatePodTimes(timeActive: response.timeActive)
         updateDeliveryStatus(deliveryStatus: response.deliveryStatus)
-        lastInsulinMeasurements = PodInsulinMeasurements(statusResponse: response, validTime: now, setupUnitsDelivered: setupUnitsDelivered)
+        lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.insulin, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)
         activeAlertSlots = response.alerts
+    }
+
+    public mutating func updateFromStatusResponse(_ response: PodInfoFaultEvent) {
+        let now = updatePodTimes(timeActive: response.timeActive)
+        updateDeliveryStatus(deliveryStatus: response.deliveryStatus)
+        lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.totalInsulinDelivered, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)
+        activeAlertSlots = response.unacknowledgedAlerts
     }
 
     public mutating func registerConfiguredAlert(slot: AlertSlot, alert: PodAlert) {
@@ -179,7 +191,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         }
     }
     
-    private mutating func updateDeliveryStatus(deliveryStatus: StatusResponse.DeliveryStatus) {
+    private mutating func updateDeliveryStatus(deliveryStatus: DeliveryStatus) {
         finalizeFinishedDoses()
 
         if let bolus = unfinalizedBolus, bolus.scheduledCertainty == .uncertain {


### PR DESCRIPTION
* readPodStatus() requests the longer type 2 (fault) pod info
* podStatusString() renamed to podInfoString() and uses PodInfoFaultEvent
* podInfoString adds pod radio and (if applicable) fault info
* add optional confirmation beep on Read Pod Status command
* readPulseLogsRequest() simplified and renamed to readPodInfo()