### PR TITLE
enable Eros pod lifecycle display

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -283,7 +283,7 @@ extension OmnipodPumpManager {
         })
     }
     
-    private func lifecycleProgress(for state: OmnipodPumpManagerState) -> PumpManagerStatus.PumpLifecycleProgress? {
+    public func lifecycleProgress(for state: OmnipodPumpManagerState) -> PumpManagerStatus.PumpLifecycleProgress? {
         guard let podState = state.podState, let expiresAt = podState.expiresAt else {
             return nil
         }

--- a/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
+++ b/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
@@ -81,7 +81,7 @@ extension OmnipodPumpManager {
     }
     
     public var pumpLifecycleProgress: DeviceLifecycleProgress? {
-        return nil
+        return lifecycleProgress(for: state)
     }
     
     public var pumpStatusBadge: DeviceStatusBadge? {


### PR DESCRIPTION
Joe noticed there was no lifecycle display for an Eros pod that had been running 75 hours.
This change enables the display.
He also noted there had been no HUD indication of expiration.  I wasn't sure how to fix that one.

Note - no modification was made to when display begins, i.e., display starts at 24 hours before expiration.
Changes as discussed in [zulipchat](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Easy.20access.20to.20Pod.20Age/near/275112771)(for Eros and Dash) will be a separate PR.