### PR TITLE
Continue interrupted pairing fix.

### DIFF
--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -223,7 +223,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
     private class func sectionList(_ podState: PodState?) -> [Section] {
         if let podState = podState {
             if podState.unfinishedPairing {
-                return [.rileyLinks, .diagnostics]
+                return [.configuration, .rileyLinks]
             } else {
                 return [.status, .configuration, .rileyLinks, .podDetails, .diagnostics]
             }


### PR DESCRIPTION
Display correct sections on settings page when in a state of interrupted pairing, to allow the user to continue pairing.