### PR TITLE
Improved PodCommsError fault checking during pod setup

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -38,7 +38,7 @@ extension OmnipodPumpManagerError: LocalizedError {
         case .podAlreadyPaired:
             return LocalizedString("Pod already paired", comment: "Error message shown when user cannot pair because pod is already paired")
         case .notReadyForCannulaInsertion:
-            return LocalizedString("Pod is not in a state ready for cannula insertion.", comment: "Error message when cannula insertion fails because the pod is in an unexpected state")
+            return LocalizedString("Pod is not in a state ready for cannula insertion", comment: "Error message when cannula insertion fails because the pod is in an unexpected state")
         }
     }
     
@@ -525,7 +525,7 @@ extension OmnipodPumpManager {
         podState.activatedAt = start
         podState.expiresAt = start + .hours(72)
         
-        let fault = mockFault ? try? DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000e00c36a020703ff020900002899080082")!) : nil
+        let fault = mockFault ? try? DetailedStatus(encodedData: Data(hexadecimalString: "020f0000000900345c000103ff0001000005ae056029")!) : nil
         podState.fault = fault
 
         self.podComms = PodComms(podState: podState)
@@ -647,12 +647,14 @@ extension OmnipodPumpManager {
         
         #if targetEnvironment(simulator)
         let mockDelay = TimeInterval(seconds: 3)
+        let mockFaultDuringInsertCannula = false
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + mockDelay) {
             let result = self.setStateWithResult({ (state) -> PumpManagerResult<TimeInterval> in
-                // Mock fault
-                //            let fault = try! DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000e00c36a020703ff020900002899080082")!)
-                //            self.state.podState?.fault = fault
-                //            return .failure(PumpManagerError.deviceState(PodCommsError.podFault(fault: fault)))
+                if mockFaultDuringInsertCannula {
+                    let fault = try! DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000e00c36a020703ff020900002899080082")!)
+                    state.podState?.fault = fault
+                    return .failure(PumpManagerError.deviceState(PodCommsError.podFault(fault: fault)))
+                }
 
                 // Mock success
                 state.podState?.setupProgress = .completed

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -404,7 +404,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         if let rawInsulinType = rawValue["insulinType"] as? InsulinType.RawValue, let insulinType = InsulinType(rawValue: rawInsulinType) {
             self.insulinType = insulinType
         } else {
-            insulinType = .humalog
+            insulinType = .novolog
         }
     }
     

--- a/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
@@ -119,14 +119,19 @@ class InsertCannulaSetupViewController: SetupTableViewController {
             }
             loadingText = errorText
             
-            var podCommsError: PodCommsError? = nil
+            let podCommsError: PodCommsError?
             if let pumpManagerError = lastError as? PumpManagerError {
                 switch pumpManagerError {
-                case .communication(let error):
+                // Check for a wrapped PodCommsError in the possible PumpManagerError types
+                case .communication(let error), .configuration(let error), .connection(let error), .deviceState(let error):
                     podCommsError = error as? PodCommsError
                 default:
+                    podCommsError = nil
                     break
                 }
+            } else {
+                // Check for a non PumpManagerError PodCommsError
+                podCommsError = lastError as? PodCommsError
             }
 
             // If we have an error, update the continue state depending on whether it's fatal or if the cannula insertion was started or not

--- a/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
@@ -134,14 +134,19 @@ class PairPodSetupViewController: SetupTableViewController {
                 errorStrings = [lastError?.localizedDescription].compactMap { $0 }
             }
             
-            var podCommsError: PodCommsError? = nil
+            let podCommsError: PodCommsError?
             if let pumpManagerError = lastError as? PumpManagerError {
                 switch pumpManagerError {
-                case .communication(let error):
+                // Check for a wrapped PodCommsError in the possible PumpManagerError types
+                case .communication(let error), .configuration(let error), .connection(let error), .deviceState(let error):
                     podCommsError = error as? PodCommsError
                 default:
+                    podCommsError = nil
                     break
                 }
+            } else {
+                // Check for a non PumpManagerError PodCommsError
+                podCommsError = lastError as? PodCommsError
             }
 
             if let podCommsError = podCommsError, podCommsError.possibleWeakCommsCause {


### PR DESCRIPTION
Fix compiler error when uncommenting mock cannula insertion fault code
Rework mock cannula insertion fault code to not be within a comment
Change mock pod fault during pairing to be a more realistic fault type
Remove extra "." in OmnipodPumpManagerError.notReadyForCannulaInsertion description
Default insulin type to .novolog in all places to be consistent