### PR TITLE
Various response handling fixes

### DIFF
--- a/OmniKit/MessageTransport/MessageBlocks/StatusResponse.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/StatusResponse.swift
@@ -77,6 +77,19 @@ public struct StatusResponse : MessageBlock {
         self.alerts = alerts
         self.data = Data()
     }
+
+    // convenience function to create a StatusResponse for a DetailedStatus
+    public init(detailedStatus: DetailedStatus) {
+        self.deliveryStatus = detailedStatus.deliveryStatus
+        self.podProgressStatus = detailedStatus.podProgressStatus
+        self.timeActive = detailedStatus.timeActive
+        self.reservoirLevel = detailedStatus.reservoirLevel
+        self.insulinDelivered = detailedStatus.totalInsulinDelivered
+        self.bolusNotDelivered = detailedStatus.bolusNotDelivered
+        self.lastProgrammingMessageSeqNum = detailedStatus.lastProgrammingMessageSeqNum
+        self.alerts = detailedStatus.unacknowledgedAlerts
+        self.data = Data()
+    }
 }
 
 extension StatusResponse: CustomDebugStringConvertible {

--- a/OmniKit/PumpManager/PodInsulinMeasurements.swift
+++ b/OmniKit/PumpManager/PodInsulinMeasurements.swift
@@ -15,15 +15,10 @@ public struct PodInsulinMeasurements: RawRepresentable, Equatable {
     public let delivered: Double
     public let reservoirLevel: Double?
     
-    public init(insulinDelivered: Double, reservoirLevel: Double?, setupUnitsDelivered: Double?, validTime: Date) {
+    public init(insulinDelivered: Double, reservoirLevel: Double?, validTime: Date) {
         self.validTime = validTime
+        self.delivered = insulinDelivered
         self.reservoirLevel = reservoirLevel
-        if let setupUnitsDelivered = setupUnitsDelivered {
-            self.delivered = max(insulinDelivered - setupUnitsDelivered, 0)
-        } else {
-            // subtract off the fixed setup command values as we don't have an actual value (yet)
-            self.delivered = max(insulinDelivered - Pod.primeUnits - Pod.cannulaInsertionUnits, 0)
-        }
     }
     
     // RawRepresentable

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -192,15 +192,19 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     public mutating func updateFromStatusResponse(_ response: StatusResponse) {
         let now = updatePodTimes(timeActive: response.timeActive)
         updateDeliveryStatus(deliveryStatus: response.deliveryStatus, podProgressStatus: response.podProgressStatus, bolusNotDelivered: response.bolusNotDelivered)
-        lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.insulinDelivered, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)
-        activeAlertSlots = response.alerts
-    }
 
-    public mutating func updateFromDetailedStatusResponse(_ response: DetailedStatus) {
-        let now = updatePodTimes(timeActive: response.timeActive)
-        updateDeliveryStatus(deliveryStatus: response.deliveryStatus, podProgressStatus: response.podProgressStatus, bolusNotDelivered: response.bolusNotDelivered)
-        lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.totalInsulinDelivered, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)
-        activeAlertSlots = response.unacknowledgedAlerts
+        let setupUnits = setupUnitsDelivered != nil ? setupUnitsDelivered! : Pod.primeUnits + Pod.cannulaInsertionUnits
+
+        // Calculated new delivered value which will be a negative value until setup has completed OR after a pod reset fault
+        let calcDelivered = response.insulinDelivered - setupUnits
+
+        // insulinDelivered should never be a negative value or decrease from the previous saved delivered value
+        let prevDelivered = lastInsulinMeasurements != nil ? lastInsulinMeasurements!.delivered : 0
+        let insulinDelivered = max(calcDelivered, prevDelivered)
+
+        lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: insulinDelivered, reservoirLevel: response.reservoirLevel, validTime: now)
+
+        activeAlertSlots = response.alerts
     }
 
     public mutating func registerConfiguredAlert(slot: AlertSlot, alert: PodAlert) {


### PR DESCRIPTION
+ Fix logic error which missed status update on command recovery
+ Handle unacknowledged commands for pod faults and detailed status
+ Unify detailed status responses handling with status responses
+ Refactor & fix insulin delivered handling to never go backwards
+ Add StatusResponse initializer for DetailedStatus
+ Obsolete need for separate updateFromDetailedStatusResponse func