### PR TITLE
Medtronic suspend resume updates

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManagerError.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManagerError.swift
@@ -10,6 +10,7 @@ import Foundation
 public enum MinimedPumpManagerError: Error {
     case noRileyLink
     case bolusInProgress
+    case pumpSuspended
     case noDate  // TODO: This is less of an error and more of a precondition/assertion state
     case tuneFailed(LocalizedError)
     case commsError(LocalizedError)
@@ -24,6 +25,8 @@ extension MinimedPumpManagerError: LocalizedError {
             return LocalizedString("No RileyLink Connected", comment: "Error description when no rileylink connected")
         case .bolusInProgress:
             return LocalizedString("Bolus in Progress", comment: "Error description when failure due to bolus in progress")
+        case .pumpSuspended:
+            return LocalizedString("Pump is Suspended", comment: "Error description when failure due to pump suspended")
         case .noDate:
             return nil
         case .tuneFailed(let error):

--- a/MinimedKit/PumpManager/MinimedPumpManagerRecents.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManagerRecents.swift
@@ -8,7 +8,7 @@
 import Foundation
 import LoopKit
 
-struct MinimedPumpManagerRecents: Equatable {
+public struct MinimedPumpManagerRecents: Equatable {
 
     internal enum EngageablePumpState: Equatable {
         case engaging
@@ -40,7 +40,7 @@ struct MinimedPumpManagerRecents: Equatable {
 }
 
 extension MinimedPumpManagerRecents: CustomDebugStringConvertible {
-    var debugDescription: String {
+    public var debugDescription: String {
         return """
         ### MinimedPumpManagerRecents
         suspendEngageState: \(suspendEngageState)

--- a/MinimedKit/PumpManager/PumpMessageSender.swift
+++ b/MinimedKit/PumpManager/PumpMessageSender.swift
@@ -78,10 +78,10 @@ extension PumpMessageSender {
     ///     - PumpOpsError.unknownResponse
     func getResponse<T: MessageBody>(to message: PumpMessage, responseType: MessageType = .pumpAck, repeatCount: Int = 0, timeout: TimeInterval = standardPumpResponseWindow, retryCount: Int = 3) throws -> T {
         
-        log.debug("getResponse(%{public}@, %d, %f, %d)", String(describing: message), repeatCount, timeout, retryCount)
+        log.debug("getResponse() Sending: %{public}@, %d, %f, %d)", String(describing: message), repeatCount, timeout, retryCount)
         
         let response = try sendAndListen(message, repeatCount: repeatCount, timeout: timeout, retryCount: retryCount)
-        
+
         guard response.messageType == responseType, let body = response.messageBody as? T else {
             if let body = response.messageBody as? PumpErrorMessageBody {
                 switch body.errorCode {
@@ -91,9 +91,11 @@ extension PumpMessageSender {
                     throw PumpOpsError.unknownPumpErrorCode(code)
                 }
             } else {
+                log.debug("getResponse() Received unexpected response: %{public}@", String(describing: response))
                 throw PumpOpsError.unexpectedResponse(response, from: message)
             }
         }
+        log.debug("getResponse() Received: %{public}@", String(describing: response))
         return body
     }
 

--- a/MinimedKitUI/MinimedPumpManager+UI.swift
+++ b/MinimedKitUI/MinimedPumpManager+UI.swift
@@ -68,7 +68,7 @@ extension MinimedPumpManager: PumpManagerUI {
 extension MinimedPumpManager {
     
     public var pumpStatusHighlight: DeviceStatusHighlight? {
-        return nil
+        return buildPumpStatusHighlight(for: state, recents: recents)
     }
     
     public var pumpLifecycleProgress: DeviceLifecycleProgress? {

--- a/RileyLinkBLEKit/PeripheralManager+RileyLink.swift
+++ b/RileyLinkBLEKit/PeripheralManager+RileyLink.swift
@@ -111,11 +111,13 @@ extension PeripheralManager.Configuration {
             valueUpdateMacros: [
                 // When the responseCount changes, the data characteristic should be read.
                 MainServiceCharacteristicUUID.responseCount.cbUUID: { (manager: PeripheralManager) in
+                    log.debug("responseCount valueUpdated")
                     guard let dataCharacteristic = manager.peripheral.getCharacteristicWithUUID(.data)
                     else {
+                        log.debug("could not get data characteristic")
                         return
                     }
-
+                    log.debug("Reading data characteristic")
                     manager.peripheral.readValue(for: dataCharacteristic)
                 }
             ]
@@ -569,7 +571,7 @@ extension PeripheralManager {
                             // We don't recognize the contents. Keep listening.
                             return false
                         }
-                        log.debug("RileyLink response: %{public}@", String(describing: response))
+                        log.debug("writeCommand response: %{public}@", String(describing: response))
                         capturedResponse = response
                         return true
                     }
@@ -635,12 +637,12 @@ extension PeripheralManager {
                     for response in buffer.responses {
                         switch response.code {
                         case .rxTimeout, .zeroData, .invalidParam, .unknownCommand:
-                            log.debug("RileyLink response: %{public}@", String(describing: response))
+                            log.debug("writeLegacyCommand response: %{public}@", String(describing: response))
                             capturedResponse = response
                             return true
                         case .commandInterrupted:
                             // This is expected in cases where an "Idle" GetPacket command is running
-                            log.debug("RileyLink response: %{public}@", String(describing: response))
+                            log.debug("writeLegacyCommand response (commandInterrupted): %{public}@", String(describing: response))
                         case .success:
                             capturedResponse = response
                             return true

--- a/RileyLinkBLEKit/PeripheralManager.swift
+++ b/RileyLinkBLEKit/PeripheralManager.swift
@@ -390,6 +390,8 @@ extension PeripheralManager: CBPeripheralDelegate {
 
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         commandLock.lock()
+
+        log.debug("didUpdateValueFor %{public}@, error = %{public}@, value=%{public}@", characteristic, String(describing: error), characteristic.value?.hexadecimalString ?? "nil")
         
         var notifyDelegate = false
 


### PR DESCRIPTION
* Detect manual resumes 
* Make sure suspend/resume is detected when running with MySentry driven updates.
* Automatic bolus should not automatically resume a suspended pump

Should fix: https://github.com/LoopKit/Loop/issues/1341, https://github.com/LoopKit/Loop/issues/1248, https://github.com/LoopKit/Loop/issues/1563