### PR TITLE
Unacknowledged command handling updates

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -459,7 +459,7 @@ extension MinimedPumpManager {
         
         if date.timeIntervalSince(lastSync(for: state, recents: recents) ?? .distantPast) > .minutes(12) {
             return PumpStatusHighlight(
-                localizedMessage: NSLocalizedString("No Data", comment: "Status highlight when communications with the pod haven't happened recently."),
+                localizedMessage: NSLocalizedString("Signal Loss", comment: "Status highlight when communications with the pod haven't happened recently."),
                 imageName: "exclamationmark.circle.fill",
                 state: .critical)
         }

--- a/OmniKit/MessageTransport/MessageTransport.swift
+++ b/OmniKit/MessageTransport/MessageTransport.swift
@@ -297,11 +297,11 @@ class PodMessageTransport: MessageTransport {
             
             return response
         } catch let error {
-            if sentFullMessage {
+            //if sentFullMessage {
                 throw PodCommsError.unacknowledgedMessage(sequenceNumber: message.sequenceNum, error: error)
-            } else {
-                throw PodCommsError.commsError(error: error)
-            }
+            //} else {
+            //    throw PodCommsError.commsError(error: error)
+            //}
         }
     }
 

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -269,8 +269,6 @@ public class PodCommsSession {
 
             let message = Message(address: podState.address, messageBlocks: blocksToSend, sequenceNum: messageNumber, expectFollowOnMessage: expectFollowOnMessage)
 
-            self.podState.lastCommsOK = false // mark last comms as not OK until we get the expected response
-
             let response = try transport.sendMessage(message)
 
             // Simulate fault
@@ -279,7 +277,6 @@ public class PodCommsSession {
 
             if let responseMessageBlock = response.messageBlocks[0] as? T {
                 log.info("POD Response: %{public}@", String(describing: responseMessageBlock))
-                self.podState.lastCommsOK = true // message successfully sent and expected response received
                 return responseMessageBlock
             }
 

--- a/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
+++ b/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
@@ -302,7 +302,21 @@ class OmnipodUICoordinator: UINavigationController, PumpManagerOnboarding, Compl
                 pumpManager.addStatusObserver(model, queue: DispatchQueue.main)
                 pumpManager.getPodStatus() { _ in }
 
-                let view = DeliveryUncertaintyRecoveryView(model: model)
+                let handleRileyLinkSelection = { [weak self] (device: RileyLinkDevice) in
+                    if let self = self {
+                        let vc = RileyLinkDeviceTableViewController(
+                            device: device,
+                            batteryAlertLevel: self.pumpManager.rileyLinkBatteryAlertLevel,
+                            batteryAlertLevelChanged: { value in
+                                self.pumpManager.rileyLinkBatteryAlertLevel = value
+                            }
+                        )
+                        self.show(vc, sender: self)
+                    }
+                }
+
+                let dataSource = RileyLinkListDataSource(rileyLinkPumpManager: pumpManager)
+                let view = DeliveryUncertaintyRecoveryView(model: model, rileyLinkListDataSource: dataSource, handleRileyLinkSelection: handleRileyLinkSelection)
 
                 let hostedView = hostingController(rootView: view)
                 hostedView.navigationItem.title = LocalizedString("Unable To Reach Pod", comment: "Title for pending command recovery screen")

--- a/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
+++ b/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
@@ -299,7 +299,6 @@ class OmnipodUICoordinator: UINavigationController, PumpManagerOnboarding, Compl
                         self.completionDelegate?.completionNotifyingDidComplete(self)
                     }
                 }
