### PR TITLE
Add toggle to optionally disable mySentry

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -694,7 +694,19 @@ extension MinimedPumpManager {
             }
         }
     }
-    
+
+    /// Whether to use MySentry packets on capable pumps:
+    public var useMySentry: Bool {
+        get {
+            return state.useMySentry
+        }
+        set {
+            setState { (state) in
+                state.useMySentry = newValue
+            }
+        }
+    }
+
 }
 
 

--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -33,7 +33,7 @@ public class MinimedPumpManager: RileyLinkPumpManager {
         super.init(rileyLinkDeviceProvider: rileyLinkDeviceProvider, rileyLinkConnectionManager: rileyLinkConnectionManager)
 
         // Pump communication
-        let idleListeningEnabled = state.pumpModel.hasMySentry
+        let idleListeningEnabled = state.pumpModel.hasMySentry && state.useMySentry
         self.pumpOps = pumpOps ?? PumpOps(pumpSettings: state.pumpSettings, pumpState: state.pumpState, delegate: self)
 
         self.rileyLinkDeviceProvider.idleListeningState = idleListeningEnabled ? MinimedPumpManagerState.idleListeningEnabledDefaults : .disabled

--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -701,8 +701,13 @@ extension MinimedPumpManager {
             return state.useMySentry
         }
         set {
+            let oldValue = state.useMySentry
             setState { (state) in
                 state.useMySentry = newValue
+            }
+            if oldValue != newValue {
+                let useIdleListening = state.pumpModel.hasMySentry && state.useMySentry
+                self.rileyLinkDeviceProvider.idleListeningState = useIdleListening ? MinimedPumpManagerState.idleListeningEnabledDefaults : .disabled
             }
         }
     }

--- a/MinimedKit/PumpManager/MinimedPumpManagerState.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManagerState.swift
@@ -86,12 +86,14 @@ public struct MinimedPumpManagerState: RawRepresentable, Equatable {
             state.timeZone = timeZone
             state.lastValidFrequency = lastValidFrequency
             state.lastTuned = lastTuned
+            state.useMySentry = useMySentry
             return state
         }
         set {
             lastValidFrequency = newValue.lastValidFrequency
             lastTuned = newValue.lastTuned
             timeZone = newValue.timeZone
+            useMySentry = newValue.useMySentry
         }
     }
 

--- a/MinimedKit/PumpManager/MinimedPumpManagerState.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManagerState.swift
@@ -93,7 +93,6 @@ public struct MinimedPumpManagerState: RawRepresentable, Equatable {
             lastValidFrequency = newValue.lastValidFrequency
             lastTuned = newValue.lastTuned
             timeZone = newValue.timeZone
-            useMySentry = newValue.useMySentry
         }
     }
 

