### PR TITLE
Fixes to better handle Omnipod comms optimizations with unreliable comms

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1412,7 +1412,13 @@ extension OmnipodPumpManager: PumpManager {
 
             var getStatusNeeded = false // initializing to true effectively disables the bolus comms getStatus optimization
             var finalizeFinishedDosesNeeded = false
-            if automatic == false || self.state.podState?.skipNextCommsOptimization == true {
+
+            // Skip the getStatus comms optimization for a manual bolus,
+            // if there was a comms issue on the last message sent, or
+            // if the last delivery status hasn't been verified
+            if automatic == false || self.state.podState?.lastCommsOK == false ||
+                self.state.podState?.deliveryStatusVerified == false
+            {
                 self.log.info("enactBolus: skipping getStatus comms optimization")
                 getStatusNeeded = true
             } else if let unfinalizedBolus = self.state.podState?.unfinalizedBolus {

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -247,6 +247,7 @@ public class PodCommsSession {
 
             let message = Message(address: podState.address, messageBlocks: blocksToSend, sequenceNum: messageNumber, expectFollowOnMessage: expectFollowOnMessage)
 
+            self.podState.skipNextCommsOptimization = true // disable any comms optimizations until we get the expected response
             let response = try transport.sendMessage(message)
             
             // Simulate fault
@@ -255,6 +256,7 @@ public class PodCommsSession {
 
             if let responseMessageBlock = response.messageBlocks[0] as? T {
                 log.info("POD Response: %@", String(describing: responseMessageBlock))
+                self.podState.skipNextCommsOptimization = false // all good for possible comms optimizations
                 return responseMessageBlock
             }
 

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -247,7 +247,7 @@ public class PodCommsSession {
 
             let message = Message(address: podState.address, messageBlocks: blocksToSend, sequenceNum: messageNumber, expectFollowOnMessage: expectFollowOnMessage)
 
-            self.podState.skipNextCommsOptimization = true // disable any comms optimizations until we get the expected response
+            self.podState.lastCommsOK = false // mark last comms as not OK until we get the expected response
             let response = try transport.sendMessage(message)
             
             // Simulate fault
@@ -256,7 +256,7 @@ public class PodCommsSession {
 
             if let responseMessageBlock = response.messageBlocks[0] as? T {
                 log.info("POD Response: %@", String(describing: responseMessageBlock))
-                self.podState.skipNextCommsOptimization = false // all good for possible comms optimizations
+                self.podState.lastCommsOK = true // message successfully sent and expected response received
                 return responseMessageBlock
             }
 

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -104,6 +104,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     
     public var insulinType: InsulinType
     
+    public var skipNextCommsOptimization: Bool
+
     public init(address: UInt32, piVersion: String, pmVersion: String, lot: UInt32, tid: UInt32, packetNumber: Int = 0, messageNumber: Int = 0, insulinType: InsulinType) {
         self.address = address
         self.nonceState = NonceState(lot: lot, tid: tid)
@@ -121,6 +123,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         self.setupProgress = .addressAssigned
         self.configuredAlerts = [.slot7: .waitingForPairingReminder]
         self.insulinType = insulinType
+        self.skipNextCommsOptimization = true // skip any initial comms optimizations
     }
     
     public var unfinishedSetup: Bool {
@@ -180,19 +183,15 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     }
 
     public mutating func updateFromStatusResponse(_ response: StatusResponse) {
-        if unfinalizedBolus == nil && response.deliveryStatus.bolusing && response.podProgressStatus.readyForDelivery {
-            // Create the unfinalizedBolus since we currently bolusing in a ready state (possible Loop restart)
-            unfinalizedBolus = UnfinalizedDose(bolusAmount: response.bolusNotDelivered, startTime: Date(), scheduledCertainty: .certain, insulinType: insulinType, automatic: nil)
-        }
         let now = updatePodTimes(timeActive: response.timeActive)
-        updateDeliveryStatus(deliveryStatus: response.deliveryStatus)
+        updateDeliveryStatus(deliveryStatus: response.deliveryStatus, podProgressStatus: response.podProgressStatus, bolusNotDelivered: response.bolusNotDelivered)
         lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.insulin, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)
         activeAlertSlots = response.alerts
     }
 
     public mutating func updateFromDetailedStatusResponse(_ response: DetailedStatus) {
         let now = updatePodTimes(timeActive: response.timeActive)
-        updateDeliveryStatus(deliveryStatus: response.deliveryStatus)
+        updateDeliveryStatus(deliveryStatus: response.deliveryStatus, podProgressStatus: response.podProgressStatus, bolusNotDelivered: response.bolusNotDelivered)
         lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.totalInsulinDelivered, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)
         activeAlertSlots = response.unacknowledgedAlerts
     }
@@ -213,7 +212,20 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         }
     }
     
-    private mutating func updateDeliveryStatus(deliveryStatus: DeliveryStatus) {
+    private mutating func updateDeliveryStatus(deliveryStatus: DeliveryStatus, podProgressStatus: PodProgressStatus, bolusNotDelivered: Double) {
+
+        // See if the pod deliveryStatus indicates an active bolus or temp basal that the PodState isn't tracking (possible Loop restart)
+        if deliveryStatus.bolusing && unfinalizedBolus == nil { // active bolus that Loop doesn't know about?
+            skipNextCommsOptimization = true // forces a get status before the next bolus command is sent
+            if podProgressStatus.readyForDelivery {
+                // Create an unfinalizedBolus with the remaining bolus amount to capture what we can.
+                unfinalizedBolus = UnfinalizedDose(bolusAmount: bolusNotDelivered, startTime: Date(), scheduledCertainty: .certain, insulinType: insulinType, automatic: nil)
+            }
+        }
+        if deliveryStatus.tempBasalRunning && unfinalizedTempBasal == nil { // active temp basal that Loop doesn't know about?
+            skipNextCommsOptimization = true // forces a cancel TB before the next temp basal command is sent
+        }
+
         finalizeFinishedDoses()
 
         if let bolus = unfinalizedBolus, bolus.scheduledCertainty == .uncertain {
@@ -406,6 +418,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         } else {
             insulinType = .humalog
         }
+
+        self.skipNextCommsOptimization = true
     }
     
     public var rawValue: RawValue {

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -104,7 +104,9 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     
     public var insulinType: InsulinType
     
-    public var skipNextCommsOptimization: Bool
+    // the following two vars are not persistent across app restarts
+    public var deliveryStatusVerified: Bool
+    public var lastCommsOK: Bool
 
     public init(address: UInt32, piVersion: String, pmVersion: String, lot: UInt32, tid: UInt32, packetNumber: Int = 0, messageNumber: Int = 0, insulinType: InsulinType) {
         self.address = address
@@ -123,7 +125,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         self.setupProgress = .addressAssigned
         self.configuredAlerts = [.slot7: .waitingForPairingReminder]
         self.insulinType = insulinType
-        self.skipNextCommsOptimization = true // skip any initial comms optimizations
+        self.deliveryStatusVerified = false
+        self.lastCommsOK = false
     }
     
     public var unfinishedSetup: Bool {
@@ -214,16 +217,17 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     
     private mutating func updateDeliveryStatus(deliveryStatus: DeliveryStatus, podProgressStatus: PodProgressStatus, bolusNotDelivered: Double) {
 
+        deliveryStatusVerified = true
         // See if the pod deliveryStatus indicates an active bolus or temp basal that the PodState isn't tracking (possible Loop restart)
         if deliveryStatus.bolusing && unfinalizedBolus == nil { // active bolus that Loop doesn't know about?
-            skipNextCommsOptimization = true // forces a get status before the next bolus command is sent
+            deliveryStatusVerified = false // remember that we had inconsistent (bolus) delivery status
             if podProgressStatus.readyForDelivery {
                 // Create an unfinalizedBolus with the remaining bolus amount to capture what we can.
                 unfinalizedBolus = UnfinalizedDose(bolusAmount: bolusNotDelivered, startTime: Date(), scheduledCertainty: .certain, insulinType: insulinType, automatic: nil)
             }
         }
         if deliveryStatus.tempBasalRunning && unfinalizedTempBasal == nil { // active temp basal that Loop doesn't know about?
-            skipNextCommsOptimization = true // forces a cancel TB before the next temp basal command is sent
+            deliveryStatusVerified = false // remember that we had inconsistent (temp basal) delivery status
         }
 
         finalizeFinishedDoses()
@@ -419,7 +423,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             insulinType = .humalog
         }
 
-        self.skipNextCommsOptimization = true
+        self.deliveryStatusVerified = false
+        self.lastCommsOK = false
     }
     
     public var rawValue: RawValue {


### PR DESCRIPTION
+ Add non-persistent var to denote when to skip comms optimizations
+ Set skipNextCommsOptimization on init or for any error or unexpected
message response to better handle bad comms on restarts and out of range
+ Have updateDeliveryStatus() create an unfinalizedBolus if pod is bolusing
and PodState doesn't have one to handle both types of status responses
+ Have updateDeliveryStatus() set skipNextCommsOptimization when the pod
is bolusing or TB is active & it doesn't match the PodState's status
+ Skip bolus communication optimizations for manual boluses