### PR TITLE
Fix and update underlying OmnipodCommon support for extended boluses

### DIFF
--- a/OmniKit/OmnipodCommon/BolusDeliveryTable.swift
+++ b/OmniKit/OmnipodCommon/BolusDeliveryTable.swift
@@ -1,0 +1,181 @@
+//
+//  BolusDeliveryTable.swift
+//  OmniKit
+//
+//  Created by Joseph Moran on 10/20/22.
+//  Copyright © 2022 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+// Implements the bolus insulin delivery table for 0x1A command (https://github.com/openaps/openomni/wiki/Command-1A-Table-2)
+
+public struct BolusDeliveryTable {
+    static let segMinutes = 30
+    static let maxDurationHours = 8
+
+    let entries: [InsulinTableEntry]
+
+    public init(entries: [InsulinTableEntry]) {
+        self.entries = entries
+    }
+
+    public init(units: Double, extendedUnits: Double = 0.0, extendedDuration: TimeInterval = 0) {
+        let immediatePulses = Int(round(units / Pod.pulseSize))
+        let extendedPulses = Int(round(extendedUnits / Pod.pulseSize))
+        let duration: TimeInterval
+
+        let maxExtendedDuration: TimeInterval = .hours(Double(min(extendedPulses, BolusDeliveryTable.maxDurationHours)))
+        if extendedDuration > maxExtendedDuration {
+            // maximum extended bolus duration of one extended pulse per hour capped at 8 hours
+            duration = maxExtendedDuration
+        } else {
+            duration = extendedDuration
+        }
+
+        self.entries = generateBolusTable(immediatePulses: immediatePulses, extendedPulses: extendedPulses, extendedDuration: duration)
+    }
+
+    public func numSegments() -> Int {
+        return entries.reduce(0) { $0 + $1.segments }
+    }
+}
+
+// Returns the bolus insulin delivery table for the specified bolus parameters as per the PDM.
+// See https://github.com/openaps/openomni/wiki/Command-1A-Table-2#Advanced-Extended-Bolus-Encoding for details.
+fileprivate func generateBolusTable(immediatePulses: Int, extendedPulses: Int, extendedDuration: TimeInterval) -> [InsulinTableEntry] {
+    var tableEntries = [InsulinTableEntry]()
+
+    if extendedPulses == 0 || extendedDuration == 0 {
+        // trivial immediate bolus case ($0ppp)
+        let entry = InsulinTableEntry(segments: 1, pulses: immediatePulses, alternateSegmentPulse: false)
+        tableEntries.append(entry)
+        return tableEntries
+    }
+
+    // Extended (square wave) bolus or combination (dual wave) bolus case
+    let ePulsesPerSeg = computeExtendedPulsesPerSeg(extendedPulses: extendedPulses, duration: extendedDuration)
+    let nseg = ePulsesPerSeg.count
+
+    // The first entry is special as its pulses value always matches the # immediate pulses,
+    // but it also describes the first 1/2 hour of the extended bolus when the # of extended
+    // pulses in the first 1/2 hour is one more or the same as the # of immediate pulses.
+    var pulses = immediatePulses
+    var segs = 1
+    var alternateSegmentPulse = false
+    if ePulsesPerSeg[0] - 1 == immediatePulses {
+        // $18ii case
+        segs += 1
+        alternateSegmentPulse = true
+    } else if ePulsesPerSeg[0] == immediatePulses {
+        // $x0ii case
+        segs += 1
+        if immediatePulses != 0 {
+            segs += numMatch(ePulsesPerSeg: ePulsesPerSeg, idx: 0, val: immediatePulses)
+        }
+    } // else $00ii case describing just the immediate bolus portion -- nothing to adjust
+
+    let entry = InsulinTableEntry(segments: segs, pulses: pulses, alternateSegmentPulse: alternateSegmentPulse)
+    tableEntries.append(entry)
+
+    var remainingPulses = (immediatePulses + extendedPulses) - (segs * pulses)
+    if alternateSegmentPulse {
+        remainingPulses -= segs/2
+    }
+
+    var idx: Int
+    if alternateSegmentPulse {
+        idx = 1
+    } else {
+        idx = segs - 1
+    }
+
+    // Step through the remaining extended pulses per segment array to generate and append the appropriate insulin table entries
+    let basePulsesPerSeg = Int(extendedPulses / nseg) // truncated to whole pulses per half hour segment
+    while idx < nseg && remainingPulses > 0 {
+        segs = 1
+        alternateSegmentPulse = false
+        pulses = basePulsesPerSeg
+        if idx < nseg - 1 && ePulsesPerSeg[idx] == pulses && ePulsesPerSeg[idx + 1] == pulses + 1 {
+            // $n8bb
+            let numAltPairs = numAltPairMatch(ePulsesPerSeg: ePulsesPerSeg, idx: idx, val: pulses)
+            alternateSegmentPulse = true
+            segs += (numAltPairs * 2) - 1
+            idx += (numAltPairs * 2) - 1
+            remainingPulses -= segs/2
+        } else {
+            // $n0bb
+            pulses = ePulsesPerSeg[idx]
+            let numMatched = numMatch(ePulsesPerSeg: ePulsesPerSeg, idx: idx, val: pulses)
+            if numMatched > 0 {
+                segs += numMatched
+                idx += numMatched
+            }
+        }
+
+        let entry = InsulinTableEntry(segments: segs, pulses: pulses, alternateSegmentPulse: alternateSegmentPulse)
+        tableEntries.append(entry)
+
+        idx += 1
+        remainingPulses -= segs * pulses
+    }
+
+    return tableEntries
+}
+
+// Returns an array of pulses to be delivered for each half hour segment for extendedPulses spaced over the given duration
+fileprivate func computeExtendedPulsesPerSeg(extendedPulses: Int, duration: TimeInterval) -> [Int] {
+    let nseg = Int(ceil(duration / .minutes(BolusDeliveryTable.segMinutes)))
+    let pulseInterval = duration / Double(extendedPulses)
+
+    var ePulsesPerSeg = Array(repeating: 0, count: nseg)
+    var t = pulseInterval
+    var ePulses = 0
+    for seg in 0..<nseg {
+        let segTimeStart = TimeInterval(Double(seg) * .minutes(BolusDeliveryTable.segMinutes))
+        let segTimeEnd = min(segTimeStart + .minutes(BolusDeliveryTable.segMinutes), duration)
+        while t <= segTimeEnd {
+            if t > segTimeStart && t <= segTimeEnd {
+                ePulsesPerSeg[seg] += 1
+                ePulses += 1
+            }
+            t += pulseInterval
+        }
+        if t > duration {
+            break
+        }
+    }
+
+    // Any remaining pulses are added to the last half hour segment
+    if extendedPulses > ePulses {
+        ePulsesPerSeg[nseg - 1] += extendedPulses - ePulses
+    }
+
+    return ePulsesPerSeg
+}
+
+// Returns the number of consecutive matched [val, val+1] pairs starting at ePulsesPerSeg[idx]
+fileprivate func numAltPairMatch(ePulsesPerSeg: [Int], idx: Int, val: Int) -> Int {
+    var cnt = 0
+
+    for i in stride(from: idx, to: ePulsesPerSeg.count - 1, by: 2) {
+        if ePulsesPerSeg[i] != val || ePulsesPerSeg[i + 1] != val + 1 {
+            break
+        }
+        cnt += 1
+    }
+    return cnt
+}
+
+// Returns the number of consecutive elements matching val starting at ePulsesPerSeg[idx]
+fileprivate func numMatch(ePulsesPerSeg: [Int], idx: Int, val: Int) -> Int {
+    var cnt = 0
+
+    for i in idx..<ePulsesPerSeg.count - 1 {
+        if ePulsesPerSeg[i + 1] != val {
+            break
+        }
+        cnt += 1
+    }
+    return cnt
+}

--- a/OmniKit/OmnipodCommon/InsulinTableEntry.swift
+++ b/OmniKit/OmnipodCommon/InsulinTableEntry.swift
@@ -1,0 +1,52 @@
+//
+//  InsulinTableEntry.swift
+//  OmniKit
+//
+//  Created by Joseph Moran on 10/26/22.
+//  Copyright © 2022 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+//
+// InsulinTableEntry describes the common InsulinScheduleElement in all the 0x1A insulin delivery commands.
+// See https://github.com/openaps/openomni/wiki/Command-1A-Insulin-Schedule#InsulinScheduleElement for details.
+// Formerly BasalTableEntry when only being used for the basal and temporary basal commands.
+//
+public struct InsulinTableEntry {
+    let segments: Int
+    let pulses: Int
+    let alternateSegmentPulse: Bool
+
+    public init(encodedData: Data) {
+        segments = Int(encodedData[0] >> 4) + 1
+        pulses = (Int(encodedData[0] & 0b11) << 8) + Int(encodedData[1])
+        alternateSegmentPulse = (encodedData[0] >> 3) & 0x1 == 1
+    }
+
+    public init(segments: Int, pulses: Int, alternateSegmentPulse: Bool) {
+        self.segments = segments
+        self.pulses = pulses
+        self.alternateSegmentPulse = alternateSegmentPulse
+    }
+
+    public var data: Data {
+        let pulsesHighBits = UInt8((pulses >> 8) & 0b11)
+        let pulsesLowBits = UInt8(pulses & 0xff)
+        return Data([
+            UInt8((segments - 1) << 4) + UInt8((alternateSegmentPulse ? 1 : 0) << 3) + pulsesHighBits,
+            UInt8(pulsesLowBits)
+            ])
+    }
+
+    public func checksum() -> UInt16 {
+        let checksumPerSegment = (pulses & 0xff) + (pulses >> 8)
+        return UInt16(checksumPerSegment * segments + (alternateSegmentPulse ? segments / 2 : 0))
+    }
+}
+
+extension InsulinTableEntry: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "InsulinTableEntry(segments:\(segments), pulses:\(pulses), alternateSegmentPulse:\(alternateSegmentPulse))"
+    }
+}

--- a/OmniKit/OmnipodCommon/MessageBlocks/BolusExtraCommand.swift
+++ b/OmniKit/OmnipodCommon/MessageBlocks/BolusExtraCommand.swift
@@ -17,8 +17,8 @@ public struct BolusExtraCommand : MessageBlock {
     public let programReminderInterval: TimeInterval
     public let units: Double
     public let timeBetweenPulses: TimeInterval
-    public let squareWaveUnits: Double
-    public let squareWaveDuration: TimeInterval
+    public let extendedUnits: Double
+    public let extendedDuration: TimeInterval
 
     // 17 0d 7c 1770 00030d40 0000 00000000
     // 0  1  2  3    5        9    13
@@ -31,13 +31,13 @@ public struct BolusExtraCommand : MessageBlock {
             beepOptions
             ])
         
-        data.appendBigEndian(UInt16(round(units * 200)))
+        data.appendBigEndian(UInt16(round(units * Pod.pulsesPerUnit * 10)))
         data.appendBigEndian(UInt32(timeBetweenPulses.hundredthsOfMilliseconds))
         
-        let pulseCountX10 = UInt16(round(squareWaveUnits * 200))
+        let pulseCountX10 = UInt16(round(extendedUnits * Pod.pulsesPerUnit * 10))
         data.appendBigEndian(pulseCountX10)
         
-        let timeBetweenExtendedPulses = pulseCountX10 > 0 ? squareWaveDuration / Double(pulseCountX10) : 0
+        let timeBetweenExtendedPulses = pulseCountX10 > 0 ? extendedDuration / (Double(pulseCountX10) / 10) : 0
         data.appendBigEndian(UInt32(timeBetweenExtendedPulses.hundredthsOfMilliseconds))
         return data
     }
@@ -51,33 +51,33 @@ public struct BolusExtraCommand : MessageBlock {
         completionBeep = encodedData[2] & (1<<6) != 0
         programReminderInterval = TimeInterval(minutes: Double(encodedData[2] & 0x3f))
         
-        units = Double(encodedData[3...].toBigEndian(UInt16.self)) / 200
+        units = Double(encodedData[3...].toBigEndian(UInt16.self)) / (Pod.pulsesPerUnit * 10)
 
         let delayCounts = encodedData[5...].toBigEndian(UInt32.self)
         timeBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(delayCounts))
 
         let pulseCountX10 = encodedData[9...].toBigEndian(UInt16.self)
