### PR TITLE
Reworked shared basal rate support for Dash & Eros

### DIFF
--- a/OmniKit/MessageTransport/MessageBlocks/BasalScheduleExtraCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/BasalScheduleExtraCommand.swift
@@ -55,7 +55,7 @@ public struct BasalScheduleExtraCommand : MessageBlock {
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~Pod.nearZeroBasalRateFlag
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~nearZeroBasalRateFlag
             let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }
@@ -86,12 +86,12 @@ public struct BasalScheduleExtraCommand : MessageBlock {
         self.currentEntryIndex = UInt8(entryIndex)
         let timeRemainingInEntry = duration - (scheduleOffsetNearestSecond - entry.startTime)
         let rate = mergedSchedule.rateAt(offset: scheduleOffsetNearestSecond)
-        var nrate = normalizedBasalTimingRate(rate: rate)
-        if nrate == 0.0 {
+        var rrate = roundToSupportedBasalTimingRate(rate: rate)
+        if rrate == 0.0 {
             // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
-            nrate = Pod.nearZeroBasalRate
+            rrate = nearZeroBasalRate
         }
-        let pulsesPerHour = nrate / Pod.pulseSize
+        let pulsesPerHour = rrate / Pod.pulseSize
         let timeBetweenPulses = TimeInterval(hours: 1) / pulsesPerHour
         self.delayUntilNextTenthOfPulse = timeRemainingInEntry.truncatingRemainder(dividingBy: (timeBetweenPulses / 10))
         self.remainingPulses = pulsesPerHour * (timeRemainingInEntry-self.delayUntilNextTenthOfPulse) / .hours(1) + 0.1

--- a/OmniKit/MessageTransport/MessageBlocks/BasalScheduleExtraCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/BasalScheduleExtraCommand.swift
@@ -55,7 +55,7 @@ public struct BasalScheduleExtraCommand : MessageBlock {
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self)
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~Pod.nearZeroBasalRateFlag
             let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }
@@ -86,7 +86,12 @@ public struct BasalScheduleExtraCommand : MessageBlock {
         self.currentEntryIndex = UInt8(entryIndex)
         let timeRemainingInEntry = duration - (scheduleOffsetNearestSecond - entry.startTime)
         let rate = mergedSchedule.rateAt(offset: scheduleOffsetNearestSecond)
-        let pulsesPerHour = round(rate / Pod.pulseSize)
+        var nrate = normalizedBasalTimingRate(rate: rate)
+        if nrate == 0.0 {
+            // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
+            nrate = Pod.nearZeroBasalRate
+        }
+        let pulsesPerHour = nrate / Pod.pulseSize
         let timeBetweenPulses = TimeInterval(hours: 1) / pulsesPerHour
         self.delayUntilNextTenthOfPulse = timeRemainingInEntry.truncatingRemainder(dividingBy: (timeBetweenPulses / 10))
         self.remainingPulses = pulsesPerHour * (timeRemainingInEntry-self.delayUntilNextTenthOfPulse) / .hours(1) + 0.1

--- a/OmniKit/MessageTransport/MessageBlocks/SetInsulinScheduleCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/SetInsulinScheduleCommand.swift
@@ -164,10 +164,10 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
     public init(nonce: UInt32, basalSchedule: BasalSchedule, scheduleOffset: TimeInterval) {
         let scheduleOffsetNearestSecond = round(scheduleOffset)
         let table = BasalDeliveryTable(schedule: basalSchedule)
-        var rate = normalizedBasalTimingRate(rate: basalSchedule.rateAt(offset: scheduleOffsetNearestSecond))
+        var rate = roundToSupportedBasalTimingRate(rate: basalSchedule.rateAt(offset: scheduleOffsetNearestSecond))
         if rate == 0.0 {
             // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
-            rate = Pod.nearZeroBasalRate
+            rate = nearZeroBasalRate
         }
 
         let segment = Int(scheduleOffsetNearestSecond / BasalDeliveryTable.segmentDuration)

--- a/OmniKit/MessageTransport/MessageBlocks/SetInsulinScheduleCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/SetInsulinScheduleCommand.swift
@@ -164,7 +164,11 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
     public init(nonce: UInt32, basalSchedule: BasalSchedule, scheduleOffset: TimeInterval) {
         let scheduleOffsetNearestSecond = round(scheduleOffset)
         let table = BasalDeliveryTable(schedule: basalSchedule)
-        let rate = basalSchedule.rateAt(offset: scheduleOffsetNearestSecond)
+        var rate = normalizedBasalTimingRate(rate: basalSchedule.rateAt(offset: scheduleOffsetNearestSecond))
+        if rate == 0.0 {
+            // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
+            rate = Pod.nearZeroBasalRate
+        }
 
         let segment = Int(scheduleOffsetNearestSecond / BasalDeliveryTable.segmentDuration)
 

--- a/OmniKit/MessageTransport/MessageBlocks/TempBasalExtraCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/TempBasalExtraCommand.swift
@@ -55,7 +55,7 @@ public struct TempBasalExtraCommand : MessageBlock {
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~Pod.nearZeroBasalRateFlag
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~nearZeroBasalRateFlag
             let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }

--- a/OmniKit/MessageTransport/MessageBlocks/TempBasalExtraCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/TempBasalExtraCommand.swift
@@ -14,7 +14,7 @@ public struct TempBasalExtraCommand : MessageBlock {
     public let completionBeep: Bool
     public let programReminderInterval: TimeInterval
     public let remainingPulses: Double
-    public let delayUntilFirstTenthOfPulse: TimeInterval
+    public let delayUntilFirstPulse: TimeInterval
     public let rateEntries: [RateEntry]
 
     public let blockType: MessageBlockType = .tempBasalExtra
@@ -27,12 +27,8 @@ public struct TempBasalExtraCommand : MessageBlock {
             beepOptions,
             0
             ])
-        data.appendBigEndian(UInt16(round(remainingPulses * 2) * 5))
-        if remainingPulses == 0 {
-            data.appendBigEndian(UInt32(delayUntilFirstTenthOfPulse.hundredthsOfMilliseconds) * 10)
-        } else {
-            data.appendBigEndian(UInt32(delayUntilFirstTenthOfPulse.hundredthsOfMilliseconds))
-        }
+        data.appendBigEndian(UInt16(round(remainingPulses * 10)))
+        data.appendBigEndian(UInt32(delayUntilFirstPulse.hundredthsOfMilliseconds))
         for entry in rateEntries {
             data.append(entry.data)
         }
@@ -40,6 +36,9 @@ public struct TempBasalExtraCommand : MessageBlock {
     }
 
     public init(encodedData: Data) throws {
+        if encodedData.count < 14 {
+            throw MessageBlockError.notEnoughData
+        }
         
         let length = encodedData[1]
         let numEntries = (length - 8) / 6
@@ -50,22 +49,14 @@ public struct TempBasalExtraCommand : MessageBlock {
         
         remainingPulses = Double(encodedData[4...].toBigEndian(UInt16.self)) / 10.0
         let timerCounter = encodedData[6...].toBigEndian(UInt32.self)
-        if remainingPulses == 0 {
-            delayUntilFirstTenthOfPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter) / 10)
-        } else {
-            delayUntilFirstTenthOfPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
-        }
+        delayUntilFirstPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
+
         var entries = [RateEntry]()
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self)
-            let delayBetweenPulses: TimeInterval
-            if totalPulses == 0 {
-                delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter)) / 10
-            } else {
-                delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
-            }
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~Pod.nearZeroBasalRateFlag
+            let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }
         rateEntries = entries
