### PR TITLE
Fix handling of bolus that finished earlier than expected.

### DIFF
--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -192,6 +192,12 @@ public class PodCommsSession {
     private unowned let delegate: PodCommsSessionDelegate
     private var transport: MessageTransport
 
+    // used for testing
+    var mockCurrentDate: Date?
+    var currentDate: Date {
+        return mockCurrentDate ?? Date()
+    }
+
     init(podState: PodState, transport: MessageTransport, delegate: PodCommsSessionDelegate) {
         self.podState = podState
         self.transport = transport
@@ -204,7 +210,7 @@ public class PodCommsSession {
         if podState.fault == nil {
             podState.fault = fault // save the first fault returned
             if let activatedAt = podState.activatedAt {
-                podState.activeTime = Date().timeIntervalSince(activatedAt)
+                podState.activeTime = currentDate.timeIntervalSince(activatedAt)
             } else {
                 podState.activeTime = fault.faultEventTimeSinceActivation
             }
@@ -213,7 +219,7 @@ public class PodCommsSession {
             if podState.unacknowledgedCommand != nil {
                 recoverUnacknowledgedCommand(using: derivedStatusResponse)
             }
-            podState.updateFromStatusResponse(derivedStatusResponse)
+            podState.updateFromStatusResponse(derivedStatusResponse, at: currentDate)
         }
         log.error("Pod Fault: %@", String(describing: fault))
     }
@@ -337,7 +343,7 @@ public class PodCommsSession {
         } else {
             // Not the first time through, check to see if prime bolus was successfully started
             let status: StatusResponse = try send([GetStatusCommand()])
-            podState.updateFromStatusResponse(status)
+            podState.updateFromStatusResponse(status, at: currentDate)
             if status.podProgressStatus == .priming || status.podProgressStatus == .primingCompleted {
                 podState.setupProgress = .priming
                 return podState.primeFinishTime?.timeIntervalSinceNow ?? primeDuration
@@ -346,7 +352,7 @@ public class PodCommsSession {
 
         // Mark Pod.primeUnits (2.6U) bolus delivery with Pod.primeDeliveryRate (1) between pulses for prime
 
-        let primeFinishTime = Date() + primeDuration
+        let primeFinishTime = currentDate + primeDuration
         podState.primeFinishTime = primeFinishTime
         podState.setupProgress = .startingPrime
 
@@ -354,7 +360,7 @@ public class PodCommsSession {
         let scheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, units: Pod.primeUnits, timeBetweenPulses: timeBetweenPulses)
         let bolusExtraCommand = BolusExtraCommand(units: Pod.primeUnits, timeBetweenPulses: timeBetweenPulses)
         let status: StatusResponse = try send([scheduleCommand, bolusExtraCommand])
-        podState.updateFromStatusResponse(status)
+        podState.updateFromStatusResponse(status, at: currentDate)
         podState.setupProgress = .priming
         return primeFinishTime.timeIntervalSinceNow
     }
@@ -363,10 +369,10 @@ public class PodCommsSession {
         if podState.setupProgress == .settingInitialBasalSchedule {
             // We started basal schedule programming, but didn't get confirmation somehow, so check status
             let status: StatusResponse = try send([GetStatusCommand()])
-            podState.updateFromStatusResponse(status)
+            podState.updateFromStatusResponse(status, at: currentDate)
             if status.podProgressStatus == .basalInitialized {
                 podState.setupProgress = .initialBasalScheduleSet
-                podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: Date(), scheduledCertainty: .certain, insulinType: podState.insulinType))
+                podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .certain, insulinType: podState.insulinType))
                 return
             }
         }
@@ -375,7 +381,7 @@ public class PodCommsSession {
         // Set basal schedule
         let _ = try setBasalSchedule(schedule: basalSchedule, scheduleOffset: scheduleOffset)
         podState.setupProgress = .initialBasalScheduleSet
-        podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: Date(), scheduledCertainty: .certain, insulinType: podState.insulinType))
+        podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .certain, insulinType: podState.insulinType))
     }
 
     @discardableResult
@@ -386,7 +392,7 @@ public class PodCommsSession {
         for alert in alerts {
             podState.registerConfiguredAlert(slot: alert.configuration.slot, alert: alert)
         }
-        podState.updateFromStatusResponse(status)
+        podState.updateFromStatusResponse(status, at: currentDate)
         return status
     }
 
