### PR TITLE
Have diagnostic commands display complete error messages

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -950,7 +950,8 @@ extension OmnipodPumpManager {
             completion(.failure(PodCommsError.noPodPaired))
             return
         }
-        if self.state.podState?.isFaulted == false && self.state.podState?.unfinalizedBolus?.isFinished == false {
+        guard state.podState?.isFaulted == true || state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished != false else
+        {
             self.log.info("Skipping Read Pod Status due to bolus still in progress.")
             completion(.failure(PodCommsError.unfinalizedBolus))
             return
@@ -1005,7 +1006,7 @@ extension OmnipodPumpManager {
             completion(OmnipodPumpManagerError.noPodPaired)
             return
         }
-        guard self.state.podState?.unfinalizedBolus?.isFinished != false else {
+        guard state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished != false else {
             self.log.info("Skipping Play Test Beeps due to bolus still in progress.")
             completion(PodCommsError.unfinalizedBolus)
             return
@@ -1038,7 +1039,8 @@ extension OmnipodPumpManager {
             completion(.failure(PodCommsError.noPodPaired))
             return
         }
-        if self.state.podState?.isFaulted == false && self.state.podState?.unfinalizedBolus?.isFinished == false {
+        guard state.podState?.isFaulted == true || state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished != false else
+        {
             self.log.info("Skipping Read Pulse Log due to bolus still in progress.")
             completion(.failure(PodCommsError.unfinalizedBolus))
             return

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -950,12 +950,6 @@ extension OmnipodPumpManager {
             completion(.failure(PodCommsError.noPodPaired))
             return
         }
-        guard state.podState?.isFaulted == true || state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished != false else
-        {
-            self.log.info("Skipping Read Pod Status due to bolus still in progress.")
-            completion(.failure(PodCommsError.unfinalizedBolus))
-            return
-        }
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         podComms.runSession(withName: "Read pod status", using: rileyLinkSelector) { (result) in


### PR DESCRIPTION
* Have Read Pulse Log only read last 50 pulse log entries
* Change readPulseLog() to have separate success and failure responses
* Check for bolus in progress before running Read Pod Status
* Change default let mockCommsErrorDuringPairing value to false
* Improved Play Test Beeps success message text
* Generalize twoDecimals for any Double w/o a reservoirLevel reference