### PR TITLE
For HUD lifecycle display trigger, use scheduledExpirationReminderOffset

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -608,8 +608,9 @@ extension OmnipodPumpManager {
     }
 
     private var shouldWarnPodEOL: Bool {
+        let eolDisplayActiveTime = Pod.timeRemainingWarningThreshold + (state.scheduledExpirationReminderOffset ?? 0.0)
         guard let podTimeRemaining = podTimeRemaining,
-              podTimeRemaining > 0 && podTimeRemaining <= Pod.timeRemainingWarningThreshold else
+              podTimeRemaining > 0 && podTimeRemaining <= eolDisplayActiveTime else
         {
             return false
         }

--- a/OmniKitUI/ViewModels/OmnipodSettingsViewModel.swift
+++ b/OmniKitUI/ViewModels/OmnipodSettingsViewModel.swift
@@ -513,8 +513,9 @@ extension OmnipodPumpManager {
                 return .expired
             default:
                 let remaining = Pod.nominalPodLife - (status.faultEventTimeSinceActivation ?? Pod.nominalPodLife)
+                let podTimeUntilReminder = remaining - (state.scheduledExpirationReminderOffset ?? 0)
                 if remaining > 0 {
-                    return .timeRemaining(remaining)
+                    return .timeRemaining(timeUntilExpiration: remaining, timeUntilExpirationReminder: podTimeUntilReminder)
                 } else {
                     return .expired
                 }
@@ -529,7 +530,8 @@ extension OmnipodPumpManager {
         case .active:
             if let podTimeRemaining = podTimeRemaining {
                 if podTimeRemaining > 0 {
-                    return .timeRemaining(podTimeRemaining)
+                    let podTimeUntilReminder = podTimeRemaining - (state.scheduledExpirationReminderOffset ?? 0)
+                    return .timeRemaining(timeUntilExpiration: podTimeRemaining, timeUntilExpirationReminder: podTimeUntilReminder)
                 } else {
                     return .expired
                 }

--- a/OmniKitUI/ViewModels/PodLifeState.swift
+++ b/OmniKitUI/ViewModels/PodLifeState.swift
@@ -14,7 +14,7 @@ import LoopKitUI
 enum PodLifeState {
     case podActivating
     // Time remaining
-    case timeRemaining(TimeInterval)
+    case timeRemaining(timeUntilExpiration: TimeInterval, timeUntilExpirationReminder: TimeInterval)
     // Time since expiry
     case expired
     case podDeactivating
@@ -22,7 +22,7 @@ enum PodLifeState {
     
     var progress: Double {
         switch self {
-        case .timeRemaining(let timeRemaining):
+        case .timeRemaining(let timeRemaining, _):
             return max(0, min(1, (1 - (timeRemaining / Pod.nominalPodLife))))
         case .expired:
             return 1
@@ -37,8 +37,8 @@ enum PodLifeState {
         switch self {
         case .expired:
             return guidanceColors.critical
-        case .timeRemaining(let timeRemaining):
-            return timeRemaining <= Pod.timeRemainingWarningThreshold ? guidanceColors.warning : .accentColor
+        case .timeRemaining(_, let timeUntilExpirationReminder):
+            return timeUntilExpirationReminder <= Pod.timeRemainingWarningThreshold ? guidanceColors.warning : .accentColor
         default:
             return Color.secondary
         }

--- a/OmniKitUI/Views/OmnipodSettingsView.swift
+++ b/OmniKitUI/Views/OmnipodSettingsView.swift
@@ -40,21 +40,21 @@ struct OmnipodSettingsView: View  {
     @Environment(\.insulinTintColor) var insulinTintColor
     
     private var daysRemaining: Int? {
-        if case .timeRemaining(let remaining) = viewModel.lifeState, remaining > .days(1) {
+        if case .timeRemaining(let remaining, _) = viewModel.lifeState, remaining > .days(1) {
             return Int(remaining.days)
         }
         return nil
     }
     
     private var hoursRemaining: Int? {
-        if case .timeRemaining(let remaining) = viewModel.lifeState, remaining > .hours(1) {
+        if case .timeRemaining(let remaining, _) = viewModel.lifeState, remaining > .hours(1) {
             return Int(remaining.hours.truncatingRemainder(dividingBy: 24))
         }
         return nil
     }
     
     private var minutesRemaining: Int? {
-        if case .timeRemaining(let remaining) = viewModel.lifeState, remaining < .hours(2) {
+        if case .timeRemaining(let remaining, _) = viewModel.lifeState, remaining < .hours(2) {
             return Int(remaining.minutes.truncatingRemainder(dividingBy: 60))
         }
         return nil


### PR DESCRIPTION
Modify the trigger for when lifecycle is displayed in HUD taking into account state.scheduledExpirationReminderOffset.
Matches the change in [OmniBLE PR 40](https://github.com/LoopKit/OmniBLE/pull/40).
The OmniBLE modification was tested with rPI DASH simulator.
This modification builds but was not tested.