### PR TITLE
Changes to better match OmniBLE and updated VersionResponse

### DIFF
--- a/OmniKit/OmnipodCommon/MessageBlocks/ErrorResponse.swift
+++ b/OmniKit/OmnipodCommon/MessageBlocks/ErrorResponse.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-fileprivate let errorResponseCode_badNonce: UInt8 = 0x14
+fileprivate let errorResponseCode_badNonce: UInt8 = 0x14 // only returned on Eros
 
 public enum ErrorResponseType {
-    case badNonce(nonceResyncKey: UInt16)
+    case badNonce(nonceResyncKey: UInt16) // only returned on Eros
     case nonretryableError(code: UInt8, faultEventCode: FaultEventCode, podProgress: PodProgressStatus)
 }
 
@@ -27,7 +27,7 @@ public struct ErrorResponse : MessageBlock {
         let errorCode = encodedData[2]
         switch (errorCode) {
         case errorResponseCode_badNonce:
-            // For this error code only the 2 next bytes are the encoded nonce resync key.
+            // For this error code only the 2 next bytes are the encoded nonce resync key (only returned on Eros)
             let nonceResyncKey: UInt16 = encodedData[3...].toBigEndian(UInt16.self)
             errorResponseType = .badNonce(nonceResyncKey: nonceResyncKey)
             break

--- a/OmniKit/OmnipodCommon/MessageBlocks/VersionResponse.swift
+++ b/OmniKit/OmnipodCommon/MessageBlocks/VersionResponse.swift
@@ -31,9 +31,9 @@ public struct VersionResponse : MessageBlock {
     
     public let blockType: MessageBlockType = .versionResponse
 
-    public let pmVersion: FirmwareVersion           // for Eros (PM) 2.x.y, for NXP Dash 3.x.y, for TWI Dash 4.x.y
-    public let piVersion: FirmwareVersion           // for Eros (PI) same as PM, for Dash BLE firmware version #
-    public let productId: UInt8                     // 02 for Eros, 04 for Dash, and perhaps 05 for Omnipod 5
+    public let firmwareVersion: FirmwareVersion     // for Eros (PM) 2.x.y, for NXP Dash 3.x.y, for TWI Dash 4.x.y
+    public let iFirmwareVersion: FirmwareVersion    // for Eros (PI) same as PM, for Dash BLE firmware version #
+    public let productId: UInt8                     // 02 for Eros, 04 for Dash, perhaps 05 for Omnipod 5
     public let lot: UInt32
     public let tid: UInt32
     public let address: UInt32
@@ -74,8 +74,8 @@ public struct VersionResponse : MessageBlock {
             // GS = ggssssss (Gain/RSSI for Eros only)
             // IIIIIIII = connection ID address
 
-            pmVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 2..<5))
-            piVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 5..<8))
+            firmwareVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 2..<5))
+            iFirmwareVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 5..<8))
             productId = encodedData[8]
             guard let progressStatus = PodProgressStatus(rawValue: encodedData[9]) else {
                 throw MessageBlockError.parseError
@@ -116,8 +116,8 @@ public struct VersionResponse : MessageBlock {
             // TTTTTTTT = Tid
             // IIIIIIII = connection ID address
 
-            pmVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 9..<12))
-            piVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 12..<15))
+            firmwareVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 9..<12))
+            iFirmwareVersion = FirmwareVersion(encodedData: encodedData.subdata(in: 12..<15))
             productId = encodedData[15]
             guard let progressStatus = PodProgressStatus(rawValue: encodedData[16]) else {
                 throw MessageBlockError.parseError
@@ -155,7 +155,7 @@ public struct VersionResponse : MessageBlock {
 
 extension VersionResponse: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "VersionResponse(lot:\(lot), tid:\(tid), address:\(Data(bigEndian: address).hexadecimalString), pmVersion:\(pmVersion), piVersion:\(piVersion), productId:\(productId), podProgressStatus:\(podProgressStatus), gain:\(gain?.description ?? "NA"), rssi:\(rssi?.description ?? "NA"), pulseSize:\(pulseSize?.description ?? "NA"), secondsPerBolusPulse:\(secondsPerBolusPulse?.description ?? "NA"), secondsPerPrimePulse:\(secondsPerPrimePulse?.description ?? "NA"), primeUnits:\(primeUnits?.description ?? "NA"), cannulaInsertionUnits:\(cannulaInsertionUnits?.description ?? "NA"), serviceDuration:\(serviceDuration?.description ?? "NA"), )"
+        return "VersionResponse(lot:\(lot), tid:\(tid), address:\(Data(bigEndian: address).hexadecimalString), firmwareVersion:\(firmwareVersion), iFirmwareVersion:\(iFirmwareVersion), productId:\(productId), podProgressStatus:\(podProgressStatus), gain:\(gain?.description ?? "NA"), rssi:\(rssi?.description ?? "NA"), pulseSize:\(pulseSize?.description ?? "NA"), secondsPerBolusPulse:\(secondsPerBolusPulse?.description ?? "NA"), secondsPerPrimePulse:\(secondsPerPrimePulse?.description ?? "NA"), primeUnits:\(primeUnits?.description ?? "NA"), cannulaInsertionUnits:\(cannulaInsertionUnits?.description ?? "NA"), serviceDuration:\(serviceDuration?.description ?? "NA"), )"
     }
 }
 

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -169,7 +169,10 @@ public class OmnipodPumpManager: RileyLinkPumpManager {
             }
 
             if oldValue.podState?.lastInsulinMeasurements?.reservoirLevel != newValue.podState?.lastInsulinMeasurements?.reservoirLevel {
-                if let lastInsulinMeasurements = newValue.podState?.lastInsulinMeasurements, let reservoirLevel = lastInsulinMeasurements.reservoirLevel {
+                if let lastInsulinMeasurements = newValue.podState?.lastInsulinMeasurements,
+                   let reservoirLevel = lastInsulinMeasurements.reservoirLevel,
+                   reservoirLevel != Pod.reservoirLevelAboveThresholdMagicNumber
+                {
                     self.pumpDelegate.notify({ (delegate) in
                         self.log.info("DU: updating reservoir level %{public}@", String(describing: reservoirLevel))
                         delegate?.pumpManager(self, didReadReservoirValue: reservoirLevel, at: lastInsulinMeasurements.validTime) { _ in }
@@ -690,7 +693,7 @@ extension OmnipodPumpManager {
     #if targetEnvironment(simulator)
     private func jumpStartPod(address: UInt32, lot: UInt32, tid: UInt32, fault: DetailedStatus? = nil, startDate: Date? = nil, mockFault: Bool) {
         let start = startDate ?? Date()
-        var podState = PodState(address: address, piVersion: "jumpstarted", pmVersion: "jumpstarted", lot: lot, tid: tid, insulinType: .novolog)
+        var podState = PodState(address: address, pmVersion: "jumpstarted", piVersion: "jumpstarted", lot: lot, tid: tid, insulinType: .novolog)
         podState.setupProgress = .podPaired
         podState.activatedAt = start
         podState.expiresAt = start + .hours(72)

--- a/OmniKit/PumpManager/PodComms.swift
+++ b/OmniKit/PumpManager/PodComms.swift
@@ -189,8 +189,8 @@ class PodComms: CustomDebugStringConvertible {
                 log.default("Creating PodState for address %{public}@ [lot %u tid %u], packet #%d, message #%d", String(format: "%04X", config.address), config.lot, config.tid, transport.packetNumber, transport.messageNumber)
                 self.podState = PodState(
                     address: config.address,
-                    piVersion: String(describing: config.piVersion),
-                    pmVersion: String(describing: config.pmVersion),
+                    pmVersion: String(describing: config.firmwareVersion),
+                    piVersion: String(describing: config.iFirmwareVersion),
                     lot: config.lot,
                     tid: config.tid,
                     packetNumber: transport.packetNumber,

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -60,8 +60,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
 
     public var setupUnitsDelivered: Double?
 
-    public let piVersion: String
     public let pmVersion: String
+    public let piVersion: String
     public let lot: UInt32
     public let tid: UInt32
     var activeAlertSlots: AlertSet
@@ -114,11 +114,11 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         return false
     }
 
-    public init(address: UInt32, piVersion: String, pmVersion: String, lot: UInt32, tid: UInt32, packetNumber: Int = 0, messageNumber: Int = 0, insulinType: InsulinType) {
+    public init(address: UInt32, pmVersion: String, piVersion: String, lot: UInt32, tid: UInt32, packetNumber: Int = 0, messageNumber: Int = 0, insulinType: InsulinType) {
         self.address = address
         self.nonceState = NonceState(lot: lot, tid: tid)
-        self.piVersion = piVersion
         self.pmVersion = pmVersion
+        self.piVersion = piVersion
         self.lot = lot
         self.tid = tid
         self.lastInsulinMeasurements = nil

--- a/OmniKitTests/MessageTests.swift
+++ b/OmniKitTests/MessageTests.swift
@@ -78,8 +78,8 @@ class MessageTests: XCTestCase {
         do {
             let config = try VersionResponse(encodedData: Data(hexadecimalString: "011502070002070002020000a64000097c279c1f08ced2")!)
             XCTAssertEqual(23, config.data.count)
-            XCTAssertEqual("2.7.0", String(describing: config.piVersion))
-            XCTAssertEqual("2.7.0", String(describing: config.pmVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.firmwareVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.iFirmwareVersion))
             XCTAssertEqual(42560, config.lot)
             XCTAssertEqual(621607, config.tid)
             XCTAssertEqual(0x1f08ced2, config.address)
@@ -103,8 +103,8 @@ class MessageTests: XCTestCase {
             let message = try Message(encodedData: Data(hexadecimalString: "ffffffff041d011b13881008340a5002070002070002030000a62b000447941f00ee878352")!)
             let config = message.messageBlocks[0] as! VersionResponse
             XCTAssertEqual(29, config.data.count)
-            XCTAssertEqual("2.7.0", String(describing: config.piVersion))
-            XCTAssertEqual("2.7.0", String(describing: config.pmVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.firmwareVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.iFirmwareVersion))
             XCTAssertEqual(42539, config.lot)
             XCTAssertEqual(280468, config.tid)
             XCTAssertEqual(0x1f00ee87, config.address)
@@ -127,8 +127,8 @@ class MessageTests: XCTestCase {
         do {
             let config = try VersionResponse(encodedData: Data(hexadecimalString: "0115031b0008080004020812a011000c175700ffffffff")!)
             XCTAssertEqual(23, config.data.count)
-            XCTAssertEqual("3.27.0", String(describing: config.pmVersion))
-            XCTAssertEqual("8.8.0", String(describing: config.piVersion))
+            XCTAssertEqual("3.27.0", String(describing: config.firmwareVersion))
+            XCTAssertEqual("8.8.0", String(describing: config.iFirmwareVersion))
             XCTAssertEqual(135438353, config.lot)
             XCTAssertEqual(792407, config.tid)
             XCTAssertEqual(0xFFFFFFFF, config.address)
@@ -152,8 +152,8 @@ class MessageTests: XCTestCase {
             let message = try Message(encodedData: Data(hexadecimalString: "ffffffff0c1d011b13881008340a50031b0008080004030812a011000c175717244389816c")!)
             let config = message.messageBlocks[0] as! VersionResponse
             XCTAssertEqual(29, config.data.count)
-            XCTAssertEqual("3.27.0", String(describing: config.pmVersion))
-            XCTAssertEqual("8.8.0", String(describing: config.piVersion))
+            XCTAssertEqual("3.27.0", String(describing: config.firmwareVersion))
+            XCTAssertEqual("8.8.0", String(describing: config.iFirmwareVersion))
             XCTAssertEqual(135438353, config.lot)
             XCTAssertEqual(792407, config.tid)
             XCTAssertEqual(0x17244389, config.address)
@@ -176,8 +176,8 @@ class MessageTests: XCTestCase {
         do {
             let message = try Message(encodedData: Data(hexadecimalString: "ffffffff04170115020700020700020e0000a5ad00053030971f08686301fd")!)
             let config = message.messageBlocks[0] as! VersionResponse
-            XCTAssertEqual("2.7.0", String(describing: config.piVersion))
-            XCTAssertEqual("2.7.0", String(describing: config.pmVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.firmwareVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.iFirmwareVersion))
             XCTAssertEqual(0x0000a5ad, config.lot)
             XCTAssertEqual(0x00053030, config.tid)
             XCTAssertEqual(0x1f086863, config.address)

--- a/OmniKitTests/PodCommsSessionTests.swift
+++ b/OmniKitTests/PodCommsSessionTests.swift
@@ -20,7 +20,7 @@ class PodCommsSessionTests: XCTestCase {
 
 
     override func setUp() {
-        podState = PodState(address: address, piVersion: "2.7.0", pmVersion: "2.7.0", lot: 43620, tid: 560313, insulinType: .novolog)
+        podState = PodState(address: address, pmVersion: "2.7.0", piVersion: "2.7.0", lot: 43620, tid: 560313, insulinType: .novolog)
         mockTransport = MockMessageTransport(address: podState.address, messageNumber: 5)
     }
 

--- a/OmniKitTests/PodStateTests.swift
+++ b/OmniKitTests/PodStateTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class PodStateTests: XCTestCase {
 
     func testNonceValues() {
-        var podState = PodState(address: 0x1f000000, piVersion: "1.1.0", pmVersion: "1.1.0", lot: 42560, tid: 661771, insulinType: .novolog)
+        var podState = PodState(address: 0x1f000000, pmVersion: "1.1.0", piVersion: "1.1.0", lot: 42560, tid: 661771, insulinType: .novolog)
         
         XCTAssertEqual(podState.currentNonce, 0x8c61ee59)
         podState.advanceToNextNonce()
@@ -26,12 +26,12 @@ class PodStateTests: XCTestCase {
     func testResyncNonce() {
         do {
             let config = try VersionResponse(encodedData: Data(hexadecimalString: "011502070002070002020000a62b0002249da11f00ee860318")!)
-            var podState = PodState(address: 0x1f00ee86, piVersion: "1.1.0", pmVersion: "1.1.0", lot: config.lot, tid: config.tid, insulinType: .novolog)
+            var podState = PodState(address: config.address, pmVersion: config.firmwareVersion.description, piVersion: config.iFirmwareVersion.description, lot: config.lot, tid: config.tid, insulinType: .novolog)
 
             XCTAssertEqual(42539, config.lot)
-            XCTAssertEqual(140445,  config.tid)
+            XCTAssertEqual(140445, config.tid)
             
-            XCTAssertEqual(0x8fd39264,  podState.currentNonce)
+            XCTAssertEqual(0x8fd39264, podState.currentNonce)
 
             // ID1:1f00ee86 PTYPE:PDM SEQ:26 ID2:1f00ee86 B9:24 BLEN:6 BODY:1c042e07c7c703c1 CRC:f4
             let sentPacket = try Packet(encodedData: Data(hexadecimalString: "1f00ee86ba1f00ee8624061c042e07c7c703c1f4")!)


### PR DESCRIPTION
+ Update ErrorResponse comments to match OmniBLE
+ Rename VersionResponse pmVersion to firmwareVersion to match OmniBLE
+ Rename VersionResponse prVersion to iFirmwareVersion to match OmniBLE
+ Add missing check for out of range reservoir updates to match OmniBLE
+ Update PodState firmware ordering to match VersionResponse layout
+ Improved and cleaned up PodStateTests using more VersionResponse fields