### PR TITLE
Gracefully handle boluses below minimum increment

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -1170,7 +1170,9 @@ extension MinimedPumpManager: PumpManager {
         let enactUnits = roundToSupportedBolusVolume(units: units)
 
         guard enactUnits > 0 else {
-            assertionFailure("Invalid zero unit bolus")
+            let error = MinimedPumpManagerError.bolusTooSmall
+            self.log.error("Bolus entered was too small to deliver.")
+            completion(.communication(error as LocalizedError))
             return
         }
         

--- a/MinimedKit/PumpManager/MinimedPumpManagerError.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManagerError.swift
@@ -15,6 +15,7 @@ public enum MinimedPumpManagerError: Error {
     case tuneFailed(LocalizedError)
     case commsError(LocalizedError)
     case storageFailure
+    case bolusTooSmall
 }
 
 
@@ -35,6 +36,8 @@ extension MinimedPumpManagerError: LocalizedError {
             return error.errorDescription
         case .storageFailure:
             return LocalizedString("Unable to store pump data", comment: "Error description when storage fails")
+        case .bolusTooSmall:
+            return LocalizedString("Bolus too small to deliver", comment: "Error description when entered bolus is below minimum deliverable amount")
         }
     }
 


### PR DESCRIPTION
Display error message rather than assertionFailure when manual bolus entered is below minimum deliverable increment.  Addresses issue LoopKit/Loop#1637.