### PR TITLE
Allow recovery from incomplete pod pairing

### DIFF
--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -223,7 +223,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
     private class func sectionList(_ podState: PodState?) -> [Section] {
         if let podState = podState {
             if podState.unfinishedPairing {
-                return [.rileyLinks, .diagnostics]
+                return [.configuration, .rileyLinks, .diagnostics]
             } else {
                 return [.status, .configuration, .rileyLinks, .podDetails, .diagnostics]
             }


### PR DESCRIPTION
If the pod doesn't finish pairing for some reason, for example you get stuck in `setupProgress: cannulaInserting`, you will end up with a screen like this with no way to finish the setup or unpair the pod:
![120832805_10224525845514649_4239984110674334030_n](https://user-images.githubusercontent.com/17150/95001941-9b13d900-0594-11eb-90d9-8e9f3c87fde2.jpg)

This PR includes the configuration section on the Pod Settings page in that scenario so that you can finish setting up the pod.