### PR TITLE
Fix rxTimeout parsing bug, and onboarding bug

### DIFF
--- a/MinimedKitUI/Setup/MinimedPumpIDSetupViewController.swift
+++ b/MinimedKitUI/Setup/MinimedPumpIDSetupViewController.swift
@@ -317,15 +317,15 @@ class MinimedPumpIDSetupViewController: SetupTableViewController {
 
     override func continueButtonPressed(_ sender: Any) {
         if case .completed = continueState {
+            if let setupViewController = navigationController as? MinimedPumpManagerSetupViewController,
+                let pumpManager = pumpManager // create mdt 1
+            {
+                setupViewController.pumpManagerSetupComplete(pumpManager)
+            }
             if isSentrySetUpNeeded {
                 performSegue(withIdentifier: "Sentry", sender: sender)
             } else {
-                if let setupViewController = navigationController as? MinimedPumpManagerSetupViewController,
-                    let pumpManager = pumpManager
-                {
-                    super.continueButtonPressed(sender)
-                    setupViewController.pumpManagerSetupComplete(pumpManager)
-                }
+                super.continueButtonPressed(sender)
             }
         } else if case .readyToRead = continueState, let pumpID = pumpID, let pumpRegion = pumpRegionCode?.region {
 #if targetEnvironment(simulator)

--- a/MinimedKitUI/Setup/MinimedPumpManagerSetupViewController.swift
+++ b/MinimedKitUI/Setup/MinimedPumpManagerSetupViewController.swift
@@ -64,22 +64,6 @@ public class MinimedPumpManagerSetupViewController: RileyLinkManagerSetupViewCon
     override public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
         super.navigationController(navigationController, willShow: viewController, animated: animated)
 
-        // Read state values
-        let viewControllers = navigationController.viewControllers
-        let count = navigationController.viewControllers.count
-
-        if count >= 2 {
-            switch viewControllers[count - 2] {
-            case let vc as MinimedPumpIDSetupViewController:
-                pumpManager = vc.pumpManager
-                maxBasalRateUnitsPerHour = vc.maxBasalRateUnitsPerHour
-                maxBolusUnits = vc.maxBolusUnits
-                basalSchedule = vc.basalSchedule
-            default:
-                break
-            }
-        }
-
         if let setupViewController = viewController as? SetupTableViewController {
             setupViewController.delegate = self
         }
@@ -124,7 +108,8 @@ public class MinimedPumpManagerSetupViewController: RileyLinkManagerSetupViewCon
         }
     }
 
-    public func pumpManagerSetupComplete(_ pumpManager: PumpManagerUI) {
+    public func pumpManagerSetupComplete(_ pumpManager: MinimedPumpManager) {
+        self.pumpManager = pumpManager
         pumpManagerOnboardingDelegate?.pumpManagerOnboarding(didCreatePumpManager: pumpManager)
     }
 

--- a/RileyLinkBLEKit/Response.swift
+++ b/RileyLinkBLEKit/Response.swift
@@ -167,13 +167,13 @@ struct PacketResponse: Response {
     let packet: RFPacket?
 
     init?(data: Data) {
-        guard data.count > 1, let code = ResponseCode(rawValue: data[data.startIndex]) else {
+        guard data.count > 0, let code = ResponseCode(rawValue: data[data.startIndex]) else {
             return nil
         }
 
         switch code {
         case .success:
-            guard let packet = RFPacket(rfspyResponse: data[data.startIndex.advanced(by: 1)...]) else {
+            guard data.count > 1, let packet = RFPacket(rfspyResponse: data[data.startIndex.advanced(by: 1)...]) else {
                 return nil
             }
             self.packet = packet


### PR DESCRIPTION
* A fix for a crash in parsing RileyLink responses was implemented incorrectly, causing rxTimeout responses to not be handled properly.
* MDT onboarding was not setting the isOnboarded flag properly due to construction of multiple pumpmanagers.