### PR TITLE
Use secondary color for Deactivate button on cannula insert failure

### DIFF
--- a/OmniKitUI/Views/InsertCannulaView.swift
+++ b/OmniKitUI/Views/InsertCannulaView.swift
@@ -59,7 +59,7 @@ struct InsertCannulaView: View {
                     }) {
                         Text(LocalizedString("Deactivate Pod", comment: "Button text for deactivate pod button"))
                             .accessibility(identifier: "button_deactivate_pod")
-                            .actionButtonStyle(.destructive)
+                            .actionButtonStyle(.secondary)
                     }
                     .disabled(self.viewModel.state.isProcessing)
                 }


### PR DESCRIPTION
I tested that this built, but I did not test with an Eros pod.