### PR TITLE
MDT Pump Settings command improvements

### DIFF
--- a/MinimedKitUI/CommandResponseViewController.swift
+++ b/MinimedKitUI/CommandResponseViewController.swift
@@ -224,7 +224,7 @@ extension CommandResponseViewController {
                     let status = try session.getCurrentPumpStatus()
 
                     var str = String(format: LocalizedString("%1$@ Units of insulin remaining\n", comment: "The format string describing units of insulin remaining: (1: number of units)"), measurementFormatter.numberFormatter.string(from: NSNumber(value: status.reservoir))!)
-                    str += String(format: LocalizedString("Battery: %1$@ volts\n", comment: "The format string describing pump battery voltage: (1: battery voltage)"), measurementFormatter.string(from: status.batteryVolts))
+                    str += String(format: LocalizedString("Battery: %1$@ volts\n", comment: "The format string describing pump battery voltage: (1: battery voltage)"), String(describing: status.batteryVolts.value))
                     str += String(format: LocalizedString("Suspended: %1$@\n", comment: "The format string describing pump suspended state: (1: suspended)"), String(describing: status.suspended))
                     str += String(format: LocalizedString("Bolusing: %1$@\n", comment: "The format string describing pump bolusing state: (1: bolusing)"), String(describing: status.bolusing))
                     

--- a/MinimedKitUI/MinimedPumpSettingsViewController.swift
+++ b/MinimedKitUI/MinimedPumpSettingsViewController.swift
@@ -169,13 +169,14 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
     
     private enum CommandsRow: Int, CaseIterable {
         case tune
-        case mySentryPair
         case dumpHistory
         case fetchGlucose
         case getPumpModel
         case pressDownButton
         case readPumpStatus
         case readBasalSchedule
+        // This should always be last so it can be omitted for non-MySentry pumps:
+        case mySentryPair
     }
 
 
@@ -197,7 +198,8 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
         case .rileyLinks:
             return super.tableView(tableView, numberOfRowsInSection: section)
         case .commands:
-            return CommandsRow.allCases.count
+            let commandsRowCount = pumpManager.state.pumpModel.hasMySentry ? CommandsRow.allCases.count : CommandsRow.allCases.count - 1
+            return commandsRowCount
         case .delete:
             return 1
         }
@@ -300,8 +302,6 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
             switch CommandsRow(rawValue: indexPath.row)! {
             case .tune:
                 cell.setTuneInfo(lastValidFrequency: pumpState?.lastValidFrequency, lastTuned: pumpState?.lastTuned, measurementFormatter: measurementFormatter, dateFormatter: dateFormatter)
-            case .mySentryPair:
-                cell.textLabel?.text = LocalizedString("MySentry Pair", comment: "The title of the command to pair with mysentry")
 
             case .dumpHistory:
                 cell.textLabel?.text = LocalizedString("Fetch Recent History", comment: "The title of the command to fetch recent history")
@@ -321,6 +321,8 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
             case .readBasalSchedule:
                 cell.textLabel?.text = LocalizedString("Read Basal Schedule", comment: "The title of the command to read basal schedule")
             
+            case .mySentryPair:
+                cell.textLabel?.text = LocalizedString("MySentry Pair", comment: "The title of the command to pair with mysentry")
             }
             return cell
 
@@ -458,8 +460,6 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
         switch command {
         case .tune:
             vc = .tuneRadio(ops: ops, device: device, measurementFormatter: measurementFormatter)
-        case .mySentryPair:
-            vc = .mySentryPair(ops: ops, device: device)
         case .dumpHistory:
             vc = .dumpHistory(ops: ops, device: device)
         case .fetchGlucose:
@@ -472,6 +472,8 @@ class MinimedPumpSettingsViewController: RileyLinkSettingsViewController {
             vc = .readPumpStatus(ops: ops, device: device, measurementFormatter: measurementFormatter)
         case .readBasalSchedule:
             vc = .readBasalSchedule(ops: ops, device: device, integerFormatter: integerFormatter)
+        case .mySentryPair:
+            vc = .mySentryPair(ops: ops, device: device)
         }
         
         vc?.title = title


### PR DESCRIPTION
+ Only display "MySentry Pair" command for mySentry capable pumps
+ Move "MySentry Pair" command to list end as per "Use MySentry"
+ Fix broken "Read Pump Status" battery voltage formatting
(e.g., display "1.54 volts" instead of "1.5400 V volts")