### PR TITLE
Display MDT battery

### DIFF
--- a/MinimedKitUI/Views/MinimedPumpSettingsView.swift
+++ b/MinimedKitUI/Views/MinimedPumpSettingsView.swift
@@ -147,6 +147,15 @@ struct MinimedPumpSettingsView: View {
 
             Section() {
                 HStack {
+                    Text(LocalizedString("Pump Battery Remaining", comment: "Text for medtronic pump battery percent remaining")).foregroundColor(Color.primary)
+                    Spacer()
+                    if let chargeRemaining = viewModel.pumpManager.status.pumpBatteryChargeRemaining {
+                        Text(String("\(Int(round(chargeRemaining * 100)))%"))
+                    } else {
+                        Text(String(LocalizedString("unknown", comment: "Text to indicate battery percentage is unknown")))
+                    }
+                }
+                HStack {
                     Text(LocalizedString("Pump Time", comment: "The title of the command to change pump time zone"))
                     Spacer()
                     if viewModel.isClockOffset {
@@ -175,15 +184,6 @@ struct MinimedPumpSettingsView: View {
                 }
             }
 
-            HStack {
-                Text(LocalizedString("Pump Battery Remaining", comment: "Text for medtronic pump battery percent remaining")).foregroundColor(Color.primary)
-                Spacer()
-                if let chargeRemaining = viewModel.pumpManager.status.pumpBatteryChargeRemaining {
-                    Text(String("\(Int(round(chargeRemaining * 100)))%"))
-                } else {
-                    Text(String(LocalizedString("unknown", comment: "Text to indicate battery percentage is unknown")))
-                }
-            }
 
             Section {
                 LabeledValueView(label: LocalizedString("Pump ID", comment: "The title text for the pump ID config value"),

--- a/MinimedKitUI/Views/MinimedPumpSettingsView.swift
+++ b/MinimedKitUI/Views/MinimedPumpSettingsView.swift
@@ -85,6 +85,16 @@ struct MinimedPumpSettingsView: View {
                     }
                 }
 
+                HStack {
+                    Text("Pump Battery Remaining").foregroundColor(Color.primary)
+                    Spacer()
+                    if let chargeRemaining = viewModel.pumpManager.status.pumpBatteryChargeRemaining {
+                        Text(String("\(Int(round(chargeRemaining * 100)))%"))
+                    } else {
+                        Text(String("unknown"))
+                    }
+                }
+
                 NavigationLink(destination: DataSourceSelectionView(batteryType: $viewModel.preferredDataSource)) {
                     HStack {
                         Text("Preferred Data Source").foregroundColor(Color.primary)

--- a/MinimedKitUI/Views/MinimedPumpSettingsView.swift
+++ b/MinimedKitUI/Views/MinimedPumpSettingsView.swift
@@ -358,7 +358,7 @@ struct MinimedPumpSettingsView: View {
             ActionSheet(
                 title: Text(LocalizedString("Are you sure you want to delete this Pump?", comment: "Text to confirm delete this pump")),
                 buttons: [
-                    .destructive(Text(LocalizedString("Delete Pump"), comment: "Text to delete pump")) {
+                    .destructive(Text(LocalizedString("Delete Pump", comment: "Text to delete pump"))) {
                         viewModel.deletePump()
                     },
                     .cancel(),

--- a/MinimedKitUI/Views/MinimedPumpSettingsView.swift
+++ b/MinimedKitUI/Views/MinimedPumpSettingsView.swift
@@ -85,16 +85,6 @@ struct MinimedPumpSettingsView: View {
                     }
                 }
 
-                HStack {
-                    Text(LocalizedString("Pump Battery Remaining", comment: "Text for medtronic pump battery percent remaining")).foregroundColor(Color.primary)
-                    Spacer()
-                    if let chargeRemaining = viewModel.pumpManager.status.pumpBatteryChargeRemaining {
-                        Text(String("\(Int(round(chargeRemaining * 100)))%"))
-                    } else {
-                        Text(String(LocalizedString("unknown", comment: "Text to indicate battery percentage is unknown")))
-                    }
-                }
-
                 NavigationLink(destination: DataSourceSelectionView(batteryType: $viewModel.preferredDataSource)) {
                     HStack {
                         Text(LocalizedString("Preferred Data Source", comment: "Text for medtronic pump preferred data source")).foregroundColor(Color.primary)
@@ -185,6 +175,15 @@ struct MinimedPumpSettingsView: View {
                 }
             }
 
+            HStack {
+                Text(LocalizedString("Pump Battery Remaining", comment: "Text for medtronic pump battery percent remaining")).foregroundColor(Color.primary)
+                Spacer()
+                if let chargeRemaining = viewModel.pumpManager.status.pumpBatteryChargeRemaining {
+                    Text(String("\(Int(round(chargeRemaining * 100)))%"))
+                } else {
+                    Text(String(LocalizedString("unknown", comment: "Text to indicate battery percentage is unknown")))
+                }
+            }
 
             Section {
                 LabeledValueView(label: LocalizedString("Pump ID", comment: "The title text for the pump ID config value"),

--- a/MinimedKitUI/Views/MinimedPumpSettingsView.swift
+++ b/MinimedKitUI/Views/MinimedPumpSettingsView.swift
@@ -78,7 +78,7 @@ struct MinimedPumpSettingsView: View {
                 }
                 NavigationLink(destination: BatteryTypeSelectionView(batteryType: $viewModel.batteryChemistryType)) {
                     HStack {
-                        Text("Pump Battery Type").foregroundColor(Color.primary)
+                        Text(LocalizedString("Pump Battery Type", comment: "Text for medtronic pump battery type")).foregroundColor(Color.primary)
                         Spacer()
                         Text(viewModel.batteryChemistryType.description)
                             .foregroundColor(.secondary)
@@ -86,18 +86,18 @@ struct MinimedPumpSettingsView: View {
                 }
 
                 HStack {
-                    Text("Pump Battery Remaining").foregroundColor(Color.primary)
+                    Text(LocalizedString("Pump Battery Remaining", comment: "Text for medtronic pump battery percent remaining")).foregroundColor(Color.primary)
                     Spacer()
                     if let chargeRemaining = viewModel.pumpManager.status.pumpBatteryChargeRemaining {
                         Text(String("\(Int(round(chargeRemaining * 100)))%"))
                     } else {
-                        Text(String("unknown"))
+                        Text(String(LocalizedString("unknown", comment: "Text to indicate battery percentage is unknown")))
                     }
                 }
 
                 NavigationLink(destination: DataSourceSelectionView(batteryType: $viewModel.preferredDataSource)) {
                     HStack {
-                        Text("Preferred Data Source").foregroundColor(Color.primary)
+                        Text(LocalizedString("Preferred Data Source", comment: "Text for medtronic pump preferred data source")).foregroundColor(Color.primary)
                         Spacer()
                         Text(viewModel.preferredDataSource.description)
                             .foregroundColor(.secondary)
@@ -107,7 +107,7 @@ struct MinimedPumpSettingsView: View {
                 if viewModel.pumpManager.state.pumpModel.hasMySentry {
                     NavigationLink(destination: UseMySentrySelectionView(mySentryConfig: $viewModel.mySentryConfig)) {
                         HStack {
-                            Text("Use MySentry").foregroundColor(Color.primary)
+                            Text(LocalizedString("Use MySentry", comment: "Text for medtronic pump to use MySentry")).foregroundColor(Color.primary)
                             Spacer()
                             Text((viewModel.mySentryConfig == .useMySentry ?
                                   LocalizedString("Yes", comment: "Value string for MySentry config when MySentry is being used") :
@@ -356,9 +356,9 @@ struct MinimedPumpSettingsView: View {
                 .foregroundColor(.red)
         }).actionSheet(isPresented: $showingDeletionSheet) {
             ActionSheet(
-                title: Text("Are you sure you want to delete this Pump?"),
+                title: Text(LocalizedString("Are you sure you want to delete this Pump?", comment: "Text to confirm delete this pump")),
                 buttons: [
-                    .destructive(Text("Delete Pump")) {
+                    .destructive(Text(LocalizedString("Delete Pump"), comment: "Text to delete pump")) {
                         viewModel.deletePump()
                     },
                     .cancel(),


### PR DESCRIPTION
This adds the pumpManager.status.pumpBatteryChargeRemaining to the Medtronic Pump Display as percent.

Also updated a few places where Text() instead of Text(LocalizedStrings()) was used.

![MDT-display-with-battery-percent](https://user-images.githubusercontent.com/19607791/219190440-0d227f12-8e27-4abb-bbbd-2517e6c8feed.jpeg)
