### PR TITLE
Fix connection monitoring configuration

### DIFF
--- a/RileyLinkBLEKit/PeripheralManager.swift
+++ b/RileyLinkBLEKit/PeripheralManager.swift
@@ -60,8 +60,6 @@ class PeripheralManager: NSObject {
         }
     }
     
-    var setDatas: [UInt8] = [0xbb, 0x0c, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-
     // Called from RileyLinkDeviceManager.managerQueue
     init(peripheral: CBPeripheral, configuration: Configuration, centralManager: CBCentralManager, queue: DispatchQueue) {
         self.peripheral = peripheral

--- a/RileyLinkBLEKit/RileyLinkDevice.swift
+++ b/RileyLinkBLEKit/RileyLinkDevice.swift
@@ -164,9 +164,9 @@ extension RileyLinkDevice {
         manager.orangeAction(command)
     }
     
-    public func orangeSetAction(index: Int, open: Bool) {
-        log.debug("orangeSetAction: %@, %@", "\(index)", "\(open)")
-        manager.setAction(index: index, open: open)
+    public func setOrangeConfig(_ config: OrangeLinkConfigurationSetting, isOn: Bool) {
+        log.debug("setOrangeConfig: %@, %@", "\(String(describing: config))", "\(isOn)")
+        manager.setOrangeConfig(config, isOn: isOn)
     }
     
     public func orangeWritePwd() {
@@ -479,7 +479,7 @@ extension RileyLinkDevice: PeripheralManagerDelegate {
         }
         
         switch OrangeServiceCharacteristicUUID(rawValue: characteristic.uuid.uuidString) {
-        case .orange, .orangeNotif:
+        case .orangeRX, .orangeTX:
             guard let data = characteristic.value, !data.isEmpty else { return }
             if data.first == 0xbb {
                 guard let data = characteristic.value, data.count > 6 else { return }
@@ -487,7 +487,7 @@ extension RileyLinkDevice: PeripheralManagerDelegate {
                     orangeLinkFirmwareHardwareVersion = "FW\(data[3]).\(data[4])/HW\(data[5]).\(data[6])"
                     NotificationCenter.default.post(name: .DeviceStatusUpdated, object: self)
                 }
-            } else if data.first == 0xdd {
+            } else if data.first == OrangeLinkRequestType.cfgHeader.rawValue {
                 guard let data = characteristic.value, data.count > 2 else { return }
                 if data[1] == 0x01 {
                     guard let data = characteristic.value, data.count > 5 else { return }

--- a/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
+++ b/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
@@ -385,8 +385,8 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
     }
 
     private enum OrangeConfigureCommandRow: Int, CaseIterable {
-        case orangeLED
-        case vibration
+        case connectionLED
+        case connectionVibrate
     }
 
     private func cellForRow(_ row: DeviceRow) -> UITableViewCell? {
@@ -479,11 +479,11 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
             }
         case .configureCommand:
             switch OrangeConfigureCommandRow(rawValue: sender.index)! {
-            case .orangeLED:
-                device.orangeSetAction(index: 0, open: sender.isOn)
+            case .connectionLED:
+                device.setOrangeConfig(.connectionLED, isOn: sender.isOn)
                 ledOn = sender.isOn
-            case .vibration:
-                device.orangeSetAction(index: 1, open: sender.isOn)
+            case .connectionVibrate:
+                device.setOrangeConfig(.connectionVibrate, isOn: sender.isOn)
                 vibrationOn = sender.isOn
             }
         default:
@@ -587,12 +587,12 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
             }
         case .configureCommand:
             switch OrangeConfigureCommandRow(rawValue: indexPath.row)! {
-            case .orangeLED:
+            case .connectionLED:
                 switchView.isHidden = false
                 switchView.isOn = ledOn
                 cell.accessoryType = .none
                 cell.textLabel?.text = NSLocalizedString("Enable Connection State LED", comment: "The title of the cell showing Stop Vibrator")
-            case .vibration:
+            case .connectionVibrate:
                 switchView.isHidden = false
                 switchView.isOn = vibrationOn
                 cell.accessoryType = .none


### PR DESCRIPTION
Fixes "Enable Connection State LED" and "Enable Connection State Vibrate" configuration options. Also update code to use descriptive enums instead of hardcoded numbers where appropriate.