@@ -74,7 +65,7 @@ public struct TempBasalExtraCommand : MessageBlock {
     public init(rate: Double, duration: TimeInterval, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) {
         rateEntries = RateEntry.makeEntries(rate: rate, duration: duration)
         remainingPulses = rateEntries[0].totalPulses
-        delayUntilFirstTenthOfPulse = rateEntries[0].delayBetweenPulses
+        delayUntilFirstPulse = rateEntries[0].delayBetweenPulses
         self.acknowledgementBeep = acknowledgementBeep
         self.completionBeep = completionBeep
         self.programReminderInterval = programReminderInterval
@@ -83,6 +74,6 @@ public struct TempBasalExtraCommand : MessageBlock {
 
 extension TempBasalExtraCommand: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "TempBasalExtraCommand(completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.stringValue) remainingPulses:\(remainingPulses), delayUntilNextPulse:\(delayUntilFirstTenthOfPulse.stringValue), rateEntries:\(rateEntries))"
+        return "TempBasalExtraCommand(completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.stringValue) remainingPulses:\(remainingPulses), delayUntilFirstPulse:\(delayUntilFirstPulse.stringValue), rateEntries:\(rateEntries))"
     }
 }

--- a/OmniKit/Model/BasalSchedule.swift
+++ b/OmniKit/Model/BasalSchedule.swift
@@ -16,7 +16,7 @@ public struct BasalScheduleEntry: RawRepresentable, Equatable {
     let startTime: TimeInterval
     
     public init(rate: Double, startTime: TimeInterval) {
-        self.rate = normalizedBasalRate(rate: rate)
+        self.rate = roundToSupportedBasalRate(rate: rate)
         self.startTime = startTime
     }
     

--- a/OmniKit/Model/BasalSchedule.swift
+++ b/OmniKit/Model/BasalSchedule.swift
@@ -16,7 +16,7 @@ public struct BasalScheduleEntry: RawRepresentable, Equatable {
     let startTime: TimeInterval
     
     public init(rate: Double, startTime: TimeInterval) {
-        self.rate = rate
+        self.rate = normalizedBasalRate(rate: rate)
         self.startTime = startTime
     }
     

--- a/OmniKit/Model/Pod.swift
+++ b/OmniKit/Model/Pod.swift
@@ -67,15 +67,6 @@ public struct Pod {
     // Minimum duration of a single basal schedule entry
     public static let minimumBasalScheduleEntryDuration = TimeInterval.minutes(30)
 
-    // Max time between pulses for basal and temp basal extra timing command
-    public static let maxTimeBetweenPulses = TimeInterval(hours: 5)
-
-    // Near zero basal rate used for non-Eros pods for zero scheduled basal rates and temp basals
-    public static let nearZeroBasalRate = 0.01
-
-    // Special flag used for non-Eros pods for near zero basal rates pulse timing for $13 & $16 extra commands
-    public static let nearZeroBasalRateFlag: UInt32 = 0x80000000
-
     // Default amount for priming bolus using secondsPerPrimePulse timing.
     // Checked to verify it agrees with value returned by pod during the pairing process.
     public static let primeUnits = 2.6

--- a/OmniKit/Model/Pod.swift
+++ b/OmniKit/Model/Pod.swift
@@ -53,13 +53,28 @@ public struct Pod {
     public static let reservoirCapacity: Double = 200
 
     // Supported basal rates
+    // Eros minimum scheduled basal rate is 0.05 U/H while for Dash supports 0 U/H.
+    // Would need to have this value based on productID to be able to share this with Eros.
     public static let supportedBasalRates: [Double] = (1...600).map { Double($0) / Double(pulsesPerUnit) }
+
+    // The internal basal rate used for non-Eros pods
+    // Would need to have this value based on productID to be able to share this file with Eros.
+    public static let zeroBasalRate: Double = 0.0
 
     // Maximum number of basal schedule entries supported
     public static let maximumBasalScheduleEntryCount: Int = 24
 
     // Minimum duration of a single basal schedule entry
     public static let minimumBasalScheduleEntryDuration = TimeInterval.minutes(30)
+
+    // Max time between pulses for basal and temp basal extra timing command
+    public static let maxTimeBetweenPulses = TimeInterval(hours: 5)
+
+    // Near zero basal rate used for non-Eros pods for zero scheduled basal rates and temp basals
+    public static let nearZeroBasalRate = 0.01
+
+    // Special flag used for non-Eros pods for near zero basal rates pulse timing for $13 & $16 extra commands
+    public static let nearZeroBasalRateFlag: UInt32 = 0x80000000
 
     // Default amount for priming bolus using secondsPerPrimePulse timing.
     // Checked to verify it agrees with value returned by pod during the pairing process.

--- a/OmniKitTests/BasalScheduleTests.swift
+++ b/OmniKitTests/BasalScheduleTests.swift
@@ -150,7 +150,7 @@ class BasalScheduleTests: XCTestCase {
         XCTAssertEqual("131a4002009600a7d8c0089d0105944905a001312d00044c0112a880", cmd2.data.hexadecimalString) // PDM
     }
     
-    func checkBasalScheduleExtraCommandDataWithLessPrecision(_ data: Data, _ expected: Data, line: UInt = #line) {
+    func checkBasalScheduleExtraCommandDataWithLessPrecision(_ expected: Data, _ data: Data, line: UInt = #line) {
         // The XXXXXXXX field is in thousands of a millisecond. Since we use TimeIntervals (floating point) for
         // recreating the offset, we can have small errors in reproducing the the encoded output, which we really
         // don't care about.
@@ -159,8 +159,8 @@ class BasalScheduleTests: XCTestCase {
             return TimeInterval(Double(data[6...].toBigEndian(UInt32.self)) / 1000000.0)
         }
         
-        let xxxxxxxx1 = extractXXXXXXXX(data)
-        let xxxxxxxx2 = extractXXXXXXXX(expected)
+        let xxxxxxxx1 = extractXXXXXXXX(expected)
+        let xxxxxxxx2 = extractXXXXXXXX(data)
         XCTAssertEqual(xxxxxxxx1, xxxxxxxx2, accuracy: 0.01, line: line)
         
         func blurXXXXXXXX(_ inStr: String) -> String {
@@ -169,7 +169,7 @@ class BasalScheduleTests: XCTestCase {
             return inStr.replacingCharacters(in: start..<end, with: "........")
         }
         print(blurXXXXXXXX(data.hexadecimalString))
-        XCTAssertEqual(blurXXXXXXXX(data.hexadecimalString), blurXXXXXXXX(expected.hexadecimalString), line: line)
+        XCTAssertEqual(blurXXXXXXXX(expected.hexadecimalString), blurXXXXXXXX(data.hexadecimalString), line: line)
     }
 
     func testBasalExtraEncoding1() {
@@ -385,6 +385,35 @@ class BasalScheduleTests: XCTestCase {
         XCTAssertEqual("1a2af36a23a3000291030ae80000000d280000111809700a180610052806100600072806001128100009e808", cmd1.data.hexadecimalString)
     }
     
+    func testFunkyRates() {
+        let entries = [
+            BasalScheduleEntry(rate:  1.325, startTime: 0),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(0.5)),
+            BasalScheduleEntry(rate:  1.699, startTime: .hours(2.0)),
+            BasalScheduleEntry(rate:  0.850001, startTime: .hours(2.5)),
+            BasalScheduleEntry(rate:  1.02499999, startTime: .hours(3.0)),
+            BasalScheduleEntry(rate:  0.650001, startTime: .hours(7.5)),
+            BasalScheduleEntry(rate:  0.50, startTime: .hours(8.5)),
+            BasalScheduleEntry(rate:  0.675, startTime: .hours(9.5)),
+            BasalScheduleEntry(rate:  0.59999, startTime: .hours(10.5)),
+            BasalScheduleEntry(rate:  0.666, startTime: .hours(11.5)),
+            BasalScheduleEntry(rate:  1.675, startTime: .hours(14.0)),
+            BasalScheduleEntry(rate:  0.849, startTime: .hours(16)),
+            ]
+
+        let schedule = BasalSchedule(entries: entries)
+
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 2a f36a23a3 00 0291 03 0ae8 0000 000d 2800 0011 1809 700a 1806 1005 2806 1006 0007 2806 0011 2810 0009 e808
+
+        let hh       = 0x03
+        let ssss     = 0x0ae8
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0xf36a23a3, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a2af36a23a3000291030ae80000000d280000111809700a180610052806100600072806001128100009e808", cmd1.data.hexadecimalString)
+    }
+
     func testBasalScheduleExtraCommandRoundsToNearestSecond() {
         let schedule = BasalSchedule(entries: [BasalScheduleEntry(rate: 1.0, startTime: 0)])
         

--- a/OmniKitTests/TempBasalTests.swift
+++ b/OmniKitTests/TempBasalTests.swift
@@ -164,11 +164,11 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(true, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 1800), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
             XCTAssertEqual(0, cmd.remainingPulses)
             XCTAssertEqual(1, cmd.rateEntries.count)
             let entry = cmd.rateEntries[0]
-            XCTAssertEqual(TimeInterval(seconds: 1800), entry.delayBetweenPulses)
+            XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
             XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
             XCTAssertEqual(0, entry.rate)
             
@@ -188,14 +188,14 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(true, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 1800), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
             XCTAssertEqual(0, cmd.remainingPulses)
             XCTAssertEqual(6, cmd.rateEntries.count)
-            let entry = cmd.rateEntries[0]
-            XCTAssertEqual(TimeInterval(seconds: 1800), entry.delayBetweenPulses)
-            XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
-            XCTAssertEqual(0, entry.rate)
-            
+            for entry in cmd.rateEntries {
+                XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
+                XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
+                XCTAssertEqual(0, entry.rate)
+            }
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
@@ -205,6 +205,33 @@ class TempBasalTests: XCTestCase {
         XCTAssertEqual("162c7c0000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d200", cmd.data.hexadecimalString)
     }
 
+    func testZeroTempTwelveHoursExtraCommand() {
+        do {
+            // 0 U/h for 12 hours
+            //        16 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+            //        16 98 7c 00 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200
+            let cmd = try TempBasalExtraCommand(encodedData: Data(hexadecimalString: "16987c0000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d200")!)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
+            XCTAssertEqual(0, cmd.remainingPulses)
+            XCTAssertEqual(24, cmd.rateEntries.count)
+            for entry in cmd.rateEntries {
+                XCTAssertEqual(0, entry.totalPulses)
+                XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
+                XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
+                XCTAssertEqual(0, entry.rate)
+            }
+
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+
+        // Encode
+        let cmd = TempBasalExtraCommand(rate: 0, duration: .hours(12), acknowledgementBeep: false, completionBeep: true, programReminderInterval: .minutes(60))
+        XCTAssertEqual("16987c0000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d200", cmd.data.hexadecimalString)
+    }
 
     func testTempBasalExtremeValues() {
         do {
@@ -244,7 +271,7 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(true, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstPulse)
             XCTAssertEqual(300, cmd.remainingPulses)
             XCTAssertEqual(1, cmd.rateEntries.count)
             let entry = cmd.rateEntries[0]
@@ -292,7 +319,7 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(false, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstPulse)
             XCTAssertEqual(6300, cmd.remainingPulses)
             XCTAssertEqual(2, cmd.rateEntries.count)
             let entry = cmd.rateEntries[0]
@@ -316,7 +343,7 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(false, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 6.01001), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(seconds: 6.01001), cmd.delayUntilFirstPulse)
             XCTAssertEqual(6289.5, cmd.remainingPulses)
             XCTAssertEqual(2, cmd.rateEntries.count)
             let entry1 = cmd.rateEntries[0]


### PR DESCRIPTION
+ Dash zero scheduled basal rates now supported
+ Dash zero temp basal corrected for all durations
+ Eros zero temp basal rate clean up work
+ Handle any non-standard basal rates
+ Add new unit test for non-standard basal rates