### PR TITLE
Various DetailedStatus related follow up items

### DIFF
--- a/OmniKit/MessageTransport/MessageBlocks/StatusResponse.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/StatusResponse.swift
@@ -9,42 +9,6 @@
 import Foundation
 
 public struct StatusResponse : MessageBlock {
-    
-    public enum DeliveryStatus: UInt8, CustomStringConvertible {
-        case suspended = 0
-        case normal = 1
-        case tempBasalRunning = 2
-        case priming = 4
-        case bolusInProgress = 5
-        case bolusAndTempBasal = 6
-        
-        public var bolusing: Bool {
-            return self == .bolusInProgress || self == .bolusAndTempBasal
-        }
-        
-        public var tempBasalRunning: Bool {
-            return self == .tempBasalRunning || self == .bolusAndTempBasal
-        }
-
-        
-        public var description: String {
-            switch self {
-            case .suspended:
-                return LocalizedString("Suspended", comment: "Delivery status when insulin delivery is suspended")
-            case .normal:
-                return LocalizedString("Scheduled Basal", comment: "Delivery status when basal is running")
-            case .tempBasalRunning:
-                return LocalizedString("Temp basal running", comment: "Delivery status when temp basal is running")
-            case .priming:
-                return LocalizedString("Priming", comment: "Delivery status when pod is priming")
-            case .bolusInProgress:
-                return LocalizedString("Bolusing", comment: "Delivery status when bolusing")
-            case .bolusAndTempBasal:
-                return LocalizedString("Bolusing with temp basal", comment: "Delivery status when bolusing and temp basal is running")
-            }
-        }
-    }
-        
     public let blockType: MessageBlockType = .statusResponse
     public let length: UInt8 = 10
     public let deliveryStatus: DeliveryStatus

--- a/OmniKit/Model/Pod.swift
+++ b/OmniKit/Model/Pod.swift
@@ -72,7 +72,7 @@ public struct Pod {
 // DeliveryStatus used in StatusResponse and DetailedStatus
 public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case suspended = 0
-    case normal = 1
+    case scheduledBasal = 1
     case tempBasalRunning = 2
     case priming = 4
     case bolusInProgress = 5
@@ -90,8 +90,8 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
         switch self {
         case .suspended:
             return LocalizedString("Suspended", comment: "Delivery status when insulin delivery is suspended")
-        case .normal:
-            return LocalizedString("Normal", comment: "Delivery status when basal is running")
+        case .scheduledBasal:
+            return LocalizedString("Scheduled basal", comment: "Delivery status when scheduled basal is running")
         case .tempBasalRunning:
             return LocalizedString("Temp basal running", comment: "Delivery status when temp basal is running")
         case .priming:

--- a/OmniKit/Model/Pod.swift
+++ b/OmniKit/Model/Pod.swift
@@ -69,7 +69,7 @@ public struct Pod {
     public static let expirationReminderAlertMaxTimeBeforeExpiration = TimeInterval.hours(24)
 }
 
-// DeliveryStatus used in StatusResponse and PodInfoFaults
+// DeliveryStatus used in StatusResponse and DetailedStatus
 public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case suspended = 0
     case normal = 1

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -919,8 +919,12 @@ extension OmnipodPumpManager {
             do {
                 switch result {
                 case .success(let session):
-                    let faultStatus = try session.getDetailedStatus()
-                    completion(.success(faultStatus))
+                    let detailedStatus = try session.getDetailedStatus()
+                    self.emitConfirmationBeep(session: session, beepConfigType: .bipBip)
+                    session.dosesForStorage({ (doses) -> Bool in
+                        self.store(doses: doses, in: session)
+                    })
+                    completion(.success(detailedStatus))
                 case .failure(let error):
                     completion(.failure(error))
                 }

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -149,8 +149,8 @@ public class OmnipodPumpManager: RileyLinkPumpManager {
                 observer.podStateDidUpdate(newValue.podState)
             }
 
-            if oldValue.podState?.lastInsulinMeasurements?.reservoirVolume != newValue.podState?.lastInsulinMeasurements?.reservoirVolume {
-                if let lastInsulinMeasurements = newValue.podState?.lastInsulinMeasurements, let reservoirVolume = lastInsulinMeasurements.reservoirVolume {
+            if oldValue.podState?.lastInsulinMeasurements?.reservoirLevel != newValue.podState?.lastInsulinMeasurements?.reservoirLevel {
+                if let lastInsulinMeasurements = newValue.podState?.lastInsulinMeasurements, let reservoirVolume = lastInsulinMeasurements.reservoirLevel {
                     self.pumpDelegate.notify({ (delegate) in
                         self.log.info("DU: updating reservoir level %{public}@", String(describing: reservoirVolume))
                         delegate?.pumpManager(self, didReadReservoirValue: reservoirVolume, at: lastInsulinMeasurements.validTime) { _ in }

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -624,10 +624,11 @@ public class PodCommsSession {
     public func getDetailedStatus() throws -> DetailedStatus {
         let infoResponse: PodInfoResponse = try send([GetStatusCommand(podInfoType: .detailedStatus)])
         
-        guard let faultEvent = infoResponse.podInfo as? DetailedStatus else {
+        guard let detailedStatus = infoResponse.podInfo as? DetailedStatus else {
             throw PodCommsError.unexpectedResponse(response: .podInfoResponse)
         }
-        return faultEvent
+        podState.updateFromStatusResponse(detailedStatus)
+        return detailedStatus
     }
 
     @discardableResult

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -627,7 +627,7 @@ public class PodCommsSession {
         guard let detailedStatus = infoResponse.podInfo as? DetailedStatus else {
             throw PodCommsError.unexpectedResponse(response: .podInfoResponse)
         }
-        podState.updateFromStatusResponse(detailedStatus)
+        podState.updateFromDetailedStatusResponse(detailedStatus)
         return detailedStatus
     }
 

--- a/OmniKit/PumpManager/PodInsulinMeasurements.swift
+++ b/OmniKit/PumpManager/PodInsulinMeasurements.swift
@@ -15,16 +15,16 @@ public struct PodInsulinMeasurements: RawRepresentable, Equatable {
     public let delivered: Double
     public let reservoirVolume: Double?
     
-    public init(statusResponse: StatusResponse, validTime: Date, setupUnitsDelivered: Double?) {
+    public init(insulinDelivered: Double, reservoirLevel: Double?, setupUnitsDelivered: Double?, validTime: Date) {
         self.validTime = validTime
-        self.reservoirVolume = statusResponse.reservoirLevel
+        self.reservoirVolume = reservoirLevel
         if let setupUnitsDelivered = setupUnitsDelivered {
-            self.delivered = statusResponse.insulin - setupUnitsDelivered
+            self.delivered = insulinDelivered - setupUnitsDelivered
         } else {
             // subtract off the fixed setup command values as we don't have an actual value (yet)
-            self.delivered = max(statusResponse.insulin - Pod.primeUnits - Pod.cannulaInsertionUnits, 0)
+            self.delivered = max(insulinDelivered - Pod.primeUnits - Pod.cannulaInsertionUnits, 0)
         }
-  }
+    }
     
     // RawRepresentable
     public init?(rawValue: RawValue) {
@@ -51,6 +51,5 @@ public struct PodInsulinMeasurements: RawRepresentable, Equatable {
         
         return rawValue
     }
-
 }
 

--- a/OmniKit/PumpManager/PodInsulinMeasurements.swift
+++ b/OmniKit/PumpManager/PodInsulinMeasurements.swift
@@ -13,11 +13,11 @@ public struct PodInsulinMeasurements: RawRepresentable, Equatable {
     
     public let validTime: Date
     public let delivered: Double
-    public let reservoirVolume: Double?
+    public let reservoirLevel: Double?
     
     public init(insulinDelivered: Double, reservoirLevel: Double?, setupUnitsDelivered: Double?, validTime: Date) {
         self.validTime = validTime
-        self.reservoirVolume = reservoirLevel
+        self.reservoirLevel = reservoirLevel
         if let setupUnitsDelivered = setupUnitsDelivered {
             self.delivered = insulinDelivered - setupUnitsDelivered
         } else {
@@ -36,7 +36,7 @@ public struct PodInsulinMeasurements: RawRepresentable, Equatable {
         }
         self.validTime = validTime
         self.delivered = delivered
-        self.reservoirVolume = rawValue["reservoirVolume"] as? Double
+        self.reservoirLevel = rawValue["reservoirLevel"] as? Double
     }
     
     public var rawValue: RawValue {
@@ -45,8 +45,8 @@ public struct PodInsulinMeasurements: RawRepresentable, Equatable {
             "delivered": delivered
             ]
         
-        if let reservoirVolume = reservoirVolume {
-            rawValue["reservoirVolume"] = reservoirVolume
+        if let reservoirLevel = reservoirLevel {
+            rawValue["reservoirLevel"] = reservoirLevel
         }
         
         return rawValue

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -173,7 +173,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         activeAlertSlots = response.alerts
     }
 
-    public mutating func updateFromStatusResponse(_ response: DetailedStatus) {
+    public mutating func updateFromDetailedStatusResponse(_ response: DetailedStatus) {
         let now = updatePodTimes(timeActive: response.timeActive)
         updateDeliveryStatus(deliveryStatus: response.deliveryStatus)
         lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.totalInsulinDelivered, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)

--- a/OmniKitTests/MessageTests.swift
+++ b/OmniKitTests/MessageTests.swift
@@ -35,7 +35,7 @@ class MessageTests: XCTestCase {
             XCTAssertEqual(nil, statusResponse.reservoirLevel)
             XCTAssertEqual(TimeInterval(minutes: 4261), statusResponse.timeActive)
 
-            XCTAssertEqual(.normal, statusResponse.deliveryStatus)
+            XCTAssertEqual(.scheduledBasal, statusResponse.deliveryStatus)
             XCTAssertEqual(.aboveFiftyUnits, statusResponse.podProgressStatus)
             XCTAssertEqual(6.3, statusResponse.insulin, accuracy: 0.01)
             XCTAssertEqual(0, statusResponse.bolusNotDelivered)

--- a/OmniKitTests/PodInfoTests.swift
+++ b/OmniKitTests/PodInfoTests.swift
@@ -121,7 +121,7 @@ class PodInfoTests: XCTestCase {
             let decoded = try DetailedStatus(encodedData: Data(hexadecimalString: "02080100000a003800000003ff008700000095ff0000")!)
             XCTAssertEqual(.detailedStatus, decoded.podInfoType)
             XCTAssertEqual(.aboveFiftyUnits, decoded.podProgressStatus)
-            XCTAssertEqual(.normal, decoded.deliveryStatus)
+            XCTAssertEqual(.scheduledBasal, decoded.deliveryStatus)
             XCTAssertEqual(0000, decoded.bolusNotDelivered)
             XCTAssertEqual(0x0a, decoded.podMessageCounter)
             XCTAssertEqual(.noFaults, decoded.faultEventCode.faultType)

--- a/OmniKitTests/StatusTests.swift
+++ b/OmniKitTests/StatusTests.swift
@@ -33,7 +33,7 @@ class StatusTests: XCTestCase {
             // Decode
             let decoded = try StatusResponse(encodedData: Data(hexadecimalString: "1d19050ec82c08376f9801dc")!)
             XCTAssertEqual(TimeInterval(minutes: 3547), decoded.timeActive)
-            XCTAssertEqual(.normal, decoded.deliveryStatus)
+            XCTAssertEqual(.scheduledBasal, decoded.deliveryStatus)
             XCTAssertEqual(.fiftyOrLessUnits, decoded.podProgressStatus)
             XCTAssertEqual(129.45, decoded.insulin, accuracy: 0.01)
             XCTAssertEqual(46.00, decoded.reservoirLevel)

--- a/OmniKitUI/PumpManager/OmnipodHUDProvider.swift
+++ b/OmniKitUI/PumpManager/OmnipodHUDProvider.swift
@@ -71,7 +71,7 @@ internal class OmnipodHUDProvider: NSObject, HUDProvider, PodStateObserver {
             let reservoirView = reservoirView,
             let podState = podState
         {
-            let reservoirVolume = lastInsulinMeasurements.reservoirVolume
+            let reservoirVolume = lastInsulinMeasurements.reservoirLevel
 
             let reservoirLevel = reservoirVolume?.asReservoirPercentage()
 
@@ -160,7 +160,7 @@ internal class OmnipodHUDProvider: NSObject, HUDProvider, PodStateObserver {
         }
         
         if let lastInsulinMeasurements = podState?.lastInsulinMeasurements {
-            rawValue["reservoirVolume"] = lastInsulinMeasurements.reservoirVolume
+            rawValue["reservoirVolume"] = lastInsulinMeasurements.reservoirLevel
             rawValue["validTime"] = lastInsulinMeasurements.validTime
         }
         

--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -963,12 +963,12 @@ private extension UITableViewCell {
             detailTextLabel?.text = LocalizedString("Unknown", comment: "The detail text for delivered insulin when no measurement is available")
             return
         }
-        if measurements.reservoirVolume == nil {
+        if measurements.reservoirLevel == nil {
             if let units = insulinFormatter.string(from: Pod.maximumReservoirReading) {
                 detailTextLabel?.text = String(format: LocalizedString("%@+ U", comment: "Format string for reservoir reading when above or equal to maximum reading. (1: The localized amount)"), units)
             }
         } else {
-            if let reservoirValue = measurements.reservoirVolume,
+            if let reservoirValue = measurements.reservoirLevel,
                 let units = insulinFormatter.string(from: reservoirValue)
             {
                 detailTextLabel?.text = String(format: LocalizedString("%@ U", comment: "Format string for insulin remaining in reservoir. (1: The localized amount)"), units)


### PR DESCRIPTION
* Update getDetailedStatus() to have analogous sematics as getStatus()
* Update readPodStatus() to match old semantics when using getStatus()
* Add new updateFromStatusResponse() for DetailedStatus
* Generalize PodInsulinMeasurements() to not take StatusResponse
* Generalize updateDeliveryStatus() to not take StatusResponse.DeliveryStatus
* Remove duplicated and unneeded DeliveryStatus declaration in StatusResponse
* Use detailedStatus variable name instead of faultEvent when appropriate
* Updated comment to use DetailedStatus instead of PodInfoFault