### PR TITLE
Convert Nightscout glucose direction to a trend

### DIFF
--- a/NightscoutUploadKit/Models/GlucoseEntry.swift
+++ b/NightscoutUploadKit/Models/GlucoseEntry.swift
@@ -27,16 +27,13 @@ public struct GlucoseEntry {
         case rateOutOfRange = 9
         
         init?(direction: String) {
-            var directionToTrends = [String:GlucoseTrend]()
             for trend in GlucoseTrend.allCases {
-                directionToTrends[trend.direction] = trend
+                if direction == trend.direction {
+                    self = trend
+                    return
+                }
             }
-            
-            if let trend = directionToTrends[direction] {
-                self = trend
-            } else {
-                return nil
-            }
+            return nil
         }
 
         public var direction: String {

--- a/NightscoutUploadKit/Models/GlucoseEntry.swift
+++ b/NightscoutUploadKit/Models/GlucoseEntry.swift
@@ -15,7 +15,7 @@ public struct GlucoseEntry {
         case sensor
     }
 
-    public enum GlucoseTrend: Int {
+    public enum GlucoseTrend: Int, CaseIterable {
         case upUpUp         = 1
         case upUp           = 2
         case up             = 3
@@ -25,6 +25,19 @@ public struct GlucoseEntry {
         case downDownDown   = 7
         case notComputable  = 8
         case rateOutOfRange = 9
+        
+        init?(direction: String) {
+            var directionToTrends = [String:GlucoseTrend]()
+            for trend in GlucoseTrend.allCases {
+                directionToTrends[trend.direction] = trend
+            }
+            
+            if let trend = directionToTrends[direction] {
+                self = trend
+            } else {
+                return nil
+            }
+        }
 
         public var direction: String {
             switch self {
@@ -119,6 +132,8 @@ public struct GlucoseEntry {
             self.trend = GlucoseTrend(rawValue: intTrend)
         } else if let stringTrend = rawValue["trend"] as? String, let intTrend = Int(stringTrend) {
             self.trend = GlucoseTrend(rawValue: intTrend)
+        } else if let directionString = rawValue["direction"] as? String {
+            self.trend = GlucoseTrend(direction: directionString)
         } else {
             self.trend = nil
         }


### PR DESCRIPTION
When the "NS as CGM" downloads data with no trend, only direction, we currently fail to show any directional arrows in Loop. This occurred recently for a user using Freestyle Libre 2. See the [Zulip thread](https://loop.zulipchat.com/#narrow/stream/144111-general/topic/CGM.20arrow.20with.20Nightscout). It seems we should be able to map those directions to trends as is also done in the ShareClient.swift. Here is an example of the trend-less data. We should be able to translate "Flat" to the corresponding GlucoseEntry.

```
  {
    "_id": "iYMDTWBOOqV5osbJmmDRLMil",
    "filtered": 89000,
    "sysTime": "2022-05-23T22:56:22.256Z",
    "dateString": "2022-05-23T22:56:22.256Z",
    "noise": 1,
    "device": "ABBOTT3MH008M1HP4",
    "direction": "Flat",
    "date": 1653346582256,
    "sgv": 89,
    "unfiltered": 89000,
    "type": "sgv",
    "utcOffset": 0
  }
```