### PR TITLE
Add ability to cancel from insulin selection screen

### DIFF
--- a/MinimedKitUI/MinimedPumpManager+UI.swift
+++ b/MinimedKitUI/MinimedPumpManager+UI.swift
@@ -21,13 +21,19 @@ extension MinimedPumpManager: PumpManagerUI {
 
     static public func setupViewController(initialSettings settings: PumpManagerSetupSettings, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool, allowedInsulinTypes: [InsulinType]) -> SetupUIResult<PumpManagerViewController, PumpManagerUI> {
         let navVC = MinimedPumpManagerSetupViewController.instantiateFromStoryboard()
-        let insulinSelectionView = InsulinTypeConfirmation(initialValue: .novolog, supportedInsulinTypes: allowedInsulinTypes) { [weak navVC] (confirmedType) in
+        let didConfirm: (InsulinType) -> Void = { [weak navVC] (confirmedType) in
             if let navVC = navVC {
                 navVC.insulinType = confirmedType
                 let nextViewController = navVC.storyboard?.instantiateViewController(identifier: "RileyLinkSetup") as! RileyLinkSetupTableViewController
                 navVC.pushViewController(nextViewController, animated: true)
             }
         }
+        let didCancel: () -> Void = { [weak navVC] in
+            if let navVC = navVC {
+                navVC.didCancel()
+            }
+        }
+        let insulinSelectionView = InsulinTypeConfirmation(initialValue: .novolog, supportedInsulinTypes: allowedInsulinTypes, didConfirm: didConfirm, didCancel: didCancel)
         let rootVC = UIHostingController(rootView: insulinSelectionView)
         rootVC.title = "Insulin Type"
         navVC.pushViewController(rootVC, animated: false)

--- a/MinimedKitUI/Setup/MinimedPumpManagerSetupViewController.swift
+++ b/MinimedKitUI/Setup/MinimedPumpManagerSetupViewController.swift
@@ -127,10 +127,14 @@ public class MinimedPumpManagerSetupViewController: RileyLinkManagerSetupViewCon
     public func finishedSettingsDisplay() {
         completionDelegate?.completionNotifyingDidComplete(self)
     }
+    
+    public func didCancel() {
+        completionDelegate?.completionNotifyingDidComplete(self)
+    }
 }
 
 extension MinimedPumpManagerSetupViewController: SetupTableViewControllerDelegate {
     public func setupTableViewControllerCancelButtonPressed(_ viewController: SetupTableViewController) {
-        completionDelegate?.completionNotifyingDidComplete(self)
+        didCancel()
     }
 }

--- a/MinimedKitUI/Views/InsulinTypeConfirmation.swift
+++ b/MinimedKitUI/Views/InsulinTypeConfirmation.swift
@@ -15,11 +15,13 @@ struct InsulinTypeConfirmation: View {
     @State private var insulinType: InsulinType?
     private var supportedInsulinTypes: [InsulinType]
     private var didConfirm: (InsulinType) -> Void
+    private var didCancel: () -> Void
     
-    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], didConfirm: @escaping (InsulinType) -> Void) {
+    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], didConfirm: @escaping (InsulinType) -> Void, didCancel: @escaping () -> Void) {
         self._insulinType = State(initialValue: initialValue)
         self.supportedInsulinTypes = supportedInsulinTypes
         self.didConfirm = didConfirm
+        self.didCancel = didCancel
     }
     
     func continueWithType(_ insulinType: InsulinType?) {
@@ -49,13 +51,18 @@ struct InsulinTypeConfirmation: View {
                     .padding()
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {
+                    didCancel()
+                })
+            }
+        }
     }
 }
 
 struct InsulinTypeConfirmation_Previews: PreviewProvider {
     static var previews: some View {
-        InsulinTypeConfirmation(initialValue: .humalog, supportedInsulinTypes: InsulinType.allCases) { (newType) in
-            
-        }
+        InsulinTypeConfirmation(initialValue: .humalog, supportedInsulinTypes: InsulinType.allCases, didConfirm: { (newType) in }, didCancel: {})
     }
 }

