### PR TITLE
Fix temp basal isMutable flag.

### DIFF
--- a/MinimedKit/Messages/Models/TimestampedHistoryEvent.swift
+++ b/MinimedKit/Messages/Models/TimestampedHistoryEvent.swift
@@ -18,14 +18,6 @@ public struct TimestampedHistoryEvent {
         self.pumpEvent = pumpEvent
         self.date = date
     }
-
-    public func isMutable(atDate date: Date = Date(), forPump model: PumpModel) -> Bool {
-        guard let bolus = self.pumpEvent as? BolusNormalPumpEvent else {
-            return false
-        }
-        let deliveryFinishDate = date.addingTimeInterval(bolus.deliveryTime)
-        return model.appendsSquareWaveToHistoryOnStartOfDelivery && bolus.type == .square && deliveryFinishDate > date
-    }
 }
 
 

--- a/MinimedKit/PumpEvents/BolusNormalPumpEvent.swift
+++ b/MinimedKit/PumpEvents/BolusNormalPumpEvent.swift
@@ -88,9 +88,13 @@ public struct BolusNormalPumpEvent: TimestampedPumpEvent {
             unabsorbedInsulinTotal = 0
         }
         type = duration > 0 ? .square : .normal
-        
     }
-    
+
+    func isMutable(atDate date: Date = Date(), forPump model: PumpModel) -> Bool {
+        let deliveryFinishDate = date.addingTimeInterval(deliveryTime)
+        return model.appendsSquareWaveToHistoryOnStartOfDelivery && type == .square && deliveryFinishDate > date
+    }
+
     public var dictionaryRepresentation: [String: Any] {
         var dictionary: [String: Any] = [
             "_type": "BolusNormal",

--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -828,7 +828,6 @@ extension MinimedPumpManager {
                     completion(nil)
                 }
             })
-
         })
     }
 

--- a/MinimedKit/PumpManager/UnfinalizedDose.swift
+++ b/MinimedKit/PumpManager/UnfinalizedDose.swift
@@ -283,7 +283,8 @@ extension DoseEntry {
         case .bolus:
             self = DoseEntry(type: .bolus, startDate: dose.startTime, endDate: dose.finishTime, value: dose.programmedUnits ?? dose.units, unit: .units, deliveredUnits: dose.finalizedUnits, insulinType: dose.insulinType, automatic: dose.automatic, isMutable: !dose.isReconciledWithHistory && !forceFinalization)
         case .tempBasal:
-            self = DoseEntry(type: .tempBasal, startDate: dose.startTime, endDate: dose.finishTime, value: dose.programmedTempRate ?? dose.rate, unit: .unitsPerHour, deliveredUnits: dose.finalizedUnits, insulinType: dose.insulinType, automatic: dose.automatic, isMutable: !dose.isReconciledWithHistory && !forceFinalization)
+            let isMutable = !forceFinalization && (!dose.isReconciledWithHistory || !dose.isFinished)
+            self = DoseEntry(type: .tempBasal, startDate: dose.startTime, endDate: dose.finishTime, value: dose.programmedTempRate ?? dose.rate, unit: .unitsPerHour, deliveredUnits: dose.finalizedUnits, insulinType: dose.insulinType, automatic: dose.automatic, isMutable: isMutable)
         case .suspend:
             self = DoseEntry(suspendDate: dose.startTime, isMutable: !dose.isReconciledWithHistory)
         case .resume:


### PR DESCRIPTION
Temp basals should remain mutable after reconciliation as long as they have not finished.

This fixes the issue described in https://github.com/LoopKit/Loop/issues/1920