--- a/MinimedKit/PumpManager/MinimedPumpManagerState.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManagerState.swift
@@ -61,6 +61,8 @@ public struct MinimedPumpManagerState: RawRepresentable, Equatable {
 
     public var preferredInsulinDataSource: InsulinDataSource
 
+    public var useMySentry: Bool
+
     public let pumpColor: PumpColor
 
     public let pumpModel: PumpModel
@@ -111,9 +113,10 @@ public struct MinimedPumpManagerState: RawRepresentable, Equatable {
     
     public var insulinType: InsulinType?
 
-    public init(batteryChemistry: BatteryChemistryType = .alkaline, preferredInsulinDataSource: InsulinDataSource = .pumpHistory, pumpColor: PumpColor, pumpID: String, pumpModel: PumpModel, pumpFirmwareVersion: String, pumpRegion: PumpRegion, rileyLinkConnectionManagerState: RileyLinkConnectionManagerState?, timeZone: TimeZone, suspendState: SuspendState, lastValidFrequency: Measurement<UnitFrequency>? = nil, batteryPercentage: Double? = nil, lastReservoirReading: ReservoirReading? = nil, unfinalizedBolus: UnfinalizedDose? = nil, unfinalizedTempBasal: UnfinalizedDose? = nil, pendingDoses: [UnfinalizedDose]? = nil, recentlyReconciledEvents: [Data:ReconciledDoseMapping]? = nil, lastReconciliation: Date? = nil, insulinType: InsulinType? = nil) {
+    public init(batteryChemistry: BatteryChemistryType = .alkaline, preferredInsulinDataSource: InsulinDataSource = .pumpHistory, useMySentry: Bool = true, pumpColor: PumpColor, pumpID: String, pumpModel: PumpModel, pumpFirmwareVersion: String, pumpRegion: PumpRegion, rileyLinkConnectionManagerState: RileyLinkConnectionManagerState?, timeZone: TimeZone, suspendState: SuspendState, lastValidFrequency: Measurement<UnitFrequency>? = nil, batteryPercentage: Double? = nil, lastReservoirReading: ReservoirReading? = nil, unfinalizedBolus: UnfinalizedDose? = nil, unfinalizedTempBasal: UnfinalizedDose? = nil, pendingDoses: [UnfinalizedDose]? = nil, recentlyReconciledEvents: [Data:ReconciledDoseMapping]? = nil, lastReconciliation: Date? = nil, insulinType: InsulinType? = nil) {
         self.batteryChemistry = batteryChemistry
         self.preferredInsulinDataSource = preferredInsulinDataSource
+        self.useMySentry = useMySentry
         self.pumpColor = pumpColor
         self.pumpID = pumpID
         self.pumpModel = pumpModel
@@ -136,6 +139,7 @@ public struct MinimedPumpManagerState: RawRepresentable, Equatable {
     public init?(rawValue: RawValue) {
         guard
             let version = rawValue["version"] as? Int,
+            let useMySentry = rawValue["useMySentry"] as? Bool,
             let batteryChemistryRaw = rawValue["batteryChemistry"] as? BatteryChemistryType.RawValue,
             let insulinDataSourceRaw = rawValue["insulinDataSource"] as? InsulinDataSource.RawValue,
             let pumpColorRaw = rawValue["pumpColor"] as? PumpColor.RawValue,
@@ -246,6 +250,7 @@ public struct MinimedPumpManagerState: RawRepresentable, Equatable {
         self.init(
             batteryChemistry: batteryChemistry,
             preferredInsulinDataSource: insulinDataSource,
+            useMySentry: useMySentry,
             pumpColor: pumpColor,
             pumpID: pumpID,
             pumpModel: pumpModel,
@@ -282,6 +287,7 @@ public struct MinimedPumpManagerState: RawRepresentable, Equatable {
             "recentlyReconciledEvents": reconciliationMappings.values.map { $0.rawValue },
         ]
 
+        value["useMySentry"] = useMySentry
         value["batteryPercentage"] = batteryPercentage
         value["lastReservoirReading"] = lastReservoirReading?.rawValue
         value["lastValidFrequency"] = lastValidFrequency?.converted(to: .megahertz).value
@@ -310,6 +316,7 @@ extension MinimedPumpManagerState: CustomDebugStringConvertible {
             "suspendState: \(suspendState)",
             "lastValidFrequency: \(String(describing: lastValidFrequency))",
             "preferredInsulinDataSource: \(preferredInsulinDataSource)",
+            "useMySentry: \(useMySentry)",
             "pumpColor: \(pumpColor)",
             "pumpID: ✔︎",
             "pumpModel: \(pumpModel.rawValue)",

--- a/MinimedKit/PumpManager/PumpState.swift
+++ b/MinimedKit/PumpManager/PumpState.swift
@@ -16,6 +16,8 @@ public struct PumpState: RawRepresentable, Equatable {
     
     public var pumpModel: PumpModel?
     
+    public var useMySentry: Bool
+    
     public var awakeUntil: Date?
     
     public var lastValidFrequency: Measurement<UnitFrequency>?
@@ -34,23 +36,27 @@ public struct PumpState: RawRepresentable, Equatable {
 
     public init() {
         self.timeZone = .currentFixed
+        self.useMySentry = true
     }
 
-    public init(timeZone: TimeZone, pumpModel: PumpModel) {
+    public init(timeZone: TimeZone, pumpModel: PumpModel, useMySentry: Bool) {
         self.timeZone = timeZone
         self.pumpModel = pumpModel
+        self.useMySentry = useMySentry
     }
 
     public init?(rawValue: RawValue) {
         guard
             let timeZoneSeconds = rawValue["timeZone"] as? Int,
-            let timeZone = TimeZone(secondsFromGMT: timeZoneSeconds)
+            let timeZone = TimeZone(secondsFromGMT: timeZoneSeconds),
+            let useMySentry = rawValue["useMySentry"] as? Bool
         else {
             return nil
         }
 
         self.timeZone = timeZone
-        
+        self.useMySentry = useMySentry
+
         if let pumpModelNumber = rawValue["pumpModel"] as? PumpModel.RawValue {
             pumpModel = PumpModel(rawValue: pumpModelNumber)
         }
@@ -63,6 +69,7 @@ public struct PumpState: RawRepresentable, Equatable {
     public var rawValue: RawValue {
         var rawValue: RawValue = [
             "timeZone": timeZone.secondsFromGMT(),
+            "useMySentry": useMySentry,
         ]
 
         if let pumpModel = pumpModel {
@@ -85,6 +92,7 @@ extension PumpState: CustomDebugStringConvertible {
             "## PumpState",
             "timeZone: \(timeZone)",
             "pumpModel: \(pumpModel?.rawValue ?? "")",
+            "useMySentry: \(useMySentry)",
             "awakeUntil: \(awakeUntil ?? .distantPast)",
             "lastValidFrequency: \(String(describing: lastValidFrequency))",
             "lastTuned: \(awakeUntil ?? .distantPast))",

--- a/MinimedKitUI/MinimedPumpSettingsViewController.swift
+++ b/MinimedKitUI/MinimedPumpSettingsViewController.swift
@@ -193,11 +193,7 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
                 cell.detailTextLabel?.text = String(describing: pumpManager.preferredInsulinDataSource)
             case .useMySentry:
                 cell.textLabel?.text = LocalizedString("Use MySentry", comment: "The title text for the preferred MySentry setting config")
-                if pumpManager.state.pumpModel.hasMySentry {
-                    cell.detailTextLabel?.text = pumpManager.useMySentry ? "Yes" : "No"
-                } else {
-                    cell.detailTextLabel?.text = "N/A"
-                }
+                cell.detailTextLabel?.text = pumpManager.useMySentry ? "Yes" : "No"
             case .timeZoneOffset:
                 cell.textLabel?.text = LocalizedString("Change Time Zone", comment: "The title of the command to change pump time zone")
 

--- a/MinimedKitUI/MinimedPumpSettingsViewController.swift
+++ b/MinimedKitUI/MinimedPumpSettingsViewController.swift
@@ -101,6 +101,7 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
         case batteryChemistry
         case preferredInsulinDataSource
         case insulinType
+        case useMySentry
     }
 
     // MARK: UITableViewDataSource
@@ -188,6 +189,9 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
             case .preferredInsulinDataSource:
                 cell.textLabel?.text = LocalizedString("Preferred Data Source", comment: "The title text for the preferred insulin data source config")
                 cell.detailTextLabel?.text = String(describing: pumpManager.preferredInsulinDataSource)
+            case .useMySentry:
+                cell.textLabel?.text = LocalizedString("Use MySentry", comment: "The title text for the preferred MySentry setting config")
+                cell.detailTextLabel?.text = pumpManager.useMySentry ? "Yes" : "No"
             case .timeZoneOffset:
                 cell.textLabel?.text = LocalizedString("Change Time Zone", comment: "The title of the command to change pump time zone")
 
@@ -269,6 +273,12 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
                 vc.title = LocalizedString("Insulin Type", comment: "Controller title for insulin type selection screen")
                 
                 show(vc, sender: sender)
+            case .useMySentry:
+                let vc = RadioSelectionTableViewController.useMySentry(pumpManager.useMySentry)
+                vc.title = sender?.textLabel?.text
+                vc.delegate = self
+
+                show(vc, sender: sender)
             }
         case .rileyLinks:
             let device = devicesDataSource.devices[indexPath.row]
@@ -304,6 +314,8 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
                 break
             case .preferredInsulinDataSource:
                 break
+            case .useMySentry:
+                break
             }
         case .info, .actions, .rileyLinks, .delete:
             break
@@ -330,6 +342,10 @@ extension MinimedPumpSettingsViewController: RadioSelectionTableViewControllerDe
             case .batteryChemistry:
                 if let selectedIndex = controller.selectedIndex, let dataSource = MinimedKit.BatteryChemistryType(rawValue: selectedIndex) {
                     pumpManager.batteryChemistry = dataSource
+                }
+            case .useMySentry:
+                if let selectedIndex = controller.selectedIndex {
+                    pumpManager.useMySentry = selectedIndex == 0
                 }
             default:
                 assertionFailure()

--- a/MinimedKitUI/MinimedPumpSettingsViewController.swift
+++ b/MinimedKitUI/MinimedPumpSettingsViewController.swift
@@ -280,14 +280,10 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
                 
                 show(vc, sender: sender)
             case .useMySentry:
-                if pumpManager.state.pumpModel.hasMySentry {
-                    let vc = RadioSelectionTableViewController.useMySentry(pumpManager.useMySentry)
-                    vc.title = sender?.textLabel?.text
-                    vc.delegate = self
-                    show(vc, sender: sender)
-                } else {
-                    break
-                }
+                let vc = RadioSelectionTableViewController.useMySentry(pumpManager.useMySentry)
+                vc.title = sender?.textLabel?.text
+                vc.delegate = self
+                show(vc, sender: sender)
             }
         case .rileyLinks:
             let device = devicesDataSource.devices[indexPath.row]

--- a/MinimedKitUI/MinimedPumpSettingsViewController.swift
+++ b/MinimedKitUI/MinimedPumpSettingsViewController.swift
@@ -101,6 +101,7 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
         case batteryChemistry
         case preferredInsulinDataSource
         case insulinType
+        // This should always be last so it can be omitted for non-MySentry pumps:
         case useMySentry
     }
 
@@ -117,7 +118,8 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
         case .actions:
             return ActionsRow.allCases.count
         case .settings:
-            return SettingsRow.allCases.count
+            let settingsRowCount = pumpManager.state.pumpModel.hasMySentry ? SettingsRow.allCases.count : SettingsRow.allCases.count - 1
+            return settingsRowCount
         case .rileyLinks:
             return super.tableView(tableView, numberOfRowsInSection: section)
         case .delete:

--- a/MinimedKitUI/MinimedPumpSettingsViewController.swift
+++ b/MinimedKitUI/MinimedPumpSettingsViewController.swift
@@ -191,7 +191,11 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
                 cell.detailTextLabel?.text = String(describing: pumpManager.preferredInsulinDataSource)
             case .useMySentry:
                 cell.textLabel?.text = LocalizedString("Use MySentry", comment: "The title text for the preferred MySentry setting config")
-                cell.detailTextLabel?.text = pumpManager.useMySentry ? "Yes" : "No"
+                if pumpManager.state.pumpModel.hasMySentry {
+                    cell.detailTextLabel?.text = pumpManager.useMySentry ? "Yes" : "No"
+                } else {
+                    cell.detailTextLabel?.text = "N/A"
+                }
             case .timeZoneOffset:
                 cell.textLabel?.text = LocalizedString("Change Time Zone", comment: "The title of the command to change pump time zone")
 
@@ -274,11 +278,14 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
                 
                 show(vc, sender: sender)
             case .useMySentry:
-                let vc = RadioSelectionTableViewController.useMySentry(pumpManager.useMySentry)
-                vc.title = sender?.textLabel?.text
-                vc.delegate = self
-
-                show(vc, sender: sender)
+                if pumpManager.state.pumpModel.hasMySentry {
+                    let vc = RadioSelectionTableViewController.useMySentry(pumpManager.useMySentry)
+                    vc.title = sender?.textLabel?.text
+                    vc.delegate = self
+                    show(vc, sender: sender)
+                } else {
+                    break
+                }
             }
         case .rileyLinks:
             let device = devicesDataSource.devices[indexPath.row]

--- a/MinimedKitUI/RadioSelectionTableViewController.swift
+++ b/MinimedKitUI/RadioSelectionTableViewController.swift
@@ -40,7 +40,7 @@ extension RadioSelectionTableViewController: IdentifiableClass {
         vc.selectedIndex = value ? 0 : 1
             
         vc.options = ["Use MySentry", "Do not use MySentry"]
-        vc.contextHelp = LocalizedString("Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, and while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models.", comment: "Instructions on selecting setting for MySentry")
+        vc.contextHelp = LocalizedString("Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models.", comment: "Instructions on selecting setting for MySentry")
 
         return vc
     }

--- a/MinimedKitUI/RadioSelectionTableViewController.swift
+++ b/MinimedKitUI/RadioSelectionTableViewController.swift
@@ -34,4 +34,14 @@ extension RadioSelectionTableViewController: IdentifiableClass {
         return vc
     }
 
+    static func useMySentry(_ value: Bool) -> T {
+        let vc = T()
+
+        vc.selectedIndex = value ? 0 : 1
+            
+        vc.options = ["Use MySentry", "Do not use MySentry"]
+        vc.contextHelp = LocalizedString("Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, and while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models.", comment: "Instructions on selecting setting for MySentry")
+
+        return vc
+    }
 }

--- a/RileyLinkKit/PumpOpsSession.swift
+++ b/RileyLinkKit/PumpOpsSession.swift
@@ -65,7 +65,7 @@ extension PumpOpsSession {
 
         let shortPowerMessage = PumpMessage(settings: settings, type: .powerOn)
 
-        if pump.pumpModel == nil || !(pump.pumpModel!.hasMySentry && pump.useMySentry) {
+        if pump.pumpModel == nil || !pump.pumpModel!.hasMySentry {
             // Older pumps have a longer sleep cycle between wakeups, so send an initial burst
             do {
                 let _: PumpAckMessageBody = try session.getResponse(to: shortPowerMessage, repeatCount: 255, timeout: .milliseconds(1), retryCount: 0)

--- a/RileyLinkKit/PumpOpsSession.swift
+++ b/RileyLinkKit/PumpOpsSession.swift
@@ -65,7 +65,7 @@ extension PumpOpsSession {
 
         let shortPowerMessage = PumpMessage(settings: settings, type: .powerOn)
 
-        if pump.pumpModel == nil || !pump.pumpModel!.hasMySentry {
+        if pump.pumpModel == nil || !(pump.pumpModel!.hasMySentry && pump.useMySentry) {
             // Older pumps have a longer sleep cycle between wakeups, so send an initial burst
             do {
                 let _: PumpAckMessageBody = try session.getResponse(to: shortPowerMessage, repeatCount: 255, timeout: .milliseconds(1), retryCount: 0)


### PR DESCRIPTION
This code adds a setting to the Pump Settings menu for Medtronic x23/x54 pumps that allows the user to disable the use of MySentry, potentially improving battery life on the RileyLink. 

- Should there be additional logging somewhere to track any change in mySentry settings? 
- Does more need to be done when toggling besides changing `idleListeningState`? 

Still to do: adding a dialog page during the pump setup process to explain and initialize the setting. 