### PR TITLE
Remove extra period from Device Error message

### DIFF
--- a/RileyLinkBLEKit/RileyLinkDeviceError.swift
+++ b/RileyLinkBLEKit/RileyLinkDeviceError.swift
@@ -51,7 +51,7 @@ extension RileyLinkDeviceError: LocalizedError {
         case .peripheralManagerError(let error):
             return error.recoverySuggestion
         case .commandsBlocked:
-            return LocalizedString("RileyLink may need to be turned off and back on.", comment: "commandsBlocked recovery suggestion")
+            return LocalizedString("RileyLink may need to be turned off and back on", comment: "commandsBlocked recovery suggestion")
         default:
             return nil
         }


### PR DESCRIPTION
Removed period from end of string. Two periods are shown on error without this removed. 

![IMG_8386](https://user-images.githubusercontent.com/50932350/131589088-41a61f21-2929-4933-9d92-99eae0e458f8.jpg)