-        squareWaveUnits = Double(pulseCountX10) / 200
+        extendedUnits = Double(pulseCountX10) / (Pod.pulsesPerUnit * 10)
         
-        let intervalCounts = encodedData[5...].toBigEndian(UInt32.self)
+        let intervalCounts = encodedData[11...].toBigEndian(UInt32.self)
         let timeBetweenExtendedPulses = TimeInterval(hundredthsOfMilliseconds: Double(intervalCounts))
-        squareWaveDuration = timeBetweenExtendedPulses * Double(pulseCountX10) / 10
+        extendedDuration = timeBetweenExtendedPulses * (Double(pulseCountX10) / 10)
     }
     
-    public init(units: Double, timeBetweenPulses: TimeInterval = Pod.secondsPerBolusPulse, squareWaveUnits: Double = 0.0, squareWaveDuration: TimeInterval = 0, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) {
+    public init(units: Double = 0, timeBetweenPulses: TimeInterval = Pod.secondsPerBolusPulse, extendedUnits: Double = 0.0, extendedDuration: TimeInterval = 0, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) {
         self.acknowledgementBeep = acknowledgementBeep
         self.completionBeep = completionBeep
         self.programReminderInterval = programReminderInterval
         self.units = units
-        self.timeBetweenPulses = timeBetweenPulses
-        self.squareWaveUnits = squareWaveUnits
-        self.squareWaveDuration = squareWaveDuration
+        self.timeBetweenPulses = timeBetweenPulses != 0 ? timeBetweenPulses : Pod.secondsPerBolusPulse
+        self.extendedUnits = extendedUnits
+        self.extendedDuration = extendedDuration
     }
 }
 
 
 extension BolusExtraCommand: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "BolusExtraCommand(units:\(units), timeBetweenPulses:\(timeBetweenPulses), squareWaveUnits:\(squareWaveUnits), squareWaveDuration:\(squareWaveDuration), acknowledgementBeep:\(acknowledgementBeep), completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.minutes))"
+        return "BolusExtraCommand(units:\(units), timeBetweenPulses:\(timeBetweenPulses), extendedUnits:\(extendedUnits), extendedDuration:\(extendedDuration), acknowledgementBeep:\(acknowledgementBeep), completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.minutes))"
     }
 }

--- a/OmniKit/OmnipodCommon/MessageBlocks/SetInsulinScheduleCommand.swift
+++ b/OmniKit/OmnipodCommon/MessageBlocks/SetInsulinScheduleCommand.swift
@@ -19,7 +19,7 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
     public enum DeliverySchedule {
         case basalSchedule(currentSegment: UInt8, secondsRemaining: UInt16, pulsesRemaining: UInt16, table: BasalDeliveryTable)
         case tempBasal(secondsRemaining: UInt16, firstSegmentPulses: UInt16, table: BasalDeliveryTable)
-        case bolus(units: Double, timeBetweenPulses: TimeInterval)
+        case bolus(units: Double, timeBetweenPulses: TimeInterval, table: BolusDeliveryTable)
         
         fileprivate func typeCode() -> ScheduleTypeCode {
             switch self {
@@ -42,19 +42,23 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
                     data.append(entry.data)
                 }
                 return data
-            case .bolus(let units, let timeBetweenPulses):
-                let pulseCount = UInt16(round(units / Pod.pulseSize))
-                let multiplier = UInt16(round(timeBetweenPulses * 8))
-                let fieldA = pulseCount * multiplier
-                let numHalfHourSegments: UInt8 = 1
-                var data = Data([numHalfHourSegments])
-                data.appendBigEndian(fieldA)
-                data.appendBigEndian(pulseCount)
-                data.appendBigEndian(pulseCount)
-                return data
+
             case .tempBasal(let secondsRemaining, let firstSegmentPulses, let table):
                 var data = Data([UInt8(table.numSegments())])
                 data.appendBigEndian(secondsRemaining << 3)
+                data.appendBigEndian(firstSegmentPulses)
+                for entry in table.entries {
+                    data.append(entry.data)
+                }
+                return data
+
+            case .bolus(let units, let timeBetweenPulses, let table):
+                let firstSegmentPulses = UInt16(round(units / Pod.pulseSize))
+                let multiplier = UInt16(round(timeBetweenPulses * 8))
+                let fieldA = firstSegmentPulses * multiplier
+
+                var data = Data([UInt8(table.numSegments())])
+                data.appendBigEndian(fieldA)
                 data.appendBigEndian(firstSegmentPulses)
                 for entry in table.entries {
                     data.append(entry.data)
@@ -66,12 +70,10 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
         
         fileprivate func checksum() -> UInt16 {
             switch self {
-            case .basalSchedule( _, _, _, let table):
+            case .basalSchedule( _, _, _, let table), .tempBasal(_, _, let table):
                 return data[0..<5].reduce(0) { $0 + UInt16($1) } +
                     table.entries.reduce(0) { $0 + $1.checksum() }
-            case .bolus:
-                return data[0..<7].reduce(0) { $0 + UInt16($1) }
-            case .tempBasal(_, _, let table):
+            case .bolus(_, _, let table):
                 return data[0..<5].reduce(0) { $0 + UInt16($1) } +
                     table.entries.reduce(0) { $0 + $1.checksum() }
             }
@@ -111,37 +113,47 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
 
         switch scheduleTypeCode {
         case .basalSchedule:
-            var entries = [BasalTableEntry]()
+            var entries = [InsulinTableEntry]()
             let numEntries = (length - 12) / 2
             for i in 0..<numEntries {
                 let dataStart = Int(i*2 + 14)
                 let entryData = encodedData.subdata(in: dataStart..<(dataStart+2))
-                entries.append(BasalTableEntry(encodedData: entryData))
+                entries.append(InsulinTableEntry(encodedData: entryData))
             }
             let currentTableIndex = encodedData[9]
             let secondsRemaining = encodedData[10...].toBigEndian(UInt16.self) >> 3
             let pulsesRemaining = encodedData[12...].toBigEndian(UInt16.self)
             let table = BasalDeliveryTable(entries: entries)
             deliverySchedule = .basalSchedule(currentSegment: currentTableIndex, secondsRemaining: secondsRemaining, pulsesRemaining: pulsesRemaining, table: table)
+
         case .tempBasal:
             let secondsRemaining = encodedData[10...].toBigEndian(UInt16.self) >> 3
             let firstSegmentPulses = encodedData[12...].toBigEndian(UInt16.self)
-            var entries = [BasalTableEntry]()
+            var entries = [InsulinTableEntry]()
             let numEntries = (length - 12) / 2
             for i in 0..<numEntries {
                 let dataStart = Int(i*2 + 14)
                 let entryData = encodedData.subdata(in: dataStart..<(dataStart+2))
-                entries.append(BasalTableEntry(encodedData: entryData))
+                entries.append(InsulinTableEntry(encodedData: entryData))
             }
             let table = BasalDeliveryTable(entries: entries)
             deliverySchedule = .tempBasal(secondsRemaining: secondsRemaining, firstSegmentPulses: firstSegmentPulses, table: table)
+
         case .bolus:
-            let duration = TimeInterval(minutes: Double(encodedData[9] * 30))
             let fieldA = encodedData[10...].toBigEndian(UInt16.self)
             let unitRate = encodedData[12...].toBigEndian(UInt16.self)
-            let units = Double(unitRate) * 0.1 * duration.hours
-            let multiplier = fieldA / unitRate
-            deliverySchedule = .bolus(units: units, timeBetweenPulses: Double(multiplier) / 8)
+            let units = Double(unitRate & 0x03ff) / Pod.pulsesPerUnit
+            let timeBetweenPulses = unitRate > 0 ? Double(fieldA / unitRate) / 8 : 0
+
+            var entries = [InsulinTableEntry]()
+            let numEntries = (length - 12) / 2
+            for i in 0..<numEntries {
+                let dataStart = Int((i << 1) + 14)
+                let entryData = encodedData.subdata(in: dataStart..<(dataStart+2))
+                entries.append(InsulinTableEntry(encodedData: entryData))
+            }
+            let table = BolusDeliveryTable(entries: entries)
+            deliverySchedule = .bolus(units: units, timeBetweenPulses: timeBetweenPulses, table: table)
         }
         
         guard checksum == deliverySchedule.checksum() else {
@@ -185,10 +197,13 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
         self.deliverySchedule = SetInsulinScheduleCommand.DeliverySchedule.basalSchedule(currentSegment: UInt8(segment), secondsRemaining: UInt16(timeRemainingInSegment), pulsesRemaining: UInt16(pulsesRemainingInSegment), table: table)
         self.nonce = nonce
     }
-}
 
-fileprivate func calculateChecksum(_ data: Data) -> UInt16 {
-    return data.reduce(0) { $0 + UInt16($1) }
+    public init(nonce: UInt32, units: Double, timeBetweenPulses: TimeInterval = 0, extendedUnits: Double = 0, extendedDuration: TimeInterval = 0) {
+        self.nonce = nonce
+        let table = BolusDeliveryTable(units: units, extendedUnits: extendedUnits, extendedDuration: extendedDuration)
+        let timeBetweenImmediatePulses = (units > 0.0 && timeBetweenPulses > 0) ? timeBetweenPulses : Pod.secondsPerBolusPulse
+        self.deliverySchedule = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: units, timeBetweenPulses: timeBetweenImmediatePulses, table: table)
+    }
 }
 
 extension SetInsulinScheduleCommand: CustomDebugStringConvertible {

--- a/OmniKit/OmnipodCommon/Pod.swift
+++ b/OmniKit/OmnipodCommon/Pod.swift
@@ -109,13 +109,19 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case priming = 4
     case bolusInProgress = 5
     case bolusAndTempBasal = 6
+    case extendedBolusRunning = 9
+    case extendedBolusAndTempBasal = 10
     
     public var bolusing: Bool {
-        return self == .bolusInProgress || self == .bolusAndTempBasal
+        return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
     }
     
     public var tempBasalRunning: Bool {
-        return self == .tempBasalRunning || self == .bolusAndTempBasal
+        return self == .tempBasalRunning || self == .bolusAndTempBasal || self == .extendedBolusAndTempBasal
+    }
+
+    public var extendedBolusRunninng: Bool {
+        return self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
     }
 
     public var description: String {
@@ -132,6 +138,10 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
             return LocalizedString("Bolusing", comment: "Delivery status when bolusing")
         case .bolusAndTempBasal:
             return LocalizedString("Bolusing with temp basal", comment: "Delivery status when bolusing and temp basal is running")
+        case .extendedBolusRunning:
+            return LocalizedString("Extended bolus running", comment: "Delivery status when extended bolus is running")
+        case .extendedBolusAndTempBasal:
+            return LocalizedString("Extended bolus running with temp basal", comment: "Delivery status when extended bolus and temp basal is running")
         }
     }
 }

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -351,8 +351,7 @@ public class PodCommsSession {
         podState.setupProgress = .startingPrime
 
         let timeBetweenPulses = TimeInterval(seconds: Pod.secondsPerPrimePulse)
-        let bolusSchedule = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: Pod.primeUnits, timeBetweenPulses: timeBetweenPulses)
-        let scheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, deliverySchedule: bolusSchedule)
+        let scheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, units: Pod.primeUnits, timeBetweenPulses: timeBetweenPulses)
         let bolusExtraCommand = BolusExtraCommand(units: Pod.primeUnits, timeBetweenPulses: timeBetweenPulses)
         let status: StatusResponse = try send([scheduleCommand, bolusExtraCommand])
         podState.updateFromStatusResponse(status)
@@ -451,8 +450,7 @@ public class PodCommsSession {
         // Mark cannulaInsertionUnits (0.5U) bolus delivery with Pod.secondsPerPrimePulse (1) between pulses for cannula insertion
 
         let timeBetweenPulses = TimeInterval(seconds: Pod.secondsPerPrimePulse)
-        let bolusSchedule = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: cannulaInsertionUnits, timeBetweenPulses: timeBetweenPulses)
-        let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, deliverySchedule: bolusSchedule)
+        let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, units: cannulaInsertionUnits, timeBetweenPulses: timeBetweenPulses)
 
         podState.setupProgress = .startingInsertCannula
         let bolusExtraCommand = BolusExtraCommand(units: cannulaInsertionUnits, timeBetweenPulses: timeBetweenPulses)
