### PR TITLE
Add option for 95% battery alert

### DIFF
--- a/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
+++ b/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
@@ -706,7 +706,7 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
                 }
                 alert.addAction(action)
 
-                for value in [20,30,40,50] {
+                for value in [20,30,40,50,95] {
                     let action = UIAlertAction.init(title: "\(value)%", style: .default) { _ in
                         self.batteryAlertLevel = value
                         self.tableView.reloadData()


### PR DESCRIPTION
Adding 95% battery alert option, for timely alert for (disposable lithium) batteries that stay at ~100% until empty. 

NB: Please check this PR, since this is my first PR ever.