### PR TITLE
Normalize makeEntries() rate to prevent potential crash on a bad value

### DIFF
--- a/OmniKit/Model/BasalDeliveryTable.swift
+++ b/OmniKit/Model/BasalDeliveryTable.swift
@@ -197,6 +197,8 @@ public struct RateEntry {
     public static func makeEntries(rate: Double, duration: TimeInterval) -> [RateEntry] {
         let maxPulsesPerEntry: Double = 6400
         var entries = [RateEntry]()
+        // normalize rate to a pulseSize multiple to prevent possible infinite loop and subsequent malloc crash
+        let rate = round(rate / Pod.pulseSize) * Pod.pulseSize
         
         var remainingSegments = Int(round(duration.minutes / 30))
         


### PR DESCRIPTION
If makeEntries() is called with a bad rate of 0.925 (due to for example the controlling app not properly handling a user switching from an x23 to an Omnipod) it will end up getting into an infinite loop and subsequently crashing the app because numSegments & pulseCount will both end up being 0 after once around the while loop, so bullet proof makeEntries() to not crash if given a rate that's not a multiple of pulseSize.