### PR TITLE
Use only allowed insulin types from pump settings.

### DIFF
--- a/MinimedKitUI/MinimedPumpManager+UI.swift
+++ b/MinimedKitUI/MinimedPumpManager+UI.swift
@@ -21,6 +21,7 @@ extension MinimedPumpManager: PumpManagerUI {
 
     static public func setupViewController(initialSettings settings: PumpManagerSetupSettings, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool, allowedInsulinTypes: [InsulinType]) -> SetupUIResult<PumpManagerViewController, PumpManagerUI> {
         let navVC = MinimedPumpManagerSetupViewController.instantiateFromStoryboard()
+        navVC.supportedInsulinTypes = allowedInsulinTypes
         let didConfirm: (InsulinType) -> Void = { [weak navVC] (confirmedType) in
             if let navVC = navVC {
                 navVC.insulinType = confirmedType
@@ -45,14 +46,14 @@ extension MinimedPumpManager: PumpManagerUI {
     }
 
     public func settingsViewController(bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool, allowedInsulinTypes: [InsulinType]) -> PumpManagerViewController {
-        let settings = MinimedPumpSettingsViewController(pumpManager: self)
+        let settings = MinimedPumpSettingsViewController(pumpManager: self, supportedInsulinTypes: allowedInsulinTypes)
         let nav = PumpManagerSettingsNavigationViewController(rootViewController: settings)
         return nav
     }
     
     public func deliveryUncertaintyRecoveryViewController(colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool) -> (UIViewController & CompletionNotifying) {
         // Return settings for now. No uncertainty handling atm.
-        let settings = MinimedPumpSettingsViewController(pumpManager: self)
+        let settings = MinimedPumpSettingsViewController(pumpManager: self, supportedInsulinTypes: [])
         let nav = SettingsNavigationViewController(rootViewController: settings)
         return nav
     }

--- a/MinimedKitUI/MinimedPumpSettingsViewController.swift
+++ b/MinimedKitUI/MinimedPumpSettingsViewController.swift
@@ -15,6 +15,8 @@ import LoopKit
 class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
 
     let pumpManager: MinimedPumpManager
+
+    let supportedInsulinTypes: [InsulinType]
     
     private var ops: PumpOps {
         return pumpManager.pumpOps
@@ -63,8 +65,9 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
     }
 
     
-    init(pumpManager: MinimedPumpManager) {
+    init(pumpManager: MinimedPumpManager, supportedInsulinTypes: [InsulinType]) {
         self.pumpManager = pumpManager
+        self.supportedInsulinTypes = supportedInsulinTypes
         super.init(rileyLinkPumpManager: pumpManager, devicesSectionIndex: Section.rileyLinks.rawValue, style: .grouped)
     }
 
@@ -373,7 +376,7 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
 
                 show(vc, sender: sender)
             case .insulinType:
-                let view = InsulinTypeSetting(initialValue: pumpManager.insulinType ?? .novolog, supportedInsulinTypes: InsulinType.allCases, allowUnsetInsulinType: false) { (newType) in
+                let view = InsulinTypeSetting(initialValue: pumpManager.insulinType ?? .novolog, supportedInsulinTypes: supportedInsulinTypes, allowUnsetInsulinType: false) { (newType) in
                     self.pumpManager.insulinType = newType
                 }
                 let vc = DismissibleHostingController(rootView: view)
@@ -397,8 +400,8 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
             let vc = RileyLinkDeviceTableViewController(
                 device: device,
                 batteryAlertLevel: pumpManager.rileyLinkBatteryAlertLevel,
-                batteryAlertLevelChanged: { value in
-                    self.pumpManager.rileyLinkBatteryAlertLevel = value
+                batteryAlertLevelChanged: { [weak self] value in
+                    self?.pumpManager.rileyLinkBatteryAlertLevel = value
                 }
             )
 

--- a/MinimedKitUI/Setup/MinimedPumpManagerSetupViewController.swift
+++ b/MinimedKitUI/Setup/MinimedPumpManagerSetupViewController.swift
@@ -40,6 +40,8 @@ public class MinimedPumpManagerSetupViewController: RileyLinkManagerSetupViewCon
     
     internal var insulinType: InsulinType?
 
+    internal var supportedInsulinTypes: [InsulinType]?
+
     /*
      1. RileyLink
      - RileyLinkPumpManagerState
@@ -119,7 +121,7 @@ public class MinimedPumpManagerSetupViewController: RileyLinkManagerSetupViewCon
 
             pumpManagerOnboardingDelegate?.pumpManagerOnboarding(didOnboardPumpManager: pumpManager)
 
-            let settingsViewController = MinimedPumpSettingsViewController(pumpManager: pumpManager)
+            let settingsViewController = MinimedPumpSettingsViewController(pumpManager: pumpManager, supportedInsulinTypes: supportedInsulinTypes!)
             setViewControllers([settingsViewController], animated: true)
         }
     }

--- a/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
+++ b/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
@@ -189,15 +189,15 @@ class OmnipodUICoordinator: UINavigationController, PumpManagerOnboarding, Compl
                     let vc = RileyLinkDeviceTableViewController(
                         device: device,
                         batteryAlertLevel: self.pumpManager.rileyLinkBatteryAlertLevel,
-                        batteryAlertLevelChanged: { value in
-                            self.pumpManager.rileyLinkBatteryAlertLevel = value
+                        batteryAlertLevelChanged: { [weak self] value in
+                            self?.pumpManager.rileyLinkBatteryAlertLevel = value
                         }
                     )
                     self.show(vc, sender: self)
                 }
             }
 
-            let view = OmnipodSettingsView(viewModel: viewModel, rileyLinkListDataSource: rileyLinkListDataSource, handleRileyLinkSelection: handleRileyLinkSelection)
+            let view = OmnipodSettingsView(viewModel: viewModel, rileyLinkListDataSource: rileyLinkListDataSource, handleRileyLinkSelection: handleRileyLinkSelection, supportedInsulinTypes: allowedInsulinTypes)
             return hostingController(rootView: view)
         case .pairPod:
             pumpManagerOnboardingDelegate?.pumpManagerOnboarding(didCreatePumpManager: pumpManager)
@@ -314,8 +314,8 @@ class OmnipodUICoordinator: UINavigationController, PumpManagerOnboarding, Compl
                         let vc = RileyLinkDeviceTableViewController(
                             device: device,
                             batteryAlertLevel: self.pumpManager.rileyLinkBatteryAlertLevel,
-                            batteryAlertLevelChanged: { value in
-                                self.pumpManager.rileyLinkBatteryAlertLevel = value
+                            batteryAlertLevelChanged: { [weak self] value in
+                                self?.pumpManager.rileyLinkBatteryAlertLevel = value
                             }
                         )
                         self.show(vc, sender: self)

--- a/OmniKitUI/Views/ExpirationReminderSetupView.swift
+++ b/OmniKitUI/Views/ExpirationReminderSetupView.swift
@@ -39,6 +39,7 @@ struct ExpirationReminderSetupView: View {
             .padding()
         }
         .navigationBarTitle("Expiration Reminder", displayMode: .automatic)
+        .navigationBarHidden(false)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {

--- a/OmniKitUI/Views/OmnipodSettingsView.swift
+++ b/OmniKitUI/Views/OmnipodSettingsView.swift
@@ -33,6 +33,8 @@ struct OmnipodSettingsView: View  {
 
     @State private var cancelingTempBasal = false
 
+    var supportedInsulinTypes: [InsulinType]
+
 
     @Environment(\.guidanceColors) var guidanceColors
     @Environment(\.insulinTintColor) var insulinTintColor
@@ -445,7 +447,7 @@ struct OmnipodSettingsView: View  {
                             .foregroundColor(.secondary)
                     }
                 }
-                NavigationLink(destination: InsulinTypeSetting(initialValue: viewModel.insulinType, supportedInsulinTypes: InsulinType.allCases, allowUnsetInsulinType: false, didChange: viewModel.didChangeInsulinType)) {
+                NavigationLink(destination: InsulinTypeSetting(initialValue: viewModel.insulinType, supportedInsulinTypes: supportedInsulinTypes, allowUnsetInsulinType: false, didChange: viewModel.didChangeInsulinType)) {
                     HStack {
                         FrameworkLocalText("Insulin Type", comment: "Text for confidence reminders navigation link").foregroundColor(Color.primary)
                         if let currentTitle = viewModel.insulinType?.brandName {

--- a/OmniKitUI/Views/RileyLinkSetupView.swift
+++ b/OmniKitUI/Views/RileyLinkSetupView.swift
@@ -67,6 +67,7 @@ struct RileyLinkSetupView: View {
                 })
             }
         }
+        .navigationBarHidden(false)
         .onAppear { dataSource.isScanningEnabled = true }
         .onDisappear { dataSource.isScanningEnabled = false }
     }

--- a/RileyLink.xcodeproj/xcshareddata/xcschemes/OmniKitPacketParser.xcscheme
+++ b/RileyLink.xcodeproj/xcshareddata/xcschemes/OmniKitPacketParser.xcscheme
@@ -61,7 +61,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "/Users/pete/Downloads/Loop-Report-2022-06-30-203038-0400.md"
+            argument = "/Users/pete/Downloads/Loop-Report-2022-08-21-185153-0400.md"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
Allowed insulin types were being respected in pump setup, but not when modifying insulin type from pump settings, for Eros and MDT pumps. Fixes https://github.com/LoopKit/Loop/issues/1782

Also includes:
* Navigation bar fixes for iOS 16
* Fixing retain cycle in RileyLink selection. This was preventing cleanup of the old PumpManager, which held onto the RL device, preventing use when trying to set up a new RL based pump.