### PR TITLE
Bulletproof prime() to prevent 049 pod fault when incorrectly invoked

### DIFF
--- a/OmniKit/Model/PodProgressStatus.swift
+++ b/OmniKit/Model/PodProgressStatus.swift
@@ -30,10 +30,6 @@ public enum PodProgressStatus: UInt8, CustomStringConvertible, Equatable {
         return self == .fiftyOrLessUnits || self == .aboveFiftyUnits
     }
     
-    public var unfinishedPairing: Bool {
-        return self.rawValue < PodProgressStatus.aboveFiftyUnits.rawValue
-    }
-
     public var description: String {
         switch self {
         case .initialized:

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -298,15 +298,17 @@ public class PodCommsSession {
     public func prime() throws -> TimeInterval {
         let primeDuration: TimeInterval = .seconds(Pod.primeUnits / Pod.primeDeliveryRate) + 3 // as per PDM
         
-        // Skip following alerts if we've already done them before
-        if podState.setupProgress != .startingPrime {
-            
-            // The following will set Tab5[$16] to 0 during pairing, which disables $6x faults.
+        // If the setupProgress indicates that the pod pairing just finished, do the pre-prime setup tasks.
+        // A FaultConfig can only be done before the prime bolus or the pod will generate an 049 fault.
+        if podState.setupProgress == .podConfigured {
+            // This FaultConfig command will set Tab5[$16] to 0 during pairing, which disables $6x faults
             let _: StatusResponse = try send([FaultConfigCommand(nonce: podState.currentNonce, tab5Sub16: 0, tab5Sub17: 0)])
+
+            // Set up the finish pod setup reminder alert which beeps every 5 minutes for 1 hour
             let finishSetupReminder = PodAlert.finishSetupReminder
             try configureAlerts([finishSetupReminder])
         } else {
-            // We started prime, but didn't get confirmation somehow, so check status
+            // Not the first time through, check to see if prime bolus was successfully started
             let status: StatusResponse = try send([GetStatusCommand()])
             podState.updateFromStatusResponse(status)
             if status.podProgressStatus == .priming || status.podProgressStatus == .primingCompleted {
@@ -338,6 +340,7 @@ public class PodCommsSession {
             podState.updateFromStatusResponse(status)
             if status.podProgressStatus == .basalInitialized {
                 podState.setupProgress = .initialBasalScheduleSet
+                podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: Date(), scheduledCertainty: .certain, insulinType: podState.insulinType))
                 return
             }
         }

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -298,9 +298,9 @@ public class PodCommsSession {
     public func prime() throws -> TimeInterval {
         let primeDuration: TimeInterval = .seconds(Pod.primeUnits / Pod.primeDeliveryRate) + 3 // as per PDM
         
-        // If the setupProgress indicates that the pod pairing just finished, do the pre-prime setup tasks.
+        // If priming has never been attempted on this pod, handle the pre-prime setup tasks.
         // A FaultConfig can only be done before the prime bolus or the pod will generate an 049 fault.
-        if podState.setupProgress == .podConfigured {
+        if podState.setupProgress.primingNeverAttempted {
             // This FaultConfig command will set Tab5[$16] to 0 during pairing, which disables $6x faults
             let _: StatusResponse = try send([FaultConfigCommand(nonce: podState.currentNonce, tab5Sub16: 0, tab5Sub17: 0)])
 

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -115,7 +115,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         self.insulinType = insulinType
     }
     
-    public var unfinishedPairing: Bool {
+    public var unfinishedSetup: Bool {
         return setupProgress != .completed
     }
     

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -21,6 +21,10 @@ public enum SetupProgress: Int {
     case completed
     case activationTimeout
     case podIncompatible
+
+    public var primingNeverAttempted: Bool {
+        return self.rawValue < SetupProgress.startingPrime.rawValue
+    }
     
     public var primingNeeded: Bool {
         return self.rawValue < SetupProgress.priming.rawValue

--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -222,7 +222,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
     
     private class func sectionList(_ podState: PodState?) -> [Section] {
         if let podState = podState {
-            if podState.unfinishedPairing {
+            if podState.unfinishedSetup {
                 return [.configuration, .rileyLinks]
             } else {
                 return [.status, .configuration, .rileyLinks, .podDetails, .diagnostics]
@@ -252,7 +252,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
     }
     
     private var configurationRows: [ConfigurationRow] {
-        if podState == nil || podState?.unfinishedPairing == true {
+        if podState == nil || podState?.unfinishedSetup == true {
             return [.replacePod]
         } else {
             return ConfigurationRow.allCases
@@ -436,7 +436,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                     cell.textLabel?.text = LocalizedString("Pair New Pod", comment: "The title of the command to pair new pod")
                 } else if let podState = podState, podState.isFaulted {
                     cell.textLabel?.text = LocalizedString("Replace Pod Now", comment: "The title of the command to replace pod when there is a pod fault")
-                } else if let podState = podState, podState.unfinishedPairing {
+                } else if let podState = podState, podState.unfinishedSetup {
                     cell.textLabel?.text = LocalizedString("Finish pod setup", comment: "The title of the command to finish pod setup")
                 } else {
                     cell.textLabel?.text = LocalizedString("Replace Pod", comment: "The title of the command to replace pod")
@@ -616,11 +616,11 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
                 show(vc, sender: sender)
             case .replacePod:
                 let vc: UIViewController
-                if podState == nil || podState!.setupProgress.primingNeeded {
-                    vc = PodReplacementNavigationController.instantiateNewPodFlow(pumpManager)
-                } else if let podState = podState, podState.isFaulted {
+                if let podState = podState, podState.isFaulted {
                     vc = PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager)
-                } else if let podState = podState, podState.unfinishedPairing {
+                } else if podState == nil || podState!.setupProgress.primingNeeded {
+                    vc = PodReplacementNavigationController.instantiateNewPodFlow(pumpManager)
+                } else if let podState = podState, podState.unfinishedSetup {
                     vc = PodReplacementNavigationController.instantiateInsertCannulaFlow(pumpManager)
                 } else {
                     vc = PodReplacementNavigationController.instantiatePodReplacementFlow(pumpManager)


### PR DESCRIPTION
Rework Pod Settings UI logic to prevent new pod flow with a faulted pod
Always invoke finalizeDoses() after the initial basal has been set
Rename PodState unfinishedPairing var to more appropriate unfinishedSetup
Remove unused and unneeded PodProgressState unfinishedPairing var