### PR TITLE
Modify HUD display of pod lifecycle

### DIFF
--- a/OmniKit/Model/Pod.swift
+++ b/OmniKit/Model/Pod.swift
@@ -30,8 +30,8 @@ public struct Pod {
     // Units per second for priming/cannula insertion
     public static let primeDeliveryRate: Double = Pod.pulseSize / Pod.secondsPerPrimePulse
 
-    // User configured time before expiration advisory (PDM allows 1-24 hours)
-    public static let expirationAlertWindow = TimeInterval(hours: 2)
+    // Threshold used to display pod end of life warnings
+    public static let timeRemainingWarningThreshold = TimeInterval(days: 1)
 
     // Expiration advisory window: time after expiration alert, and end of service imminent alarm
     public static let expirationAdvisoryWindow = TimeInterval(hours: 7)

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -287,18 +287,19 @@ extension OmnipodPumpManager {
         guard let podState = state.podState, let expiresAt = podState.expiresAt else {
             return nil
         }
+        let eolDisplayActiveTime = expiresAt.timeIntervalSinceNow + Pod.timeRemainingWarningThreshold
         
         switch expiresAt.timeIntervalSinceNow {
         case let remaining where remaining <= 0:
             return PumpLifecycleProgress(
                 percentComplete: 1,
                 progressState: .critical)
-        case let remaining where remaining < .hours(24):
+        case let remaining where remaining < eolDisplayActiveTime:
             return PumpLifecycleProgress(
                 percentComplete: 1 - remaining / Pod.nominalPodLife,
                 progressState: .warning)
         default:
-            // Do not display lifecycle progress when we have >= 24 hours left
+            // Do not display lifecycle progress when we have >= 24 hours left until user selected warning time
             return nil
        }
     }


### PR DESCRIPTION
Modify HUD pod lifecycle display logic for Eros pods to include user selected expiration warning.
Please see [PR 40: modify HUD pod lifecycle display](https://github.com/LoopKit/OmniBLE/pull/40) for more information about motivation and design.

Warning - The code builds onto a test phone and I think it will modify behavior as desired but I have not tested it.
I hope to find an Eros user willing to test this PR.

Two changes:
* OmniKit/Model/Pod.swift:
```
    Add timeRemainingWarningThreshold
    Remove expirationAlertWindow which is not used and has a name similar to
    expirationReminderAlertDefaultTimeBeforeExpiration which is used
```
* OmniKit/PumpManager/OmnipodPumpManager.swift:
```
modify HUD pod lifecycle display logic based on user selected expiration reminder
```