--- a/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
+++ b/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
@@ -22,13 +22,17 @@ extension OmnipodPumpManager: PumpManagerUI {
 
     static public func setupViewController(initialSettings settings: PumpManagerSetupSettings, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool, allowedInsulinTypes: [InsulinType]) -> SetupUIResult<PumpManagerViewController, PumpManagerUI> {
         let navVC = OmnipodPumpManagerSetupViewController.instantiateFromStoryboard()
-        let insulinSelectionView = InsulinTypeConfirmation(initialValue: .novolog, supportedInsulinTypes: allowedInsulinTypes) { [weak navVC] (confirmedType) in
+        let didConfirm: (InsulinType) -> Void = { [weak navVC] (confirmedType) in
             if let navVC = navVC {
                 navVC.insulinType = confirmedType
                 let nextViewController = navVC.storyboard?.instantiateViewController(identifier: "RileyLinkSetup") as! RileyLinkSetupTableViewController
                 navVC.pushViewController(nextViewController, animated: true)
             }
         }
+        let didCancel: () -> Void = { [weak navVC] in
+            navVC?.didCancel()
+        }
+        let insulinSelectionView = InsulinTypeConfirmation(initialValue: .novolog, supportedInsulinTypes: allowedInsulinTypes, didConfirm: didConfirm, didCancel: didCancel)
         let rootVC = UIHostingController(rootView: insulinSelectionView)
         rootVC.title = "Insulin Type"
         navVC.pushViewController(rootVC, animated: false)

--- a/OmniKitUI/ViewControllers/OmnipodPumpManagerSetupViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodPumpManagerSetupViewController.swift
@@ -99,10 +99,14 @@ public class OmnipodPumpManagerSetupViewController: RileyLinkManagerSetupViewCon
     public func finishedSettingsDisplay() {
         completionDelegate?.completionNotifyingDidComplete(self)
     }
+    
+    public func didCancel() {
+        completionDelegate?.completionNotifyingDidComplete(self)
+    }
 }
 
 extension OmnipodPumpManagerSetupViewController: SetupTableViewControllerDelegate {
     public func setupTableViewControllerCancelButtonPressed(_ viewController: SetupTableViewController) {
-        completionDelegate?.completionNotifyingDidComplete(self)
+        didCancel()
     }
 }

--- a/OmniKitUI/Views/InsulinTypeConfirmation.swift
+++ b/OmniKitUI/Views/InsulinTypeConfirmation.swift
@@ -15,11 +15,13 @@ struct InsulinTypeConfirmation: View {
     @State private var insulinType: InsulinType?
     private var supportedInsulinTypes: [InsulinType]
     private var didConfirm: (InsulinType) -> Void
+    private var didCancel: () -> Void
     
-    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], didConfirm: @escaping (InsulinType) -> Void) {
+    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], didConfirm: @escaping (InsulinType) -> Void, didCancel: @escaping () -> Void) {
         self._insulinType = State(initialValue: initialValue)
         self.supportedInsulinTypes = supportedInsulinTypes
         self.didConfirm = didConfirm
+        self.didCancel = didCancel
     }
     
     func continueWithType(_ insulinType: InsulinType?) {
@@ -49,13 +51,18 @@ struct InsulinTypeConfirmation: View {
                     .padding()
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {
+                    didCancel()
+                })
+            }
+        }
     }
 }
 
 struct InsulinTypeConfirmation_Previews: PreviewProvider {
     static var previews: some View {
-        InsulinTypeConfirmation(initialValue: .humalog, supportedInsulinTypes: InsulinType.allCases) { (newType) in
-            
-        }
+        InsulinTypeConfirmation(initialValue: .humalog, supportedInsulinTypes: InsulinType.allCases, didConfirm: { (newType) in }, didCancel: {})
     }
 }


### PR DESCRIPTION
This PR adds a "cancel" button to the insulin model selection screen to mirror the cancel functionality on other screens within the pump setup flow (see also https://github.com/LoopKit/OmniBLE/pull/46)

<img width="390" alt="Captura de Pantalla 2022-05-29 a la(s) 10 07 32 a m" src="https://user-images.githubusercontent.com/31571514/170858569-d1db107c-1f59-45bd-8842-10c4a40f43fd.png">
