### PR TITLE
Fix date picker appearance in iOS 14

### DIFF
--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -394,6 +394,11 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                     cell.titleLabel.text = LocalizedString("Expiration Reminder", comment: "The title of the cell showing the pod expiration reminder date")
                     cell.date = reminderDate
                     cell.datePicker.datePickerMode = .dateAndTime
+                    #if swift(>=5.2)
+                        if #available(iOS 14.0, *) {
+                            cell.datePicker.preferredDatePickerStyle = .wheels
+                        }
+                    #endif
                     cell.datePicker.maximumDate = podState.expiresAt?.addingTimeInterval(-Pod.expirationReminderAlertMinTimeBeforeExpiration)
                     cell.datePicker.minimumDate = podState.expiresAt?.addingTimeInterval(-Pod.expirationReminderAlertMaxTimeBeforeExpiration)
                     cell.datePicker.minuteInterval = 1

--- a/OmniKitUI/ViewControllers/PodSetupCompleteViewController.swift
+++ b/OmniKitUI/ViewControllers/PodSetupCompleteViewController.swift
@@ -33,6 +33,11 @@ class PodSetupCompleteViewController: SetupTableViewController {
         self.navigationItem.rightBarButtonItem = nil
 
         expirationReminderDateCell.datePicker.datePickerMode = .dateAndTime
+        #if swift(>=5.2)
+            if #available(iOS 14.0, *) {
+                expirationReminderDateCell.datePicker.preferredDatePickerStyle = .wheels
+            }
+        #endif
         expirationReminderDateCell.titleLabel.text = LocalizedString("Expiration Reminder", comment: "The title of the cell showing the pod expiration reminder date")
         expirationReminderDateCell.datePicker.minuteInterval = 1
         expirationReminderDateCell.delegate = self


### PR DESCRIPTION
This is a small fix to address the date picker UI change that was made in iOS 14; I added a change to force the picker to show up in the `.wheels` style that it had before.