@@ -400,7 +406,7 @@ public class PodCommsSession {
         let beepConfigCommand = BeepConfigCommand(beepType: beepType, tempBasalCompletionBeep: tempBasalCompletionBeep, bolusCompletionBeep: bolusCompletionBeep)
         do {
             let statusResponse: StatusResponse = try send([beepConfigCommand])
-            podState.updateFromStatusResponse(statusResponse)
+            podState.updateFromStatusResponse(statusResponse, at: currentDate)
             return .success(statusResponse)
         } catch let error {
             return .failure(error)
@@ -428,15 +434,15 @@ public class PodCommsSession {
             let status: StatusResponse = try send([GetStatusCommand()])
             if status.podProgressStatus == .insertingCannula {
                 podState.setupProgress = .cannulaInserting
-                podState.updateFromStatusResponse(status)
+                podState.updateFromStatusResponse(status, at: currentDate)
                 return insertionWait // Not sure when it started, wait full time to be sure
             }
             if status.podProgressStatus.readyForDelivery {
                 markSetupProgressCompleted(statusResponse: status)
-                podState.updateFromStatusResponse(status)
+                podState.updateFromStatusResponse(status, at: currentDate)
                 return TimeInterval(0) // Already done; no need to wait
             }
-            podState.updateFromStatusResponse(status)
+            podState.updateFromStatusResponse(status, at: currentDate)
         } else {
             // Configure all the non-optional Pod Alarms
             let expirationTime = activatedAt + Pod.nominalPodLife
@@ -455,7 +461,7 @@ public class PodCommsSession {
         podState.setupProgress = .startingInsertCannula
         let bolusExtraCommand = BolusExtraCommand(units: cannulaInsertionUnits, timeBetweenPulses: timeBetweenPulses)
         let status2: StatusResponse = try send([bolusScheduleCommand, bolusExtraCommand])
-        podState.updateFromStatusResponse(status2)
+        podState.updateFromStatusResponse(status2, at: currentDate)
 
         podState.setupProgress = .cannulaInserting
         return insertionWait
@@ -467,7 +473,7 @@ public class PodCommsSession {
             if response.podProgressStatus.readyForDelivery {
                 markSetupProgressCompleted(statusResponse: response)
             }
-            podState.updateFromStatusResponse(response)
+            podState.updateFromStatusResponse(response, at: currentDate)
         }
     }
 
@@ -497,7 +503,7 @@ public class PodCommsSession {
         if podState.unfinalizedBolus != nil {
             var ongoingBolus = true
             if let statusResponse: StatusResponse = try? send([GetStatusCommand()]) {
-                podState.updateFromStatusResponse(statusResponse)
+                podState.updateFromStatusResponse(statusResponse, at: currentDate)
                 ongoingBolus = podState.unfinalizedBolus != nil
             }
             guard !ongoingBolus else {
@@ -507,11 +513,11 @@ public class PodCommsSession {
 
         let bolusExtraCommand = BolusExtraCommand(units: units, timeBetweenPulses: timeBetweenPulses, extendedUnits: extendedUnits, extendedDuration: extendedDuration, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep, programReminderInterval: programReminderInterval)
         do {
-            podState.unacknowledgedCommand = PendingCommand.program(.bolus(volume: units, automatic: automatic), transport.messageNumber, Date())
+            podState.unacknowledgedCommand = PendingCommand.program(.bolus(volume: units, automatic: automatic), transport.messageNumber, currentDate)
             let statusResponse: StatusResponse = try send([bolusScheduleCommand, bolusExtraCommand])
             podState.unacknowledgedCommand = nil
-            podState.unfinalizedBolus = UnfinalizedDose(bolusAmount: units, startTime: Date(), scheduledCertainty: .certain, insulinType: podState.insulinType, automatic: automatic)
-            podState.updateFromStatusResponse(statusResponse)
+            podState.unfinalizedBolus = UnfinalizedDose(bolusAmount: units, startTime: currentDate, scheduledCertainty: .certain, insulinType: podState.insulinType, automatic: automatic)
+            podState.updateFromStatusResponse(statusResponse, at: currentDate)
             return DeliveryCommandResult.success(statusResponse: statusResponse)
         } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
             podState.unacknowledgedCommand = podState.unacknowledgedCommand?.commsFinished
@@ -536,14 +542,14 @@ public class PodCommsSession {
             return DeliveryCommandResult.certainFailure(error: .unfinalizedBolus)
         }
 
-        let startTime = Date()
+        let startTime = currentDate
 
         do {
             podState.unacknowledgedCommand = PendingCommand.program(.tempBasal(unitsPerHour: rate, duration: duration, isHighTemp: isHighTemp, automatic: automatic), transport.messageNumber, startTime)
             let status: StatusResponse = try send([tempBasalCommand, tempBasalExtraCommand])
             podState.unacknowledgedCommand = nil
             podState.unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: rate, startTime: startTime, duration: duration, isHighTemp: isHighTemp, automatic: automatic, scheduledCertainty: .certain, insulinType: podState.insulinType)
-            podState.updateFromStatusResponse(status)
+            podState.updateFromStatusResponse(status, at: currentDate)
             return DeliveryCommandResult.success(statusResponse: status)
         } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
             podState.unacknowledgedCommand = podState.unacknowledgedCommand?.commsFinished
@@ -558,7 +564,7 @@ public class PodCommsSession {
     @discardableResult
     private func handleCancelDosing(deliveryType: CancelDeliveryCommand.DeliveryType, bolusNotDelivered: Double) -> UnfinalizedDose? {
         var canceledDose: UnfinalizedDose? = nil
-        let now = Date()
+        let now = currentDate
 
         if deliveryType.contains(.basal) {
             podState.unfinalizedSuspend = UnfinalizedDose(suspendStartTime: now, scheduledCertainty: .certain)
@@ -631,11 +637,11 @@ public class PodCommsSession {
                 commandsToSend += [configureAlerts]
             }
 
-            podState.unacknowledgedCommand = PendingCommand.stopProgram(.all, transport.messageNumber, Date())
+            podState.unacknowledgedCommand = PendingCommand.stopProgram(.all, transport.messageNumber, currentDate)
             let status: StatusResponse = try send(commandsToSend, beepBlock: beepBlock)
             podState.unacknowledgedCommand = nil
             let canceledDose = handleCancelDosing(deliveryType: .all, bolusNotDelivered: status.bolusNotDelivered)
-            podState.updateFromStatusResponse(status)
+            podState.updateFromStatusResponse(status, at: currentDate)
 
             if let alert = podSuspendedReminderAlert {
                 podState.registerConfiguredAlert(slot: alert.configuration.slot, alert: alert)
@@ -680,13 +686,13 @@ public class PodCommsSession {
         }
 
         do {
-            podState.unacknowledgedCommand = PendingCommand.stopProgram(deliveryType, transport.messageNumber, Date())
+            podState.unacknowledgedCommand = PendingCommand.stopProgram(deliveryType, transport.messageNumber, currentDate)
             let cancelDeliveryCommand = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: deliveryType, beepType: beepType)
             let status: StatusResponse = try send([cancelDeliveryCommand], beepBlock: beepBlock)
             podState.unacknowledgedCommand = nil
 
             let canceledDose = handleCancelDosing(deliveryType: deliveryType, bolusNotDelivered: status.bolusNotDelivered)
-            podState.updateFromStatusResponse(status)
+            podState.updateFromStatusResponse(status, at: currentDate)
 
             return CancelDeliveryResult.success(statusResponse: status, canceledDose: canceledDose)
         } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
@@ -728,7 +734,7 @@ public class PodCommsSession {
 
         do {
             var status: StatusResponse = try send([basalScheduleCommand, basalExtraCommand])
-            let now = Date()
+            let now = currentDate
             podState.suspendState = .resumed(now)
             podState.unfinalizedResume = UnfinalizedDose(resumeStartTime: now, scheduledCertainty: .certain, insulinType: podState.insulinType)
             if hasActiveSuspendAlert(configuredAlerts: podState.configuredAlerts),
@@ -736,14 +742,14 @@ public class PodCommsSession {
             {
                 status = cancelStatus // update using the latest status
             }
-            podState.updateFromStatusResponse(status)
+            podState.updateFromStatusResponse(status, at: currentDate)
             return status
         } catch PodCommsError.nonceResyncFailed {
             throw PodCommsError.nonceResyncFailed
         } catch PodCommsError.rejectedMessage(let errorCode) {
             throw PodCommsError.rejectedMessage(errorCode: errorCode)
         } catch let error {
-            podState.unfinalizedResume = UnfinalizedDose(resumeStartTime: Date(), scheduledCertainty: .uncertain, insulinType: podState.insulinType)
+            podState.unfinalizedResume = UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .uncertain, insulinType: podState.insulinType)
             throw error
         }
     }
@@ -757,7 +763,7 @@ public class PodCommsSession {
 
         let status = try setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, programReminderInterval: programReminderInterval)
 
-        podState.suspendState = .resumed(Date())
+        podState.suspendState = .resumed(currentDate)
 
         return status
     }
@@ -777,7 +783,7 @@ public class PodCommsSession {
         case .success(let response, _):
             statusResponse = response
         }
-        podState.updateFromStatusResponse(statusResponse)
+        podState.updateFromStatusResponse(statusResponse, at: currentDate)
         return statusResponse
     }
 
@@ -789,7 +795,7 @@ public class PodCommsSession {
         if podState.unacknowledgedCommand != nil {
             recoverUnacknowledgedCommand(using: statusResponse)
         }
-        podState.updateFromStatusResponse(statusResponse)
+        podState.updateFromStatusResponse(statusResponse, at: currentDate)
         return statusResponse
     }
 
@@ -808,7 +814,7 @@ public class PodCommsSession {
             if podState.unacknowledgedCommand != nil {
                 recoverUnacknowledgedCommand(using: derivedStatusResponse)
             }
-            podState.updateFromStatusResponse(derivedStatusResponse)
+            podState.updateFromStatusResponse(derivedStatusResponse, at: currentDate)
         }
         return detailedStatus
     }
@@ -897,10 +903,10 @@ public class PodCommsSession {
                 recoverUnacknowledgedCommand(using: status)
             }
 
-            podState.updateFromStatusResponse(status)
+            podState.updateFromStatusResponse(status, at: currentDate)
 
             if podState.activeTime == nil, let activatedAt = podState.activatedAt {
-                podState.activeTime = Date().timeIntervalSince(activatedAt)
+                podState.activeTime = currentDate.timeIntervalSince(activatedAt)
             }
         } catch let error as PodCommsError {
             switch error {
@@ -915,7 +921,7 @@ public class PodCommsSession {
     public func acknowledgeAlerts(alerts: AlertSet, beepBlock: MessageBlock? = nil) throws -> [AlertSlot: PodAlert] {
         let cmd = AcknowledgeAlertCommand(nonce: podState.currentNonce, alerts: alerts)
         let status: StatusResponse = try send([cmd], beepBlock: beepBlock)
-        podState.updateFromStatusResponse(status)
+        podState.updateFromStatusResponse(status, at: currentDate)
         return podState.activeAlerts
     }
 

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -189,9 +189,9 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         return now
     }
 
-    public mutating func updateFromStatusResponse(_ response: StatusResponse) {
+    public mutating func updateFromStatusResponse(_ response: StatusResponse, at date: Date = Date()) {
         let now = updatePodTimes(timeActive: response.timeActive)
-        updateDeliveryStatus(deliveryStatus: response.deliveryStatus, podProgressStatus: response.podProgressStatus, bolusNotDelivered: response.bolusNotDelivered)
+        updateDeliveryStatus(deliveryStatus: response.deliveryStatus, podProgressStatus: response.podProgressStatus, bolusNotDelivered: response.bolusNotDelivered, at: date)
 
         let setupUnits = setupUnitsDelivered ?? Pod.primeUnits + Pod.cannulaInsertionUnits + Pod.cannulaInsertionUnitsExtra
 
@@ -271,22 +271,29 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         self.unacknowledgedCommand = nil
     }
     
-    private mutating func updateDeliveryStatus(deliveryStatus: DeliveryStatus, podProgressStatus: PodProgressStatus, bolusNotDelivered: Double) {
+    private mutating func updateDeliveryStatus(deliveryStatus: DeliveryStatus, podProgressStatus: PodProgressStatus, bolusNotDelivered: Double, at date: Date) {
 
         // See if the pod deliveryStatus indicates an active bolus or temp basal that the PodState isn't tracking (possible Loop restart)
         if deliveryStatus.bolusing && unfinalizedBolus == nil { // active bolus that Loop doesn't know about?
             if podProgressStatus.readyForDelivery {
                 // Create an unfinalizedBolus with the remaining bolus amount to capture what we can.
-                unfinalizedBolus = UnfinalizedDose(bolusAmount: bolusNotDelivered, startTime: Date(), scheduledCertainty: .certain, insulinType: insulinType, automatic: false)
+                unfinalizedBolus = UnfinalizedDose(bolusAmount: bolusNotDelivered, startTime: date, scheduledCertainty: .certain, insulinType: insulinType, automatic: false)
             }
         }
 
-        if let bolus = unfinalizedBolus, !deliveryStatus.bolusing {
+        if var bolus = unfinalizedBolus, !deliveryStatus.bolusing {
+            // Due to clock drift or comms delays, boluses can finish earlier than we expect
+            if !bolus.isFinished() {
+                bolus.finishTime = date
+            }
             finalizedDoses.append(bolus)
             unfinalizedBolus = nil
         }
 
-        if let tempBasal = unfinalizedTempBasal, !deliveryStatus.tempBasalRunning {
+        if var tempBasal = unfinalizedTempBasal, !deliveryStatus.tempBasalRunning {
+            if !tempBasal.isFinished() {
+                tempBasal.finishTime = date
+            }
             finalizedDoses.append(tempBasal)
             unfinalizedTempBasal = nil
         }

--- a/RileyLink.xcodeproj/xcshareddata/xcschemes/OmniKitPacketParser.xcscheme
+++ b/RileyLink.xcodeproj/xcshareddata/xcschemes/OmniKitPacketParser.xcscheme
@@ -61,7 +61,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "/Users/pete/Downloads/Loop.Report.2023-01-02.20_28_47-05_00.md"
+            argument = "/Users/pete/Downloads/Loop.Report.2023-03-10.07.45.18-05.00.md"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
Mark doses as non-mutable if pod indicates they finish before Loop expects.

Fixes the Eros equivalent bug of https://github.com/LoopKit/Loop/issues/1941