### PR TITLE
Eros new UI Confidence Reminders fixes and improvements

### DIFF
--- a/OmniKit/PumpManager/BeepPreference.swift
+++ b/OmniKit/PumpManager/BeepPreference.swift
@@ -29,9 +29,9 @@ public enum BeepPreference: Int, CaseIterable {
         case .silent:
             return LocalizedString("No confidence reminders are used.", comment: "Description for BeepPreference.silent")
         case .manualCommands:
-            return LocalizedString("Confidence reminders will sound for commands you initiate, like bolus, cancel bolus, suspend, resume, etc. When Loop automatically adjusts delivery, the pod will remain silent.", comment: "Description for BeepPreference.manualCommands")
+            return LocalizedString("Confidence reminders will sound for commands you initiate, like bolus, cancel bolus, suspend, resume, save notification reminders, etc. When Loop automatically adjusts delivery, no confidence reminders are used.", comment: "Description for BeepPreference.manualCommands")
         case .extended:
-            return LocalizedString("All manual delivery commands will beep, as well as automatic boluses.", comment: "Description for BeepPreference.extended")
+            return LocalizedString("Confidence reminders will sound when Loop automatically adjusts delivery as well as for commands you initiate.", comment: "Description for BeepPreference.extended")
         }
     }
 
@@ -39,7 +39,15 @@ public enum BeepPreference: Int, CaseIterable {
         return self == .extended || self == .manualCommands
     }
 
-    var shouldBeepForAutomaticBolus: Bool {
+    var shouldBeepForAutomaticCommands: Bool {
         return self == .extended
+    }
+
+    func shouldBeepForCommand(automatic: Bool) -> Bool {
+        if automatic {
+            return shouldBeepForAutomaticCommands
+        } else {
+            return shouldBeepForManualCommand
+        }
     }
 }


### PR DESCRIPTION
+ Add missing completion beeps for manual Temporary Basal Rates when Confidence Reminders are enabled
+ Update Extended Confidence Reminders to beep for any automatic delivery changes made by Loop
(i.e., for set & cancel temp basal in addition to automatic boluses) for better consistency and usefulness
+ Remove uses of a .noBeep beep command block when Confidence Reminders are disabled for setting
the low reservior alert, setting the expiration reminder, and acknowledging a pod alert to prevent incorrect
completion beep for an in-progress bolus
+ Add back missing Confirmation Reminder beep in readPulseLog()
+ Fix silenceAcknowledgedAlerts() to never use beep blocks to prevent spurious & incorrect beep behavior
+ Fix commands using a beep block causing an incorrect completion beep for an in-progress automatic bolus
+ Fix enabling Confidence Reminders causing an incorrect completion beep for an in-progress automatic bolus
+ Remove use of basal schedule completion beeps which are meaningless since they never normally complete