@@ -487,15 +485,14 @@ public class PodCommsSession {
     }
 
 
-    public func bolus(units: Double, automatic: Bool = false, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) -> DeliveryCommandResult {
+    public func bolus(units: Double, automatic: Bool = false, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0, extendedUnits: Double = 0.0, extendedDuration: TimeInterval = 0) -> DeliveryCommandResult {
 
         guard podState.unacknowledgedCommand == nil else {
             return DeliveryCommandResult.certainFailure(error: .unacknowledgedCommandPending)
         }
 
         let timeBetweenPulses = TimeInterval(seconds: Pod.secondsPerBolusPulse)
-        let bolusSchedule = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: units, timeBetweenPulses: timeBetweenPulses)
-        let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, deliverySchedule: bolusSchedule)
+        let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, units: units, timeBetweenPulses: timeBetweenPulses, extendedUnits: extendedUnits, extendedDuration: extendedDuration)
 
         if podState.unfinalizedBolus != nil {
             var ongoingBolus = true
@@ -508,7 +505,7 @@ public class PodCommsSession {
             }
         }
 
-        let bolusExtraCommand = BolusExtraCommand(units: units, timeBetweenPulses: timeBetweenPulses, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep, programReminderInterval: programReminderInterval)
+        let bolusExtraCommand = BolusExtraCommand(units: units, timeBetweenPulses: timeBetweenPulses, extendedUnits: extendedUnits, extendedDuration: extendedDuration, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep, programReminderInterval: programReminderInterval)
         do {
             podState.unacknowledgedCommand = PendingCommand.program(.bolus(volume: units, automatic: automatic), transport.messageNumber, Date())
             let statusResponse: StatusResponse = try send([bolusScheduleCommand, bolusExtraCommand])

--- a/OmniKitTests/BasalScheduleTests.swift
+++ b/OmniKitTests/BasalScheduleTests.swift
@@ -11,12 +11,12 @@ import XCTest
 
 class BasalScheduleTests: XCTestCase {
     
-    func testBasalTableEntry() {
-        let entry = BasalTableEntry(segments: 2, pulses: 300, alternateSegmentPulse: false)
+    func testInsulinTableEntry() {
+        let entry = InsulinTableEntry(segments: 2, pulses: 300, alternateSegmentPulse: false)
         // $01 $2c $01 $2c = 1 + 44 + 1 + 44 = 90 = $5a
         XCTAssertEqual(0x5a, entry.checksum())
         
-        let entry2 = BasalTableEntry(segments: 2, pulses: 260, alternateSegmentPulse: true)
+        let entry2 = InsulinTableEntry(segments: 2, pulses: 260, alternateSegmentPulse: true)
         // $01 $04 $01 $04 = 1 + 4 + 1 + 5 = 1 = $0b
         XCTAssertEqual(0x0b, entry2.checksum())
     }
@@ -40,7 +40,7 @@ class BasalScheduleTests: XCTestCase {
         }
         
         // Encode
-        let scheduleEntry = BasalTableEntry(segments: 16, pulses: 0, alternateSegmentPulse: true)
+        let scheduleEntry = InsulinTableEntry(segments: 16, pulses: 0, alternateSegmentPulse: true)
         let table = BasalDeliveryTable(entries: [scheduleEntry, scheduleEntry, scheduleEntry])
         let deliverySchedule = SetInsulinScheduleCommand.DeliverySchedule.basalSchedule(currentSegment: 0x2b, secondsRemaining: 737, pulsesRemaining: 0, table: table)
         let cmd = SetInsulinScheduleCommand(nonce: 0x77a05551, deliverySchedule: deliverySchedule)

--- a/OmniKitTests/BolusTests.swift
+++ b/OmniKitTests/BolusTests.swift
@@ -12,19 +12,25 @@ import XCTest
 @testable import OmniKit
 
 class BolusTests: XCTestCase {
-        func testSetBolusCommand() {
+    func testPrimeBolusCommand() {
         //    2017-09-11T11:07:57.476872 ID1:1f08ced2 PTYPE:PDM SEQ:18 ID2:1f08ced2 B9:18 BLEN:31 MTYPE:1a0e BODY:bed2e16b02010a0101a000340034170d000208000186a0 CRC:fd
         //    2017-09-11T11:07:57.552574 ID1:1f08ced2 PTYPE:ACK SEQ:19 ID2:1f08ced2 CRC:b8
         //    2017-09-11T11:07:57.734557 ID1:1f08ced2 PTYPE:CON SEQ:20 CON:00000000000003c0 CRC:a9
         
         do {
             // Decode
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP 0ppp
+            // 1a 0e bed2e16b 02 010a 01 01a0 0034 0034
             let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a0ebed2e16b02010a0101a000340034")!)
             XCTAssertEqual(0xbed2e16b, cmd.nonce)
             
-            if case SetInsulinScheduleCommand.DeliverySchedule.bolus(let units, let timeBetweenPulses) = cmd.deliverySchedule {
-                XCTAssertEqual(2.6, units)
-                XCTAssertEqual(.seconds(1), timeBetweenPulses)
+            if case SetInsulinScheduleCommand.DeliverySchedule.bolus(let units, let timeBetweenPulses, let table) = cmd.deliverySchedule {
+                XCTAssertEqual(Pod.primeUnits, units)
+                XCTAssertEqual(Pod.secondsPerPrimePulse, timeBetweenPulses)
+                XCTAssertEqual(1, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(Int(Pod.primeUnits / Pod.pulseSize), table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
             } else {
                 XCTFail("Expected ScheduleEntry.bolus type")
             }
@@ -33,9 +39,7 @@ class BolusTests: XCTestCase {
         }
         
         // Encode
-        let timeBetweenPulses = TimeInterval(seconds: 1)
-        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: 2.6, timeBetweenPulses: timeBetweenPulses)
-        let cmd = SetInsulinScheduleCommand(nonce: 0xbed2e16b, deliverySchedule: scheduleEntry)
+        let cmd = SetInsulinScheduleCommand(nonce: 0xbed2e16b, units: Pod.primeUnits, timeBetweenPulses: Pod.secondsPerPrimePulse)
         XCTAssertEqual("1a0ebed2e16b02010a0101a000340034", cmd.data.hexadecimalString)
     }
 
@@ -50,53 +54,872 @@ class BolusTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(true, cmd.completionBeep)
             XCTAssertEqual(.hours(1), cmd.programReminderInterval)
-            XCTAssertEqual(.seconds(2), cmd.timeBetweenPulses)
-            XCTAssertEqual(0, cmd.squareWaveUnits)
-            XCTAssertEqual(0, cmd.squareWaveDuration)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, cmd.timeBetweenPulses)
+            XCTAssertEqual(0, cmd.extendedUnits)
+            XCTAssertEqual(0, cmd.extendedDuration)
             
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
         
         // Encode typical prime
-        let cmd = BolusExtraCommand(units: 2.6, timeBetweenPulses: .seconds(1))
+        let cmd = BolusExtraCommand(units: Pod.primeUnits, timeBetweenPulses: Pod.secondsPerPrimePulse)
         XCTAssertEqual("170d000208000186a0000000000000", cmd.data.hexadecimalString)
     }
-    
+
+    func testExtendedBolus() {
+        // 1.0U extended (square wave) bolus over 1 hour with no immediate bolus
+        // 1A LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+        // 1a 10 0375a602 02 0017 03 0000 0000 0000 100a
+        do {
+            let insulinCmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a100375a60202001703000000000000100a")!)
+            XCTAssertEqual(0x0375a602, insulinCmd.nonce)
+            let schedule = insulinCmd.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(0.0, units)
+                XCTAssertEqual(0, timeBetweenPulses)
+                XCTAssertEqual(2, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(0, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[1].segments)
+                XCTAssertEqual(10, table.entries[1].pulses)
+                XCTAssertEqual(false, table.entries[1].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+        } catch (let error) {
+            XCTFail("insulin command decoding threw error: \(error)")
+        }
+
+        // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 17 0d 7c 0000 00030d40 00c8 0112a880
+        do {
+            let extraCmd = try BolusExtraCommand(encodedData: Data(hexadecimalString: "170d7c000000030d4000c80112a880")!)
+            XCTAssertEqual(false, extraCmd.acknowledgementBeep)
+            XCTAssertEqual(true, extraCmd.completionBeep)
+            XCTAssertEqual(.minutes(60), extraCmd.programReminderInterval)
+            XCTAssertEqual(0.0, extraCmd.units)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, extraCmd.timeBetweenPulses)
+            XCTAssertEqual(1.0, extraCmd.extendedUnits)
+            XCTAssertEqual(.hours(1), extraCmd.extendedDuration)
+        } catch (let error) {
+            XCTFail("bolus extra command decoding threw error: \(error)")
+        }
+    }
+
+    func testNoImmediateExtendedBolusDeliveryEncoding() {
+        // 1.0U extended bolus over 4.5 hours
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP 0ppp napp napp napp napp
+        // 1a 16 b93c64f6 02 001e 0a 0000 0000 0000 3002 0003 2002 0003
+        let bolus_1_00U_Ext_4_5Hr = SetInsulinScheduleCommand(nonce: 0xb93c64f6, units: 0.0, extendedUnits: 1.0, extendedDuration: .hours(4.5))
+        XCTAssertEqual("1a16b93c64f602001e0a0000000000003002000320020003", bolus_1_00U_Ext_4_5Hr.data.hexadecimalString)
+
+        // 0.05U extended bolus over 0.5 hours -> only one entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp   17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 0e 05181992 02 0003 02 0000 0000 1800   17 0d 00 0000 00030d40 000a 0aba9500
+        let bolus_0_05U_Ext_0_5Hr = SetInsulinScheduleCommand(nonce: 0x05181992, units: 0.0, extendedUnits: 0.05, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a0e0518199202000302000000001800", bolus_0_05U_Ext_0_5Hr.data.hexadecimalString)
+
+        // 0.10U extended bolus over 1 hour -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+        // 1a 10 06211961 02 0005 03 0000 0000 1800 0001
+        let bolus_0_10U_Ext_1Hr = SetInsulinScheduleCommand(nonce: 0x06211961, units: 0.0, extendedUnits: 0.10, extendedDuration: .hours(1))
+        XCTAssertEqual("1a1006211961020005030000000018000001", bolus_0_10U_Ext_1Hr.data.hexadecimalString)
+
+        // 0.10U extended bolus over 1.5 hours
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp -> non-zero first entry
+        // 1a 10 04111967 02 0006 04 0000 0000 1000 1001
+        let bolus_0_10U_Ext_1_5Hr = SetInsulinScheduleCommand(nonce: 0x08121964, units: 0.0, extendedUnits: 0.10, extendedDuration: .hours(1.5))
+        XCTAssertEqual("1a1008121964020006040000000010001001", bolus_0_10U_Ext_1_5Hr.data.hexadecimalString)
+
+        // 0.10U extended bolus over 2 hours -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp
+        // 1a 12 07041776 02 0007 05 0000 0000 1000 0001 1800
+        let bolus_0_10U_Ext_2Hr = SetInsulinScheduleCommand(nonce: 0x04111967, units: 0.0, extendedUnits: 0.10, extendedDuration: .hours(2))
+        XCTAssertEqual("1a12041119670200070500000000100000011800", bolus_0_10U_Ext_2Hr.data.hexadecimalString)
+
+        // 0.15U extended bolus over 1 hour -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+        // 1a 10 05181983 02 0006 03 0000 0000 1800 0002
+        let bolus_0_15U_Ext_1Hr = SetInsulinScheduleCommand(nonce: 0x05181983, units: 0.0, extendedUnits: 0.15, extendedDuration: .hours(1))
+        XCTAssertEqual("1a1005181983020006030000000018000002", bolus_0_15U_Ext_1Hr.data.hexadecimalString)
+
+        // 0.35U extended bolus over 0.5 hours
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+        // 1a 10 06151215 02 0009 02 0000 0000 0000 0007
+        let bolus_0_35U_Ext_0_5Hr = SetInsulinScheduleCommand(nonce: 0x06151215, units: 0.0, extendedUnits: 0.35, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a1006151215020009020000000000000007", bolus_0_35U_Ext_0_5Hr.data.hexadecimalString)
+
+        // 0.35U extended bolus over 4.5 hours -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp
+        // 1a 14 07211946 02 0011 0a 0000 0000 1000 2001 1800 2001
+        let bolus_0_35U_Ext_4_5Hr = SetInsulinScheduleCommand(nonce: 0x07211946, units: 0.0, extendedUnits: 0.35, extendedDuration: .hours(4.5))
+        XCTAssertEqual("1a14072119460200110a000000001000200118002001", bolus_0_35U_Ext_4_5Hr.data.hexadecimalString)
+
+        // 0.35U extended bolus over 5.0 hours -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp napp napp
+        // 1a 18 03231932 02 0012 0b 0000 0000 1000 1001 1800 0001 1800 1001
+        let bolus_0_35U_Ext_5_0Hr = SetInsulinScheduleCommand(nonce: 0x03231932, units: 0.0, extendedUnits: 0.35, extendedDuration: .hours(5.0))
+        XCTAssertEqual("1a18032319320200120b00000000100010011800000118001001", bolus_0_35U_Ext_5_0Hr.data.hexadecimalString)
+
+        // 0.35U extended bolus over 5.5 hours -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp
+        // 1a 1c 03011936 02 0013 0c 0000 0000 1000 0001 1800 0001 1800 0001 1800 0001
+        let bolus_0_35U_Ext_5_5Hr = SetInsulinScheduleCommand(nonce: 0x03011936, units: 0.0, extendedUnits: 0.35, extendedDuration: .hours(5.5))
+        XCTAssertEqual("1a1c030119360200130c0000000010000001180000011800000118000001", bolus_0_35U_Ext_5_5Hr.data.hexadecimalString)
+
+        // 0.35U extended bolus over 6.0 hours -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp napp napp
+        // 1a 18 03231957 02 0014 0d 0000 0000 1000 0001 3800 0001 3800 0001
+        let bolus_0_35U_Ext_6_0Hr = SetInsulinScheduleCommand(nonce: 0x03231957, units: 0.0, extendedUnits: 0.35, extendedDuration: .hours(6.0))
+        XCTAssertEqual("1a18032319570200140d00000000100000013800000138000001", bolus_0_35U_Ext_6_0Hr.data.hexadecimalString)
+
+        // 0.35U extended bolus over 6.5 hours -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp
+        // 1a 14 08151959 02 0015 0e 0000 0000 1000 0001 9800 0001
+        let bolus_0_35U_Ext_6_5Hr = SetInsulinScheduleCommand(nonce: 0x08151959, units: 0.0, extendedUnits: 0.35, extendedDuration: .hours(6.5))
+        XCTAssertEqual("1a14081519590200150e000000001000000198000001", bolus_0_35U_Ext_6_5Hr.data.hexadecimalString)
+
+        // 0.35U extended bolus over 7.0 hours -> non-zero first entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp
+        // 1a 12 12041962 02 0016 0f 0000 0000 1000 0001 b800
+        let bolus_0_35U_Ext_7_0Hr = SetInsulinScheduleCommand(nonce: 0x12041962, units: 0.0, extendedUnits: 0.35, extendedDuration: .hours(7.0))
+        XCTAssertEqual("1a12120419620200160f0000000010000001b800", bolus_0_35U_Ext_7_0Hr.data.hexadecimalString)
+    }
+
+    func testBolusDualWave() {
+        // 6.0U dual wave bolus with 2.0U immediate and 4.0U extended over 3 hours
+        // 1A LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp napp
+        // 1a 16 01e475cb 02 0129 07 0280 0028 0028 100d 000e 100d 000e
+        // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 17 0d 3c 0190 00030d40 0320 00cdfe60
+        do {
+            let insulinCmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a1601e475cb02012907028000280028100d000e100d000e")!)
+            XCTAssertEqual(0x01e475cb, insulinCmd.nonce)
+            let schedule = insulinCmd.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(2.0, units)
+                XCTAssertEqual(Pod.secondsPerBolusPulse, timeBetweenPulses)
+                XCTAssertEqual(5, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(0x28, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[1].segments)
+                XCTAssertEqual(0xd, table.entries[1].pulses)
+                XCTAssertEqual(false, table.entries[1].alternateSegmentPulse)
+                XCTAssertEqual(1, table.entries[2].segments)
+                XCTAssertEqual(0xe, table.entries[2].pulses)
+                XCTAssertEqual(false, table.entries[2].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[3].segments)
+                XCTAssertEqual(0xd, table.entries[3].pulses)
+                XCTAssertEqual(false, table.entries[3].alternateSegmentPulse)
+                XCTAssertEqual(1, table.entries[4].segments)
+                XCTAssertEqual(0xe, table.entries[4].pulses)
+                XCTAssertEqual(false, table.entries[4].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            let extraCmd = try BolusExtraCommand(encodedData: Data(hexadecimalString: "170d3c019000030d40032000cdfe60")!)
+            XCTAssertEqual(2.0, extraCmd.units)
+            XCTAssertEqual(false, extraCmd.acknowledgementBeep)
+            XCTAssertEqual(false, extraCmd.completionBeep)
+            XCTAssertEqual(.hours(1), extraCmd.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, extraCmd.timeBetweenPulses)
+            XCTAssertEqual(4, extraCmd.extendedUnits)
+            XCTAssertEqual(.hours(3), extraCmd.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+
+        // Encode 0.10 combo bolus with 0.05U immediate, 0.05U over 30 minutes -> only one entry used!
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp
+        // 1a 0e 06021986 02 0015 02 0010 0001 1001
+        let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: 0x06021986, units: 0.05, extendedUnits: 0.05, extendedDuration: .minutes(30))
+        XCTAssertEqual("1a0e0602198602001502001000011001", bolusScheduleCommand.data.hexadecimalString)
+
+        // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 17 0d 00 000a 00030d40 000a 0aba9500
+        let cmd = BolusExtraCommand(units: 0.05, timeBetweenPulses: Pod.secondsPerBolusPulse, extendedUnits: 0.05, extendedDuration: .hours(0.5), programReminderInterval: .minutes(60))
+        XCTAssertEqual("170d3c000a00030d40000a0aba9500", cmd.data.hexadecimalString)
+    }
+
+    func testLargeExtendedBolus() {
+        // 12U extended (square wave) bolus over 6 hours with no immediate bolus
+        // 1A LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+        // 1a 10 03171958 02 00fd 0d 0000 0000 0000 b014
+        do {
+            let insulinCmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a10031719580200fd0d000000000000b014")!)
+            XCTAssertEqual(0x03171958, insulinCmd.nonce)
+            let schedule = insulinCmd.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(0.0, units)
+                XCTAssertEqual(0, timeBetweenPulses)
+                XCTAssertEqual(2, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(0, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(12, table.entries[1].segments)
+                XCTAssertEqual(0x14, table.entries[1].pulses)
+                XCTAssertEqual(false, table.entries[1].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+        } catch (let error) {
+            XCTFail("insulin command decoding threw error: \(error)")
+        }
+
+        // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 17 0d 7c 0000 00030d40 0960 00895440
+        do {
+            let extraCmd = try BolusExtraCommand(encodedData: Data(hexadecimalString: "170d7c000000030d40096000895440")!)
+            XCTAssertEqual(false, extraCmd.acknowledgementBeep)
+            XCTAssertEqual(true, extraCmd.completionBeep)
+            XCTAssertEqual(.minutes(60), extraCmd.programReminderInterval)
+            XCTAssertEqual(0.0, extraCmd.units)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, extraCmd.timeBetweenPulses)
+            XCTAssertEqual(12, extraCmd.extendedUnits)
+            XCTAssertEqual(.hours(6), extraCmd.extendedDuration)
+        } catch (let error) {
+            XCTFail("bolus extra command decoding threw error: \(error)")
+        }
+
+        // Encode 12U extended (square wave) bolus over 6 hours with no immediate bolus
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+        // 1a 10 07041960 02 00fd 0d 0000 0000 0000 b014
+        let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: 0x07041960, units: 0.0, extendedUnits: 12, extendedDuration: .hours(6))
+        XCTAssertEqual("1a10070419600200fd0d000000000000b014", bolusScheduleCommand.data.hexadecimalString)
+
+        let extraCmd = BolusExtraCommand(extendedUnits: 12, extendedDuration: .hours(6), completionBeep: true, programReminderInterval: .minutes(60))
+        XCTAssertEqual("170d7c000000030d40096000895440", extraCmd.data.hexadecimalString)
+    }
+
+    func testLargeBolusDualWave() {
+        // 30U dual bolus 50% extended over 8 hours
+        do {
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp    17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 1a 1e 11161988 02 0269 11 12c0 012c 012c 1812 1013 1812 1013 1812 1013 1812 1013    17 0d 7c 0bb8 00030d40 0bb8 00927c00
+            let insulinCmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a1e111619880202691112c0012c012c18121013181210131812101318121013")!)
+            XCTAssertEqual(0x11161988, insulinCmd.nonce)
+            let schedule = insulinCmd.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(15.0, units)
+                XCTAssertEqual(2, timeBetweenPulses)
+                XCTAssertEqual(9, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(0x12c, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[1].segments)
+                XCTAssertEqual(0x12, table.entries[1].pulses)
+                XCTAssertEqual(true, table.entries[1].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[2].segments)
+                XCTAssertEqual(0x13, table.entries[2].pulses)
+                XCTAssertEqual(false, table.entries[2].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[3].segments)
+                XCTAssertEqual(0x12, table.entries[3].pulses)
+                XCTAssertEqual(true, table.entries[3].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[4].segments)
+                XCTAssertEqual(0x13, table.entries[4].pulses)
+                XCTAssertEqual(false, table.entries[4].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[5].segments)
+                XCTAssertEqual(0x12, table.entries[5].pulses)
+                XCTAssertEqual(true, table.entries[5].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[6].segments)
+                XCTAssertEqual(0x13, table.entries[6].pulses)
+                XCTAssertEqual(false, table.entries[6].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[7].segments)
+                XCTAssertEqual(0x12, table.entries[7].pulses)
+                XCTAssertEqual(true, table.entries[7].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[8].segments)
+                XCTAssertEqual(0x13, table.entries[8].pulses)
+                XCTAssertEqual(false, table.entries[8].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 17 0d 7c 0bb8 00030d40 0bb8 00927c00
+            let extraCmd = try BolusExtraCommand(encodedData: Data(hexadecimalString: "170d7c0bb800030d400bb800927c00")!)
+            XCTAssertEqual(15.0, extraCmd.units)
+            XCTAssertEqual(false, extraCmd.acknowledgementBeep)
+            XCTAssertEqual(true, extraCmd.completionBeep)
+            XCTAssertEqual(.minutes(60), extraCmd.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, extraCmd.timeBetweenPulses)
+            XCTAssertEqual(15, extraCmd.extendedUnits)
+            XCTAssertEqual(.hours(8), extraCmd.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testDualBolusDeliveryEncoding() {
+        // 0.10U dual bolus 50% extended over 0.5 hours (1i 2e) -> only one entry used
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp         17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 0e 03231932 02 0015 02 0010 0001 1001         17 0d 00 000a 00030d40 000a 0aba9500
+        let bolus_0_10U_50P_ext_30min = SetInsulinScheduleCommand(nonce: 0x03231932, units: 0.05, extendedUnits: 0.05, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a0e0323193202001502001000011001", bolus_0_10U_50P_ext_30min.data.hexadecimalString)
+
+        // 0.10U dual bolus 50% extended over 1.0 hour (1i 2e) -> max duration allowed
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp   17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 03011936 02 0016 03 0010 0001 0001 1800   17 0d 00 000a 00030d40 000a 15752a00
+        let bolus_0_10U_50P_ext_60min = SetInsulinScheduleCommand(nonce: 0x03011936, units: 0.05, extendedUnits: 0.05, extendedDuration: .hours(1.0))
+        XCTAssertEqual("1a1003011936020016030010000100011800", bolus_0_10U_50P_ext_60min.data.hexadecimalString)
+
+
+        // 0.15U dual bolus 65% extended over 0.5 hours (1i 2e) -> only one entry used
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp             17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 0e 03171958 02 0016 02 0010 0001 1801             17 0d 00 000a 00030d40 0014 055d4a80
+        let bolus_0_15U_65P_ext_30min = SetInsulinScheduleCommand(nonce: 0x03171958, units: 0.05, extendedUnits: 0.10, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a0e0317195802001602001000011801", bolus_0_15U_65P_ext_30min.data.hexadecimalString)
+
+        // 0.15U dual bolus 65% extended over 1.0 hour (1i 2e) -> only one entry used
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp             17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 0e 08151959 02 0017 03 0010 0001 2001             17 0d 00 000a 00030d40 0014 0aba9500
+        let bolus_0_15U_65P_ext_60min = SetInsulinScheduleCommand(nonce: 0x08151959, units: 0.05, extendedUnits: 0.10, extendedDuration: .hours(1.0))
+        XCTAssertEqual("1a0e0815195902001703001000012001", bolus_0_15U_65P_ext_60min.data.hexadecimalString)
+
+        // 0.15U dual bolus 65% extended over 1.5 hours (1i 2e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp   17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 12 06211961 02 0018 04 0010 0001 0001 1800 0001   17 0d 00 000a 00030d40 0014 1017df80
+        let bolus_0_15U_65P_ext_90min = SetInsulinScheduleCommand(nonce: 0x06211961, units: 0.05, extendedUnits: 0.10, extendedDuration: .hours(1.5))
+        XCTAssertEqual("1a12062119610200180400100001000118000001", bolus_0_15U_65P_ext_90min.data.hexadecimalString)
+
+        // 0.15U dual bolus 65% extended over 2.0 hours (1i 2e) -> max duration allowed
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp        17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 12041962 02 0019 05 0010 0001 0001 3800        17 0d 00 000a 00030d40 0014 15752a00
+        let bolus_0_15U_65P_ext_120min = SetInsulinScheduleCommand(nonce: 0x12041962, units: 0.05, extendedUnits: 0.10, extendedDuration: .hours(2.0))
+        XCTAssertEqual("1a1012041962020019050010000100013800", bolus_0_15U_65P_ext_120min.data.hexadecimalString)
+
+
+        // 0.20U dual bolus 75% extended over 0.5 hours (1i 3e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 08121964 02 0017 02 0010 0001 0001 0003            17 0d 00 000a 00030d40 001e 03938700
+        let bolus_0_20U_75P_ext_30min = SetInsulinScheduleCommand(nonce: 0x08121964, units: 0.05, extendedUnits: 0.15, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a1008121964020017020010000100010003", bolus_0_20U_75P_ext_30min.data.hexadecimalString)
+
+        // 0.20U dual bolus 75% extended over 1.0 hour (1i 3e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 04111967 02 0018 03 0010 0001 1001 0002            17 0d 00 000a 00030d40 001e 07270e00
+        let bolus_0_20U_75P_ext_60min = SetInsulinScheduleCommand(nonce: 0x04111967, units: 0.05, extendedUnits: 0.15, extendedDuration: .hours(1.0))
+        XCTAssertEqual("1a1004111967020018030010000110010002", bolus_0_20U_75P_ext_60min.data.hexadecimalString)
+
+        // 0.20U dual bolus 75% extended over 1.5 hours (1i 3e) -> only one entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp                 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 0e 09301968 02 0019 04 0010 0001 3001                 17 0d 00 000a 00030d40 001e 0aba9500
+        let bolus_0_20U_75P_ext_90min = SetInsulinScheduleCommand(nonce: 0x09301968, units: 0.05, extendedUnits: 0.15, extendedDuration: .hours(1.5))
+        XCTAssertEqual("1a0e0930196802001904001000013001", bolus_0_20U_75P_ext_90min.data.hexadecimalString)
+
+        // 0.20U dual bolus 75% extended over 2.0 hours (1i 3e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp       17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 12 07271971 02 001a 05 0010 0001 0001 1800 1001       17 0d 00 000a 00030d40 001e 0e4e1c00
+        let bolus_0_20U_75P_ext_120min = SetInsulinScheduleCommand(nonce: 0x07271971, units: 0.05, extendedUnits: 0.15, extendedDuration: .hours(2.0))
+        XCTAssertEqual("1a120727197102001a0500100001000118001001", bolus_0_20U_75P_ext_120min.data.hexadecimalString)
+
+        // 0.20U dual bolus 75% extended over 2.5 hours (1i 3e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp       17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 12 03091975 02 001b 06 0010 0001 0001 3800 0001       17 0d 00 000a 00030d40 001e 11e1a300
+        let bolus_0_20U_75P_ext_150min = SetInsulinScheduleCommand(nonce: 0x03091975, units: 0.05, extendedUnits: 0.15, extendedDuration: .hours(2.5))
+        XCTAssertEqual("1a120309197502001b0600100001000138000001", bolus_0_20U_75P_ext_150min.data.hexadecimalString)
+
+        // 0.20U dual bolus 75% extended over 3.0 hours (1i 3e) -> max duration allowed
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 01242016 02 001c 07 0010 0001 0001 5800            17 0d 00 000a 00030d40 001e 15752a00
+        let bolus_0_20U_75P_ext_180min = SetInsulinScheduleCommand(nonce: 0x01242016, units: 0.05, extendedUnits: 0.15, extendedDuration: .hours(3.0))
+        XCTAssertEqual("1a100124201602001c070010000100015800", bolus_0_20U_75P_ext_180min.data.hexadecimalString)
+
+
+        // 0.25U dual bolus 80% extended over 0.5 hours (1i 4e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp                    17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 03211983 02 0018 02 0010 0001 0001 0004                    17 0d 00 000a 00030d40 0028 02aea540
+        let bolus_0_25U_80P_ext_30min = SetInsulinScheduleCommand(nonce: 0x03211983, units: 0.05, extendedUnits: 0.20, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a1003211983020018020010000100010004", bolus_0_25U_80P_ext_30min.data.hexadecimalString)
+
+        // 0.25U dual bolus 80% extended over 1.0 hour (1i 4e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp                    17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 11041986 02 0019 03 0010 0001 1801 0002                    17 0d 00 000a 00030d40 0028 055d4a80
+        let bolus_0_25U_80P_ext_60min = SetInsulinScheduleCommand(nonce: 0x11041986, units: 0.05, extendedUnits: 0.20, extendedDuration: .hours(1.0))
+        XCTAssertEqual("1a1011041986020019030010000118010002", bolus_0_25U_80P_ext_60min.data.hexadecimalString)
+
+        // 0.25U dual bolus 80% extended over 1.5 hours (1i 4e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp                    17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 05061987 02 001a 04 0010 0001 2001 0002                    17 0d 00 000a 00030d40 0028 080befc0
+        let bolus_0_25U_80P_ext_90min = SetInsulinScheduleCommand(nonce: 0x05061987, units: 0.05, extendedUnits: 0.20, extendedDuration: .hours(1.5))
+        XCTAssertEqual("1a100506198702001a040010000120010002", bolus_0_25U_80P_ext_90min.data.hexadecimalString)
+
+        // 0.25U dual bolus 80% extended over 2.0 hours (1i 4e) -> only one entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp                         17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 0e 10201988 02 001b 05 0010 0001 4001                         17 0d 00 000a 00030d40 0028 0aba9500
+        let bolus_0_25U_80P_ext_120min = SetInsulinScheduleCommand(nonce: 0x10201988, units: 0.05, extendedUnits: 0.20, extendedDuration: .hours(2.0))
+        XCTAssertEqual("1a0e1020198802001b05001000014001", bolus_0_25U_80P_ext_120min.data.hexadecimalString)
+
+        // 0.25U dual bolus 80% extended over 2.5 hours (1i 4e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp               17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 12 07051989 02 001c 06 0010 0001 0001 1800 2001               17 0d 00 000a 00030d40 0028 0d693a40
+        let bolus_0_25U_80P_ext_150min = SetInsulinScheduleCommand(nonce: 0x07051989, units: 0.05, extendedUnits: 0.20, extendedDuration: .hours(2.5))
+        XCTAssertEqual("1a120705198902001c0600100001000118002001", bolus_0_25U_80P_ext_150min.data.hexadecimalString)
+
+        // 0.25U dual bolus 80% extended over 3.0 hours (1i 4e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp napp     17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 16 09061990 02 001d 07 0010 0001 0001 1800 0001 1800 0001     17 0d 00 000a 00030d40 0028 1017df80
+        let bolus_0_25U_80P_ext_180min = SetInsulinScheduleCommand(nonce: 0x09061990, units: 0.05, extendedUnits: 0.20, extendedDuration: .hours(3.0))
+        XCTAssertEqual("1a160906199002001d070010000100011800000118000001", bolus_0_25U_80P_ext_180min.data.hexadecimalString)
+
+        // 0.25U dual bolus 80% extended over 3.5 hours (1i 4e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp               17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 12 09061990 02 001e 08 0010 0001 0001 5800 0001               17 0d 00 000a 00030d40 0028 12c684c0
+        let bolus_0_25U_80P_ext_210min = SetInsulinScheduleCommand(nonce: 0x09061990, units: 0.05, extendedUnits: 0.20, extendedDuration: .hours(3.5))
+        XCTAssertEqual("1a120906199002001e0800100001000158000001", bolus_0_25U_80P_ext_210min.data.hexadecimalString)
+
+        // 0.25U dual bolus 80% extended over 4.0 hours (1i 4e) -> max duration allowed
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp                    17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 01311991 02 001f 09 0010 0001 0001 7800                    17 0d 00 000a 00030d40 0028 15752a00
+        let bolus_0_25U_80P_ext_240min = SetInsulinScheduleCommand(nonce: 0x01311991, units: 0.05, extendedUnits: 0.20, extendedDuration: .hours(4.0))
+        XCTAssertEqual("1a100131199102001f090010000100017800", bolus_0_25U_80P_ext_240min.data.hexadecimalString)
+
+
+        // 0.15U dual bolus 30% extended over 0.5 hours (2i 1e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 05071991 02 0027 02 0020 0002 0002 0001            17 0d 00 0014 00030d40 000a 0aba9500
+        let bolus_0_15U_30P_ext_30min = SetInsulinScheduleCommand(nonce: 0x05071991, units: 0.10, extendedUnits: 0.05, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a1005071991020027020020000200020001", bolus_0_15U_30P_ext_30min.data.hexadecimalString)
+
+        // 0.15U dual bolus 30% extended over 1.0 hour (2i 1e) -> max duration allowed
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 08311995 02 0028 03 0020 0002 0002 1800            17 0d 00 0014 00030d40 000a 15752a00
+        let bolus_0_15U_30P_ext_60min = SetInsulinScheduleCommand(nonce: 0x08311995, units: 0.10, extendedUnits: 0.05, extendedDuration: .hours(1.0))
+        XCTAssertEqual("1a1008311995020028030020000200021800", bolus_0_15U_30P_ext_60min.data.hexadecimalString)
+
+
+        // 0.20U dual bolus 50% extended over 0.5 hours (2i 2e) -> only one entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp                 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 0e 10061995 02 0028 02 0020 0002 1002                 17 0d 00 0014 00030d40 0014 055d4a80
+        let bolus_0_20U_50P_ext_30min = SetInsulinScheduleCommand(nonce: 0x10061995, units: 0.10, extendedUnits: 0.10, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a0e1006199502002802002000021002", bolus_0_20U_50P_ext_30min.data.hexadecimalString)
+
+        // 0.20U dual bolus 50% extended over 1.0 hour (2i 2e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 07132004 02 0029 03 0020 0002 0002 1001            17 0d 00 0014 00030d40 0014 0aba9500
+        let bolus_0_20U_50P_ext_60min = SetInsulinScheduleCommand(nonce: 0x07132004, units: 0.10, extendedUnits: 0.10, extendedDuration: .hours(1.0))
+        XCTAssertEqual("1a1007132004020029030020000200021001", bolus_0_20U_50P_ext_60min.data.hexadecimalString)
+
+        // 0.20U dual bolus 50% extended over 1.5 hours (2i 2e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 12 02192008 02 002a 04 0020 0002 0002 1800 0001       17 0d 00 0014 00030d40 0014 1017df80
+        let bolus_0_20U_50P_ext_90min = SetInsulinScheduleCommand(nonce: 0x02192008, units: 0.10, extendedUnits: 0.10, extendedDuration: .hours(1.5))
+        XCTAssertEqual("1a120219200802002a0400200002000218000001", bolus_0_20U_50P_ext_90min.data.hexadecimalString)
+
+        // 0.20U dual bolus 50% extended over 2.0 hours (2i 2e) -> max duration allowed
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 10092008 02 002b 05 0020 0002 0002 3800            17 0d 00 0014 00030d40 0014 15752a00
+        let bolus_0_20U_50P_ext_120min = SetInsulinScheduleCommand(nonce: 0x10092008, units: 0.10, extendedUnits: 0.10, extendedDuration: .hours(2.0))
+        XCTAssertEqual("1a101009200802002b050020000200023800", bolus_0_20U_50P_ext_120min.data.hexadecimalString)
+
+
+        // 0.25U dual bolus 60% extended over 0.5 hours (2i 3e) -> only one entry
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp                 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 0e 06222009 02 0029 02 0020 0002 1802                 17 0d 00 0014 00030d40 001e 03938700
+        let bolus_0_25U_60P_ext_30min = SetInsulinScheduleCommand(nonce: 0x06222009, units: 0.10, extendedUnits: 0.15, extendedDuration: .hours(0.5))
+        XCTAssertEqual("1a0e0622200902002902002000021802", bolus_0_25U_60P_ext_30min.data.hexadecimalString)
+
+        // 0.25U dual bolus 60% extended over 1.0 hour (2i 3e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 07122009 02 002a 03 0020 0002 0002 1801            17 0d 00 0014 00030d40 001e 07270e00
+        let bolus_0_25U_60P_ext_60min = SetInsulinScheduleCommand(nonce: 0x07122009, units: 0.10, extendedUnits: 0.15, extendedDuration: .hours(1.0))
+        XCTAssertEqual("1a100712200902002a030020000200021801", bolus_0_25U_60P_ext_60min.data.hexadecimalString)
+
+        // 0.25U dual bolus 60% extended over 1.5 hours (2i 3e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 08102009 02 002b 04 0020 0002 0002 2001            17 0d 00 0014 00030d40 001e 0aba9500
+        let bolus_0_25U_60P_ext_90min = SetInsulinScheduleCommand(nonce: 0x08102009, units: 0.10, extendedUnits: 0.15, extendedDuration: .hours(1.5))
+        XCTAssertEqual("1a100810200902002b040020000200022001", bolus_0_25U_60P_ext_90min.data.hexadecimalString)
+
+        // 0.25U dual bolus 60% extended over 2.0 hours (2i 3e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp       17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 12 07162010 02 002c 05 0020 0002 0002 1800 1001       17 0d 00 0014 00030d40 001e 0e4e1c00
+        let bolus_0_25U_60P_ext_120min = SetInsulinScheduleCommand(nonce: 0x07162010, units: 0.10, extendedUnits: 0.15, extendedDuration: .hours(2.0))
+        XCTAssertEqual("1a120716201002002c0500200002000218001001", bolus_0_25U_60P_ext_120min.data.hexadecimalString)
+
+        // 0.25U dual bolus 60% extended over 2.5 hours (2i 3e)
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp       17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 12 08072010 02 002d 06 0020 0002 0002 3800 0001       17 0d 00 0014 00030d40 001e 11e1a300
+        let bolus_0_25U_60P_ext_150min = SetInsulinScheduleCommand(nonce: 0x08072010, units: 0.10, extendedUnits: 0.15, extendedDuration: .hours(2.5))
+        XCTAssertEqual("1a120807201002002d0600200002000238000001", bolus_0_25U_60P_ext_150min.data.hexadecimalString)
+
+        // 0.25U dual bolus 60% extended over 3.0 hours (2i 3e) -> max duration allowed
+        // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp            17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 1a 10 05062012 02 002e 07 0020 0002 0002 5800            17 0d 00 0014 00030d40 001e 15752a00
+        let bolus_0_25U_60P_ext_180min = SetInsulinScheduleCommand(nonce: 0x05062012, units: 0.10, extendedUnits: 0.15, extendedDuration: .hours(3.0))
+        XCTAssertEqual("1a100506201202002e070020000200025800", bolus_0_25U_60P_ext_180min.data.hexadecimalString)
+    }
+
+    func test_30U_100P_ext() {
+        // 30U bolus 100% ext over 0.5 hours (0i 600e)
+        do {
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+            // 1a 10 494e532e 02 005c 02 0000 0000 0000 0258
+            let bolus30U_100P_ext_30min = SetInsulinScheduleCommand(nonce: 0x494e532e, units: 0.0, extendedUnits: 30, extendedDuration: .hours(0.5))
+            XCTAssertEqual("1a10494e532e02005c020000000000000258", bolus30U_100P_ext_30min.data.hexadecimalString)
+
+            let bolus30U_100P_ext_30min_encoded = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: bolus30U_100P_ext_30min.data.hexadecimalString)!)
+            XCTAssertEqual(0x494e532e, bolus30U_100P_ext_30min_encoded.nonce)
+            let schedule = bolus30U_100P_ext_30min_encoded.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(0.0, units)
+                XCTAssertEqual(0, timeBetweenPulses)
+                XCTAssertEqual(2, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(0, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(1, table.entries[1].segments)
+                XCTAssertEqual(600, table.entries[1].pulses)
+                XCTAssertEqual(false, table.entries[1].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 17 0d 00 0000 00030d40 1770 000493e0
+            let bolus30U_100P_ext_30min_extra = BolusExtraCommand(extendedUnits: 30.0, extendedDuration: .hours(0.5))
+            XCTAssertEqual("170d00000000030d401770000493e0", bolus30U_100P_ext_30min_extra.data.hexadecimalString)
+
+            let bolus30U_100P_ext_30min_extra_encoded = try BolusExtraCommand(encodedData: Data(hexadecimalString: bolus30U_100P_ext_30min_extra.data.hexadecimalString)!)
+            XCTAssertEqual(0.0, bolus30U_100P_ext_30min_extra_encoded.units)
+            XCTAssertEqual(false, bolus30U_100P_ext_30min_extra_encoded.acknowledgementBeep)
+            XCTAssertEqual(false, bolus30U_100P_ext_30min_extra_encoded.completionBeep)
+            XCTAssertEqual(0, bolus30U_100P_ext_30min_extra_encoded.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, bolus30U_100P_ext_30min_extra_encoded.timeBetweenPulses)
+            XCTAssertEqual(30.0, bolus30U_100P_ext_30min_extra_encoded.extendedUnits)
+            XCTAssertEqual(.hours(0.5), bolus30U_100P_ext_30min_extra_encoded.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func test_30U_75P_ext() {
+        // 30U bolus 75% ext over 0.5 hours (450i 150e)
+        do {
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+            // 1a 10 494e532e 02 025a 02 0960 0096 0096 01c2
+            let bolus30U_75P_ext_30min = SetInsulinScheduleCommand(nonce: 0x494e532e, units: 7.5, extendedUnits: 22.5, extendedDuration: .hours(0.5))
+            XCTAssertEqual("1a10494e532e02025a0209600096009601c2", bolus30U_75P_ext_30min.data.hexadecimalString)
+
+            let bolus30U_75P_ext_30min_encoded = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: bolus30U_75P_ext_30min.data.hexadecimalString)!)
+            XCTAssertEqual(0x494e532e, bolus30U_75P_ext_30min_encoded.nonce)
+            let schedule = bolus30U_75P_ext_30min_encoded.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(7.5, units)
+                XCTAssertEqual(Pod.secondsPerBolusPulse, timeBetweenPulses)
+                XCTAssertEqual(2, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(150, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(1, table.entries[1].segments)
+                XCTAssertEqual(450, table.entries[1].pulses)
+                XCTAssertEqual(false, table.entries[1].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 17 0d 00 05dc 00030d40 1194 00061a80
+            let bolus30U_75P_ext_30min_extra = BolusExtraCommand(units: 7.5, extendedUnits: 22.5, extendedDuration: .hours(0.5))
+            XCTAssertEqual("170d0005dc00030d40119400061a80", bolus30U_75P_ext_30min_extra.data.hexadecimalString)
+
+            let bolus30U_75P_ext_30min_extra_encoded = try BolusExtraCommand(encodedData: Data(hexadecimalString: bolus30U_75P_ext_30min_extra.data.hexadecimalString)!)
+            XCTAssertEqual(7.5, bolus30U_75P_ext_30min_extra_encoded.units)
+            XCTAssertEqual(false, bolus30U_75P_ext_30min_extra_encoded.acknowledgementBeep)
+            XCTAssertEqual(false, bolus30U_75P_ext_30min_extra_encoded.completionBeep)
+            XCTAssertEqual(0, bolus30U_75P_ext_30min_extra_encoded.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, bolus30U_75P_ext_30min_extra_encoded.timeBetweenPulses)
+            XCTAssertEqual(22.5, bolus30U_75P_ext_30min_extra_encoded.extendedUnits)
+            XCTAssertEqual(.hours(0.5), bolus30U_75P_ext_30min_extra_encoded.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func test_30U_50P_ext() {
+        // 30U bolus 50% ext over 0.5 hours (300i 300e)
+        do {
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp
+            // 1a 0e 494e532e 02 015b 02 12c0 012c 112c
+            let bolus30U_50P_ext_30min = SetInsulinScheduleCommand(nonce: 0x494e532e, units: 15.0, extendedUnits: 15.0, extendedDuration: .hours(0.5))
+            XCTAssertEqual("1a0e494e532e02015b0212c0012c112c", bolus30U_50P_ext_30min.data.hexadecimalString)
+
+            let bolus30U_50P_ext_30min_encoded = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: bolus30U_50P_ext_30min.data.hexadecimalString)!)
+            XCTAssertEqual(0x494e532e, bolus30U_50P_ext_30min_encoded.nonce)
+            let schedule = bolus30U_50P_ext_30min_encoded.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(15.0, units)
+                XCTAssertEqual(Pod.secondsPerBolusPulse, timeBetweenPulses)
+                XCTAssertEqual(1, table.entries.count)
+                XCTAssertEqual(2, table.entries[0].segments)
+                XCTAssertEqual(300, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 17 0d 00 0bb8 00030d40 0bb8 000927c0
+            let bolus30U_50P_ext_30min_extra = BolusExtraCommand(units: 15.0, extendedUnits: 15.0, extendedDuration: .hours(0.5))
+            XCTAssertEqual("170d000bb800030d400bb8000927c0", bolus30U_50P_ext_30min_extra.data.hexadecimalString)
+
+            let bolus30U_50P_ext_30min_extra_encoded = try BolusExtraCommand(encodedData: Data(hexadecimalString: bolus30U_50P_ext_30min_extra.data.hexadecimalString)!)
+            XCTAssertEqual(15.0, bolus30U_50P_ext_30min_extra_encoded.units)
+            XCTAssertEqual(false, bolus30U_50P_ext_30min_extra_encoded.acknowledgementBeep)
+            XCTAssertEqual(false, bolus30U_50P_ext_30min_extra_encoded.completionBeep)
+            XCTAssertEqual(0, bolus30U_50P_ext_30min_extra_encoded.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, bolus30U_50P_ext_30min_extra_encoded.timeBetweenPulses)
+            XCTAssertEqual(15.0, bolus30U_50P_ext_30min_extra_encoded.extendedUnits)
+            XCTAssertEqual(.hours(0.5), bolus30U_50P_ext_30min_extra_encoded.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func test_30U_25P_ext() {
+        // 30U bolus 25% ext over 0.5 hours (450i 150e)
+        do {
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+            // 1a 10 494e532e 02 025a 02 1c20 01c2 01c2 0096
+            let bolus30U_25P_ext_30min = SetInsulinScheduleCommand(nonce: 0x494e532e, units: 22.5, extendedUnits: 7.5, extendedDuration: .hours(0.5))
+            XCTAssertEqual("1a10494e532e02025a021c2001c201c20096", bolus30U_25P_ext_30min.data.hexadecimalString)
+
+            let bolus30U_25P_ext_30min_encoded = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: bolus30U_25P_ext_30min.data.hexadecimalString)!)
+            XCTAssertEqual(0x494e532e, bolus30U_25P_ext_30min_encoded.nonce)
+            let schedule = bolus30U_25P_ext_30min_encoded.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(22.5, units)
+                XCTAssertEqual(Pod.secondsPerBolusPulse, timeBetweenPulses)
+                XCTAssertEqual(2, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(450, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(1, table.entries[1].segments)
+                XCTAssertEqual(150, table.entries[1].pulses)
+                XCTAssertEqual(false, table.entries[1].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 17 0d 00 1194 00030d40 05dc 00124f80
+            let bolus30U_25P_ext_30min_extra = BolusExtraCommand(units: 22.5, extendedUnits: 7.5, extendedDuration: .hours(0.5))
+            XCTAssertEqual("170d00119400030d4005dc00124f80", bolus30U_25P_ext_30min_extra.data.hexadecimalString)
+
+            let bolus30U_25P_ext_30min_extra_encoded = try BolusExtraCommand(encodedData: Data(hexadecimalString: bolus30U_25P_ext_30min_extra.data.hexadecimalString)!)
+            XCTAssertEqual(22.5, bolus30U_25P_ext_30min_extra_encoded.units)
+            XCTAssertEqual(false, bolus30U_25P_ext_30min_extra_encoded.acknowledgementBeep)
+            XCTAssertEqual(false, bolus30U_25P_ext_30min_extra_encoded.completionBeep)
+            XCTAssertEqual(0, bolus30U_25P_ext_30min_extra_encoded.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, bolus30U_25P_ext_30min_extra_encoded.timeBetweenPulses)
+            XCTAssertEqual(7.5, bolus30U_25P_ext_30min_extra_encoded.extendedUnits)
+            XCTAssertEqual(.hours(0.5), bolus30U_25P_ext_30min_extra_encoded.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func test_1U_immediate_9123secs_remaining() {
+        // extended bolus of 1.0U over 3.5 hours
+        // immediate 1.0U bolus with 2:32:05 (9123 seconds) remaining, cancel bolus returns 15 pulses (0.75U) not delivered
+        do {
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp napp napp
+            // 1a 14 d3039c04 02 007f 07 0140 0014 0014 1802 2003 0001
+            let nonce: UInt32 = 0xd3039c04
+            let immediateUnits = 1.0
+            let remainingExtendedUnits = 0.75
+            let remainingExtendedBolusTime: TimeInterval = .seconds(9123)
+
+            let bolus_1U_immediate_9123secs_remaining = SetInsulinScheduleCommand(nonce: nonce, units: immediateUnits, extendedUnits: remainingExtendedUnits, extendedDuration: remainingExtendedBolusTime)
+            XCTAssertEqual("1a14d3039c0402007f07014000140014180220030001", bolus_1U_immediate_9123secs_remaining.data.hexadecimalString)
+
+            let bolus_1U_immediate_9123secs_remaining_encoded = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: bolus_1U_immediate_9123secs_remaining.data.hexadecimalString)!)
+            XCTAssertEqual(nonce, bolus_1U_immediate_9123secs_remaining.nonce)
+            let schedule = bolus_1U_immediate_9123secs_remaining_encoded.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(immediateUnits, units)
+                XCTAssertEqual(Pod.secondsPerBolusPulse, timeBetweenPulses)
+                XCTAssertEqual(4, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(20, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[1].segments)
+                XCTAssertEqual(2, table.entries[1].pulses)
+                XCTAssertEqual(true, table.entries[1].alternateSegmentPulse)
+                XCTAssertEqual(3, table.entries[2].segments)
+                XCTAssertEqual(3, table.entries[2].pulses)
+                XCTAssertEqual(false, table.entries[2].alternateSegmentPulse)
+                XCTAssertEqual(1, table.entries[3].segments)
+                XCTAssertEqual(1, table.entries[3].pulses)
+                XCTAssertEqual(false, table.entries[3].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 17 0d 00 00c8 00030d40 0096 03a00a20
+            let bolus_1U_immediate_9123secs_remaining_extra = BolusExtraCommand(units: immediateUnits, extendedUnits: remainingExtendedUnits, extendedDuration: remainingExtendedBolusTime)
+            XCTAssertEqual("170d0000c800030d40009603a00a20", bolus_1U_immediate_9123secs_remaining_extra.data.hexadecimalString)
+            let bolus_1U_immediate_9123secs_remaining_extra_encoded = try BolusExtraCommand(encodedData: Data(hexadecimalString: bolus_1U_immediate_9123secs_remaining_extra.data.hexadecimalString)!)
+            XCTAssertEqual(immediateUnits, bolus_1U_immediate_9123secs_remaining_extra_encoded.units)
+            XCTAssertEqual(false, bolus_1U_immediate_9123secs_remaining_extra.acknowledgementBeep)
+            XCTAssertEqual(false, bolus_1U_immediate_9123secs_remaining_extra.completionBeep)
+            XCTAssertEqual(0, bolus_1U_immediate_9123secs_remaining_extra_encoded.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, bolus_1U_immediate_9123secs_remaining_extra.timeBetweenPulses)
+            XCTAssertEqual(remainingExtendedUnits, bolus_1U_immediate_9123secs_remaining_extra_encoded.extendedUnits)
+            XCTAssertEqual(remainingExtendedBolusTime, bolus_1U_immediate_9123secs_remaining_extra.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func test_1U_immediate_3363secs_remaining() {
+        // extended bolus of 1.0U over 3.5 hours
+        // immediate 1.0U bolus with 56:03 min (3363 seconds) remaining, cancel bolus returns 6 pulses (0.30U) not delivered
+        do {
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+            // 1a 10 1304de22 02 0072 03 0140 0014 0014 1003
+            let nonce: UInt32 = 0x1304de22
+            let immediateUnits = 1.0
+            let remainingExtendedUnits = 0.3
+            let remainingExtendedBolusTime: TimeInterval = .seconds(3363)
+
+            let bolus_1U_immediate_3363secs_remaining = SetInsulinScheduleCommand(nonce: nonce, units: immediateUnits, extendedUnits: remainingExtendedUnits, extendedDuration: remainingExtendedBolusTime)
+            XCTAssertEqual("1a101304de22020072030140001400141003", bolus_1U_immediate_3363secs_remaining.data.hexadecimalString)
+
+            let bolus_1U_immediate_3363secs_remaining_encoded = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: bolus_1U_immediate_3363secs_remaining.data.hexadecimalString)!)
+            XCTAssertEqual(nonce, bolus_1U_immediate_3363secs_remaining.nonce)
+            let schedule = bolus_1U_immediate_3363secs_remaining_encoded.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(immediateUnits, units)
+                XCTAssertEqual(Pod.secondsPerBolusPulse, timeBetweenPulses)
+                XCTAssertEqual(2, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(20, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(2, table.entries[1].segments)
+                XCTAssertEqual(3, table.entries[1].pulses)
+                XCTAssertEqual(false, table.entries[1].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 17 0d 00 00c8 00030d40 003c 03574150
+            let bolus_1U_immediate_3363secs_remaining_extra = BolusExtraCommand(units: immediateUnits, extendedUnits: remainingExtendedUnits, extendedDuration: remainingExtendedBolusTime)
+            XCTAssertEqual("170d0000c800030d40003c03574150", bolus_1U_immediate_3363secs_remaining_extra.data.hexadecimalString)
+            let bolus_1U_immediate_3363secs_remaining_extra_encoded = try BolusExtraCommand(encodedData: Data(hexadecimalString: bolus_1U_immediate_3363secs_remaining_extra.data.hexadecimalString)!)
+            XCTAssertEqual(immediateUnits, bolus_1U_immediate_3363secs_remaining_extra_encoded.units)
+            XCTAssertEqual(false, bolus_1U_immediate_3363secs_remaining_extra.acknowledgementBeep)
+            XCTAssertEqual(false, bolus_1U_immediate_3363secs_remaining_extra.completionBeep)
+            XCTAssertEqual(0, bolus_1U_immediate_3363secs_remaining_extra_encoded.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, bolus_1U_immediate_3363secs_remaining_extra.timeBetweenPulses)
+            XCTAssertEqual(remainingExtendedUnits, bolus_1U_immediate_3363secs_remaining_extra_encoded.extendedUnits)
+            XCTAssertEqual(remainingExtendedBolusTime, bolus_1U_immediate_3363secs_remaining_extra.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func test_1U_immediate_382secs_remaining() {
+        // extended bolus of 1.0U over 3.5 hours
+        // immediate 1.0U bolus with 6:22 (382 seconds) remaining, cancel bolus returns 1 pulse (0.05U) not delivered
+        do {
+            // 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP napp napp
+            // 1a 10 10bbea5c 02 006c 02 0140 0014 0014 0001
+            let nonce: UInt32 = 0x10bbea5c
+            let immediateUnits = 1.0
+            let remainingExtendedUnits = 0.05
+            let remainingExtendedBolusTime: TimeInterval = .seconds(382)
+
+            let bolus_1U_immediate_382secs_remaining = SetInsulinScheduleCommand(nonce: nonce, units: immediateUnits, extendedUnits: remainingExtendedUnits, extendedDuration: remainingExtendedBolusTime)
+            XCTAssertEqual("1a1010bbea5c02006c020140001400140001", bolus_1U_immediate_382secs_remaining.data.hexadecimalString)
+
+            let bolus_1U_immediate_382secs_remaining_encoded = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: bolus_1U_immediate_382secs_remaining.data.hexadecimalString)!)
+            XCTAssertEqual(nonce, bolus_1U_immediate_382secs_remaining.nonce)
+            let schedule = bolus_1U_immediate_382secs_remaining_encoded.deliverySchedule
+            switch schedule {
+            case .bolus(let units, let timeBetweenPulses, let table):
+                XCTAssertEqual(immediateUnits, units)
+                XCTAssertEqual(Pod.secondsPerBolusPulse, timeBetweenPulses)
+                XCTAssertEqual(2, table.entries.count)
+                XCTAssertEqual(1, table.entries[0].segments)
+                XCTAssertEqual(20, table.entries[0].pulses)
+                XCTAssertEqual(false, table.entries[0].alternateSegmentPulse)
+                XCTAssertEqual(1, table.entries[1].segments)
+                XCTAssertEqual(1, table.entries[1].pulses)
+                XCTAssertEqual(false, table.entries[1].alternateSegmentPulse)
+            default:
+                XCTFail("unexpected insulin delivery type \(schedule)")
+                break
+            }
+
+            // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // 17 0d 00 00c8 00030d40 000a 0246e2c0
+            let bolus_1U_immediate_382secs_remaining_extra = BolusExtraCommand(units: immediateUnits, extendedUnits: remainingExtendedUnits, extendedDuration: remainingExtendedBolusTime)
+            XCTAssertEqual("170d0000c800030d40000a0246e2c0", bolus_1U_immediate_382secs_remaining_extra.data.hexadecimalString)
+            let bolus_1U_immediate_382secs_remaining_extra_encoded = try BolusExtraCommand(encodedData: Data(hexadecimalString: bolus_1U_immediate_382secs_remaining_extra.data.hexadecimalString)!)
+            XCTAssertEqual(immediateUnits, bolus_1U_immediate_382secs_remaining_extra_encoded.units)
+            XCTAssertEqual(false, bolus_1U_immediate_382secs_remaining_extra.acknowledgementBeep)
+            XCTAssertEqual(false, bolus_1U_immediate_382secs_remaining_extra.completionBeep)
+            XCTAssertEqual(0, bolus_1U_immediate_382secs_remaining_extra_encoded.programReminderInterval)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, bolus_1U_immediate_382secs_remaining_extra.timeBetweenPulses)
+            XCTAssertEqual(remainingExtendedUnits, bolus_1U_immediate_382secs_remaining_extra_encoded.extendedUnits)
+            XCTAssertEqual(remainingExtendedBolusTime, bolus_1U_immediate_382secs_remaining_extra.extendedDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
     func testBolusExtraOddPulseCount() {
         // 17 0d 7c 00fa 00030d40 000000000000
         let cmd = BolusExtraCommand(units: 1.25, acknowledgementBeep: false, completionBeep: true, programReminderInterval: .hours(1))
         XCTAssertEqual("170d7c00fa00030d40000000000000", cmd.data.hexadecimalString)
     }
 
-    //    1a 0e NNNNNNNN 02 CCCC HH SSSS 0ppp 0ppp 17 LL RR NNNN XXXXXXXX
-    //    1a 0e 19e4890b 02 0025 01 0020 0002 0002 17 0d 00 001e 00030d40
+    //    1a 0e NNNNNNNN 02 CCCC HH SSSS PPPP 0ppp  17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+    //    1a 0e 19e4890b 02 0025 01 0020 0002 0002  17 0d 00 001e 00030d40 0000 00000000
     //    0ppp = $0002                     -> 2 pulses
     //    NNNN = $001e = 30 (dec) / 10     -> 3 pulses
-    
-
-    // Found in PDM logs: 1a0e243085c802002501002000020002 170d00001400030d40000000000000
     func testBolusAndBolusExtraMatch() {
-        let bolusAmount = 0.1
-        
-        // 1a 0e NNNNNNNN 02 CCCC HH SSSS 0ppp 0ppp
+        // 1a 0e NNNNNNNN 02 CCCC HH SSSS PPPP 0ppp
         // 1a 0e 243085c8 02 0025 01 0020 0002 0002
-        let timeBetweenPulses = TimeInterval(seconds: 2)
-        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: bolusAmount, timeBetweenPulses: timeBetweenPulses)
-        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x243085c8, deliverySchedule: scheduleEntry)
+        let bolusAmount = 0.1
+        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x243085c8, units: bolusAmount)
         XCTAssertEqual("1a0e243085c802002501002000020002", bolusCommand.data.hexadecimalString)
 
-        // 17 LL RR NNNN XXXXXXXX
-        // 17 0d 00 0014 00030d40 000000000000
+        // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 17 0d 00 0014 00030d40 0000 00000000
         let bolusExtraCommand = BolusExtraCommand(units: bolusAmount)
         XCTAssertEqual("170d00001400030d40000000000000", bolusExtraCommand.data.hexadecimalString)
     }
 
     func testBolusAndBolusExtraMatch2() {
         let bolusAmount = 0.15
-        let timeBetweenPulses = TimeInterval(seconds: 2)
-        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: bolusAmount, timeBetweenPulses: timeBetweenPulses)
-        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x243085c8, deliverySchedule: scheduleEntry)
+        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x243085c8, units: bolusAmount)
         XCTAssertEqual("1a0e243085c802003701003000030003", bolusCommand.data.hexadecimalString)
         
         let bolusExtraCommand = BolusExtraCommand(units: bolusAmount)
@@ -105,9 +928,7 @@ class BolusTests: XCTestCase {
     
     func testLargeBolus() {
         let bolusAmount = 29.95
-        let timeBetweenPulses = TimeInterval(seconds: 2)
-        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: bolusAmount, timeBetweenPulses: timeBetweenPulses)
-        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x31204ba7, deliverySchedule: scheduleEntry)
+        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x31204ba7, units: bolusAmount)
         XCTAssertEqual("1a0e31204ba702014801257002570257", bolusCommand.data.hexadecimalString)
         
         let bolusExtraCommand = BolusExtraCommand(units: bolusAmount, acknowledgementBeep: false, completionBeep: true, programReminderInterval: .hours(1))
@@ -115,22 +936,19 @@ class BolusTests: XCTestCase {
     }
     
     func testOddBolus() {
-        // 1a 0e NNNNNNNN 02 CCCC HH SSSS 0ppp 0ppp
+        // 1a 0e NNNNNNNN 02 CCCC HH SSSS PPPP 0ppp
         // 1a 0e cf9e81ac 02 00e5 01 0290 0029 0029
 
         let bolusAmount = 2.05
-        let timeBetweenPulses = TimeInterval(seconds: 2)
-        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: bolusAmount, timeBetweenPulses: timeBetweenPulses)
-        let bolusCommand = SetInsulinScheduleCommand(nonce: 0xcf9e81ac, deliverySchedule: scheduleEntry)
+        let bolusCommand = SetInsulinScheduleCommand(nonce: 0xcf9e81ac, units: bolusAmount)
         XCTAssertEqual("1a0ecf9e81ac0200e501029000290029", bolusCommand.data.hexadecimalString)
         
-        // 17 LL RR NNNN XXXXXXXX
+        // 17 LL BO NNNN XXXXXXXX YYYY ZZZZZZZZ
         // 17 0d 3c 019a 00030d40 0000 00000000
         let bolusExtraCommand = BolusExtraCommand(units: bolusAmount, acknowledgementBeep: false, completionBeep: false, programReminderInterval: .hours(1))
         XCTAssertEqual("170d3c019a00030d40000000000000", bolusExtraCommand.data.hexadecimalString)
     }
 
-    
     func testCancelBolusCommand() {
         do {
             // Decode 1f 05 4d91f8ff 64

--- a/OmniKitTests/PodCommsSessionTests.swift
+++ b/OmniKitTests/PodCommsSessionTests.swift
@@ -42,9 +42,8 @@ class PodCommsSessionTests: XCTestCase {
         let session = PodCommsSession(podState: podState, transport: mockTransport, delegate: self)
 
 
-        // 2018-05-26T09:11:07.984983 pdm Message(1f16b11e seq:05 [SetInsulinScheduleCommand(nonce:2232447658, bolus(units: 1.0, timeBetweenPulses: 2.0)), OmniKitPacketParser.BolusExtraCommand(blockType: OmniKitPacketParser.MessageBlockType.bolusExtra, completionBeep: false, programReminderInterval: 0.0, units: 1.0, timeBetweenPulses: 2.0, squareWaveUnits: 0.0, squareWaveDuration: 0.0)])
-        let bolusDelivery = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: 1.0, timeBetweenPulses: 2.0)
-        let sentCommand = SetInsulinScheduleCommand(nonce: 2232447658, deliverySchedule: bolusDelivery)
+        // 2018-05-26T09:11:07.984983 pdm Message(1f16b11e seq:05 [SetInsulinScheduleCommand(nonce:2232447658, bolus(units: 1.0, timeBetweenPulses: 2.0)), OmniKitPacketParser.BolusExtraCommand(blockType: OmniKitPacketParser.MessageBlockType.bolusExtra, completionBeep: false, programReminderInterval: 0.0, units: 1.0, timeBetweenPulses: 2.0, extendedUnits: 0.0, extendedDuration: 0.0)])
+        let sentCommand = SetInsulinScheduleCommand(nonce: 2232447658, units: 1.0)
 
         do {
             let status: StatusResponse = try session.send([sentCommand])

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -656,6 +656,8 @@
 		D807D7D82289135D006BCDF0 /* BeepType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D807D7D72289135D006BCDF0 /* BeepType.swift */; };
 		D807D7DA228913EC006BCDF0 /* BeepConfigCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = D807D7D9228913EC006BCDF0 /* BeepConfigCommand.swift */; };
 		D82B0D19287D44C2009F3709 /* DetailedStatus+OmniKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82B0D18287D44C2009F3709 /* DetailedStatus+OmniKit.swift */; };
+		D897B06729347AC000FDB009 /* BolusDeliveryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D897B06629347AC000FDB009 /* BolusDeliveryTable.swift */; };
+		D897B06929347B1000FDB009 /* InsulinTableEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D897B06829347B1000FDB009 /* InsulinTableEntry.swift */; };
 		E95D0660215D76E40072157B /* PodInfoPulseLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E95D065F215D76E40072157B /* PodInfoPulseLog.swift */; };
 		E9C06B262150371700B602AD /* PodInfoConfiguredAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C06B252150371700B602AD /* PodInfoConfiguredAlerts.swift */; };
 		E9C06B2821506A9200B602AD /* AcknowledgeAlertsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C06B2721506A9200B602AD /* AcknowledgeAlertsTests.swift */; };
@@ -1670,6 +1672,8 @@
 		D807D7D72289135D006BCDF0 /* BeepType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeepType.swift; sourceTree = "<group>"; };
 		D807D7D9228913EC006BCDF0 /* BeepConfigCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeepConfigCommand.swift; sourceTree = "<group>"; };
 		D82B0D18287D44C2009F3709 /* DetailedStatus+OmniKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DetailedStatus+OmniKit.swift"; sourceTree = "<group>"; };
+		D897B06629347AC000FDB009 /* BolusDeliveryTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusDeliveryTable.swift; sourceTree = "<group>"; };
+		D897B06829347B1000FDB009 /* InsulinTableEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsulinTableEntry.swift; sourceTree = "<group>"; };
 		E95D065F215D76E40072157B /* PodInfoPulseLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodInfoPulseLog.swift; sourceTree = "<group>"; };
 		E9C06B252150371700B602AD /* PodInfoConfiguredAlerts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodInfoConfiguredAlerts.swift; sourceTree = "<group>"; };
 		E9C06B2721506A9200B602AD /* AcknowledgeAlertsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgeAlertsTests.swift; sourceTree = "<group>"; };
@@ -2456,8 +2460,10 @@
 				C1FFAF9F213323E800C50C1D /* BasalSchedule.swift */,
 				C1C9F88F283D94CE00CFC769 /* BeepPreference.swift */,
 				D807D7D72289135D006BCDF0 /* BeepType.swift */,
+				D897B06629347AC000FDB009 /* BolusDeliveryTable.swift */,
 				C1FFAF9E213323E700C50C1D /* CRC16.swift */,
 				C13FD2F3215E7338005FC495 /* FaultEventCode.swift */,
+				D897B06829347B1000FDB009 /* InsulinTableEntry.swift */,
 				C1FFAF9C213323E700C50C1D /* Message.swift */,
 				C1FFAFA3213323E800C50C1D /* MessageBlocks */,
 				C1328AF0284A94E00096C110 /* PendingCommand.swift */,
@@ -4178,6 +4184,7 @@
 				C1328AEE284A825E0096C110 /* PumpManagerAlert.swift in Sources */,
 				E9E54AB62156B2D500E319B8 /* PodInfoPulseLogPlus.swift in Sources */,
 				C13BD643214033E5006D7F19 /* UnfinalizedDose.swift in Sources */,
+				D897B06929347B1000FDB009 /* InsulinTableEntry.swift in Sources */,
 				C1FFAFD1213323E900C50C1D /* ConfigureAlertsCommand.swift in Sources */,
 				C1FFAFBE213323E900C50C1D /* CRC16.swift in Sources */,
 				D807D7DA228913EC006BCDF0 /* BeepConfigCommand.swift in Sources */,
@@ -4194,6 +4201,7 @@
 				C1CB13A521383F1E00F9EEDA /* LocalizedString.swift in Sources */,
 				C13FD2F4215E7338005FC495 /* FaultEventCode.swift in Sources */,
 				C1FFAFBF213323E900C50C1D /* BasalSchedule.swift in Sources */,
+				D897B06729347AC000FDB009 /* BolusDeliveryTable.swift in Sources */,
 				C1BB12B421CB5697009A29B5 /* Packet+RFPacket.swift in Sources */,
 				E9C06B2A21506BF300B602AD /* AcknowledgeAlertCommand.swift in Sources */,
 				C1FFAFC9213323E900C50C1D /* StatusResponse.swift in Sources */,


### PR DESCRIPTION
+ Fix intervalCounts offset in bolus extra command for extended bolus
+ Fix timeBetweenExtendedPulses calculation in bolus extra command
+ Separate out & rename BasalTableEntry to shared InsulinTableEntry
+ Add BolusDeliveryTable which handles both immediate & extended boluses
+ Generalize DeliverySchedule enum for bolus to use BolusDeliveryTable
+ Update DeliveryStatus enum to handle extended bolus delivery state
+ Simplied SetInsulinScheduleCommand init with extended bolus support
+ Remove unused SetInsulinScheduleCommand calculateChecksum func
+ Much expanded & improved unit tests for various bolus situations