### PR TITLE
Fix to handle an imported zero bsaal schedule rate on Eros

### DIFF
--- a/OmniKit/Model/BasalSchedule.swift
+++ b/OmniKit/Model/BasalSchedule.swift
@@ -16,7 +16,12 @@ public struct BasalScheduleEntry: RawRepresentable, Equatable {
     let startTime: TimeInterval
     
     public init(rate: Double, startTime: TimeInterval) {
-        self.rate = roundToSupportedBasalRate(rate: rate)
+        var rrate = roundToSupportedBasalRate(rate: rate)
+        if rrate == 0 && Pod.zeroBasalRate == 0 {
+            // Got a zero scheduled basal rate for an Eros pod, use the min allowed
+            rrate = Pod.pulseSize
+        }
+        self.rate = rrate
         self.startTime = startTime
     }
     


### PR DESCRIPTION
Add new unit test for sample MDT 723 only basal schedule import