### PR TITLE
Fix For Nightscout-as-CGM inop for LibreLinkUp users

### DIFF
--- a/NightscoutUploadKit/Models/GlucoseEntry.swift
+++ b/NightscoutUploadKit/Models/GlucoseEntry.swift
@@ -114,15 +114,14 @@ public struct GlucoseEntry {
 
         guard
             let id = rawValue["_id"] as? String,
-            let epoch = rawValue["date"] as? Double,
-            let device = rawValue["device"] as? String
+            let epoch = rawValue["date"] as? Double
         else {
             return nil
         }
 
         self.id = id
         self.date = Date(timeIntervalSince1970: epoch / 1000.0)
-        self.device = device
+        self.device = rawValue["device"] as? String
 
         //Dexcom changed the format of trend in 2021 so we accept both String/Int types
         if let intTrend = rawValue["trend"] as? Int {


### PR DESCRIPTION
This is a potential fix for the following issue https://github.com/LoopKit/Loop/issues/1733

It appears that the "device" attribute is empty for those using Libre 3. This causes Loop to not accept the Glucose entries from Nightscout. This PR allows the glucose entries to be created, even when the device is nil. I was not familiar with this Libre setup but here is a description from the user:

```
I am using the freestyle libre 3 system with a script that uploads the data from LibreLinkUp to NS.
```