-                pumpManager.addStatusObserver(model, queue: DispatchQueue.main)
                 pumpManager.getPodStatus() { _ in }
 
                 let handleRileyLinkSelection = { [weak self] (device: RileyLinkDevice) in
@@ -424,6 +423,11 @@ class OmnipodUICoordinator: UINavigationController, PumpManagerOnboarding, Compl
             viewController.isModalInPresentation = false
             setViewControllers([viewController], animated: false)
         }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        completionDelegate?.completionNotifyingDidComplete(self)
     }
 
     var customTraitCollection: UITraitCollection {

--- a/OmniKitUI/ViewModels/DeliveryUncertaintyRecoveryViewModel.swift
+++ b/OmniKitUI/ViewModels/DeliveryUncertaintyRecoveryViewModel.swift
@@ -18,23 +18,18 @@ class DeliveryUncertaintyRecoveryViewModel: PumpManagerStatusObserver {
     var didRecover: (() -> Void)?
     var onDeactivate: (() -> Void)?
     
-    private var finished = false
-    
     init(appName: String, uncertaintyStartedAt: Date) {
         self.appName = appName
         self.uncertaintyStartedAt = uncertaintyStartedAt
     }
 
     func pumpManager(_ pumpManager: PumpManager, didUpdate status: PumpManagerStatus, oldStatus: PumpManagerStatus) {
-        if !finished {
-            if !status.deliveryIsUncertain {
-                didRecover?()
-            }
+        if !status.deliveryIsUncertain {
+            didRecover?()
         }
     }
     
     func podDeactivationChosen() {
-        finished = true
         self.onDeactivate?()
     }
 }

--- a/OmniKitUI/ViewModels/DeliveryUncertaintyRecoveryViewModel.swift
+++ b/OmniKitUI/ViewModels/DeliveryUncertaintyRecoveryViewModel.swift
@@ -13,6 +13,7 @@ class DeliveryUncertaintyRecoveryViewModel: PumpManagerStatusObserver {
     
     let appName: String
     let uncertaintyStartedAt: Date
+    var respondToRecovery: Bool
     
     var onDismiss: (() -> Void)?
     var didRecover: (() -> Void)?
@@ -21,10 +22,11 @@ class DeliveryUncertaintyRecoveryViewModel: PumpManagerStatusObserver {
     init(appName: String, uncertaintyStartedAt: Date) {
         self.appName = appName
         self.uncertaintyStartedAt = uncertaintyStartedAt
+        respondToRecovery = false
     }
 
     func pumpManager(_ pumpManager: PumpManager, didUpdate status: PumpManagerStatus, oldStatus: PumpManagerStatus) {
-        if !status.deliveryIsUncertain {
+        if !status.deliveryIsUncertain && respondToRecovery {
             didRecover?()
         }
     }

--- a/OmniKitUI/ViewModels/OmnipodSettingsViewModel.swift
+++ b/OmniKitUI/ViewModels/OmnipodSettingsViewModel.swift
@@ -382,7 +382,7 @@ class OmnipodSettingsViewModel: ObservableObject {
             }
         case .active:
             if isPodDataStale {
-                return LocalizedString("No Data", comment: "Error message for reservoir view during general pod fault")
+                return LocalizedString("Signal Loss", comment: "Error message for reservoir view during general pod fault")
             } else {
                 return nil
             }

--- a/OmniKitUI/Views/DeliveryUncertaintyRecoveryView.swift
+++ b/OmniKitUI/Views/DeliveryUncertaintyRecoveryView.swift
@@ -42,7 +42,6 @@ struct DeliveryUncertaintyRecoveryView: View {
                                     Image(systemName: "wifi.exclamationmark")
                                         .imageScale(.large)
                                         .foregroundColor(guidanceColors.warning)
-                                        .padding(.top,5)
                                 }
                             }
                         }
@@ -53,8 +52,14 @@ struct DeliveryUncertaintyRecoveryView: View {
                     }
                 }
             }
-            .onAppear { rileyLinkListDataSource.isScanningEnabled = true }
-            .onDisappear { rileyLinkListDataSource.isScanningEnabled = false }
+            .onAppear {
+                rileyLinkListDataSource.isScanningEnabled = true
+                model.respondToRecovery = true
+            }
+            .onDisappear {
+                rileyLinkListDataSource.isScanningEnabled = false
+                model.respondToRecovery = false
+            }
         }) {
             VStack {
                 Text(LocalizedString("Attemping to re-establish communication", comment: "Description string above progress indicator while attempting to re-establish communication from an unacknowledged command")).padding(.top)

--- a/OmniKitUI/Views/DeliveryUncertaintyRecoveryView.swift
+++ b/OmniKitUI/Views/DeliveryUncertaintyRecoveryView.swift
@@ -8,19 +8,53 @@
 
 import SwiftUI
 import LoopKitUI
+import RileyLinkBLEKit
 
 struct DeliveryUncertaintyRecoveryView: View {
     
     let model: DeliveryUncertaintyRecoveryViewModel
 
-    init(model: DeliveryUncertaintyRecoveryViewModel) {
-        self.model = model
-    }
+    @ObservedObject var rileyLinkListDataSource: RileyLinkListDataSource
+
+    var handleRileyLinkSelection: (RileyLinkDevice) -> Void
+
+    @Environment(\.guidanceColors) var guidanceColors
 
     var body: some View {
         GuidePage(content: {
             Text(String(format: LocalizedString("%1$@ has been unable to communicate with the pod on your body since %2$@.\n\nWithout communication with the pod, the app cannot continue to send commands for insulin delivery or display accurate, recent information about your active insulin or the insulin being delivered by the Pod.\n\nMonitor your glucose closely for the next 6 or more hours, as there may or may not be insulin actively working in your body that %3$@ cannot display.", comment: "Format string for main text of delivery uncertainty recovery page. (1: app name)(2: date of command)(3: app name)"), self.model.appName, self.uncertaintyDateLocalizedString, self.model.appName))
                 .padding([.top, .bottom])
+            Section(header: HStack {
+                FrameworkLocalText("Devices", comment: "Header for devices section of RileyLinkSetupView")
+                Spacer()
+                ProgressView()
+            }) {
+                ForEach(rileyLinkListDataSource.devices) { device in
+                    Toggle(isOn: rileyLinkListDataSource.autoconnectBinding(for: device)) {
+                        HStack {
+                            Text(device.name ?? "Unknown")
+                            Spacer()
+
+                            if rileyLinkListDataSource.autoconnectBinding(for: device).wrappedValue {
+                                if device.isConnected {
+                                    Text(formatRSSI(rssi:device.rssi)).foregroundColor(.secondary)
+                                } else {
+                                    Image(systemName: "wifi.exclamationmark")
+                                        .imageScale(.large)
+                                        .foregroundColor(guidanceColors.warning)
+                                        .padding(.top,5)
+                                }
+                            }
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            handleRileyLinkSelection(device)
+                        }
+                    }
+                }
+            }
+            .onAppear { rileyLinkListDataSource.isScanningEnabled = true }
+            .onDisappear { rileyLinkListDataSource.isScanningEnabled = false }
         }) {
             VStack {
                 Text(LocalizedString("Attemping to re-establish communication", comment: "Description string above progress indicator while attempting to re-establish communication from an unacknowledged command")).padding(.top)
@@ -41,17 +75,28 @@ struct DeliveryUncertaintyRecoveryView: View {
     private var uncertaintyDateLocalizedString: String {
         DateFormatter.localizedString(from: model.uncertaintyStartedAt, dateStyle: .none, timeStyle: .short)
     }
+
+    var decimalFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+
+        return formatter
+    }()
+
+    private func formatRSSI(rssi: Int?) -> String {
+        if let rssi = rssi, let rssiStr = decimalFormatter.decibleString(from: rssi) {
+            return rssiStr
+        } else {
+            return ""
+        }
+    }
     
     private var backButton: some View {
         Button(LocalizedString("Back", comment: "Back button text on DeliveryUncertaintyRecoveryView"), action: {
             self.model.onDismiss?()
         })
-    }
-}
-
-struct DeliveryUncertaintyRecoveryView_Previews: PreviewProvider {
-    static var previews: some View {
-        let model = DeliveryUncertaintyRecoveryViewModel(appName: "Test App", uncertaintyStartedAt: Date())
-        return DeliveryUncertaintyRecoveryView(model: model)
     }
 }

--- a/OmniKitUI/Views/OmnipodSettingsView.swift
+++ b/OmniKitUI/Views/OmnipodSettingsView.swift
@@ -368,7 +368,6 @@ struct OmnipodSettingsView: View  {
                                     Image(systemName: "wifi.exclamationmark")
                                         .imageScale(.large)
                                         .foregroundColor(guidanceColors.warning)
-                                        .padding(.top,5)
                                 }
                             }
                         }

--- a/OmniKitUI/Views/UncertaintyRecoveredView.swift
+++ b/OmniKitUI/Views/UncertaintyRecoveredView.swift
@@ -17,6 +17,7 @@ struct UncertaintyRecoveredView: View {
     var body: some View {
         GuidePage(content: {
             Text("\(self.appName) has recovered communication with the pod on your body.\n\nInsulin delivery records have been updated and should match what has actually been delivered.\n\nYou may continue to use \(self.appName) normally now.")
+                .fixedSize(horizontal: false, vertical: true)
                 .padding([.top, .bottom])
         }) {
             VStack {


### PR DESCRIPTION
* Allow user to connect to other RileyLinks during unacknowledged command recovery (for https://github.com/LoopKit/Loop/issues/1722)
* "No Data" -> "Signal Loss"
* Bolusing while suspended no longer auto-resumes, and will show a failure.
* Remove older uncertainty handling
